### PR TITLE
feat(cli): add backlog-md version tracking integration

### DIFF
--- a/.spec-kit-compatibility.yml
+++ b/.spec-kit-compatibility.yml
@@ -67,3 +67,20 @@ jp-spec-kit:
     strategy: "two-stage"
     description: "Downloads base spec-kit templates, then overlays jp-spec-kit extensions"
     precedence: "jp-spec-kit overrides spec-kit where conflicts exist"
+
+# Backlog.md compatibility
+backlog-md:
+  description: "Project management CLI for task tracking and backlog management"
+  compatible_with:
+    min: "1.20.0"
+    max: "2.0.0"
+    tested: "1.21.0"
+    recommended: "1.21.0"
+  repository: "jpoley/backlog-md"
+  installation:
+    pnpm:
+      method: "pnpm add -g backlog-md@<version>"
+      check: "backlog --version"
+    npm:
+      method: "npm install -g backlog-md@<version>"
+      check: "backlog --version"

--- a/backlog/tasks/task-67 - Integrate-backlog.md-version-tracking-into-specify-CLI.md
+++ b/backlog/tasks/task-67 - Integrate-backlog.md-version-tracking-into-specify-CLI.md
@@ -1,9 +1,11 @@
 ---
 id: task-67
 title: Integrate backlog.md version tracking into specify CLI
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2025-11-25 21:42'
+updated_date: '2025-11-25 23:13'
 labels:
   - P0
   - integration
@@ -20,11 +22,75 @@ Add backlog.md as a tracked dependency alongside spec-kit, enabling unified vers
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Extend .spec-kit-compatibility.yml with backlog-md section (min/max/tested/recommended versions)
-- [ ] #2 Add specify backlog install command that auto-detects pnpm/npm and installs validated version
-- [ ] #3 Add specify backlog upgrade command (or integrate into existing specify upgrade)
-- [ ] #4 During specify init, check for backlog.md and offer to install if missing
-- [ ] #5 Add --backlog-version flag to specify init for version pinning
-- [ ] #6 Update specify upgrade to check and sync backlog.md to validated version
-- [ ] #7 Add backlog.md version to specify check output
+- [x] #1 Extend .spec-kit-compatibility.yml with backlog-md section (min/max/tested/recommended versions)
+- [x] #2 Add specify backlog install command that auto-detects pnpm/npm and installs validated version
+- [x] #3 Add specify backlog upgrade command (or integrate into existing specify upgrade)
+- [x] #4 During specify init, check for backlog.md and offer to install if missing
+- [x] #5 Add --backlog-version flag to specify init for version pinning
+- [x] #6 Update specify upgrade to check and sync backlog.md to validated version
+- [x] #7 Add backlog.md version to specify check output
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Update .spec-kit-compatibility.yml - Add backlog-md section with version tracking (min: 1.20.0, tested: 1.21.0, recommended: 1.21.0)
+
+2. Add VersionManager utility in __init__.py:
+   - load_compatibility_matrix() - parse YAML config
+   - get_validated_version(dependency) - get recommended version
+   - check_installed_version(tool) - run tool --version
+   - is_compatible(tool, version) - semver range check
+
+3. Add specify backlog install command:
+   - Auto-detect pnpm vs npm (prefer pnpm)
+   - Fetch validated version from compatibility matrix
+   - Install with version pinning
+   - Verify installation success
+
+4. Add specify backlog upgrade command:
+   - Check current installed version
+   - Compare to recommended version
+   - Upgrade if needed with pnpm/npm update
+
+5. Enhance specify init:
+   - Add --backlog-version flag
+   - Check if backlog-md installed after template download
+   - Offer to install if missing (confirm prompt)
+
+6. Enhance specify upgrade:
+   - Check backlog-md version after spec-kit upgrade
+   - Offer to sync to validated version if out of range
+
+7. Enhance specify check:
+   - Add backlog-md to tool checks
+   - Show version and compatibility status
+
+8. Add tests for new functionality
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented comprehensive backlog-md version tracking integration:
+
+**New Features:**
+- `specify backlog install` - Auto-detect pnpm/npm, install validated version
+- `specify backlog upgrade` - Upgrade to recommended version
+- `specify init --backlog-version` - Pin backlog version during init
+- `specify check` now shows backlog-md version and compatibility status
+- `specify upgrade` now syncs backlog-md after spec-kit upgrade
+
+**Files Modified:**
+- `.spec-kit-compatibility.yml` - Added backlog-md compatibility section
+- `src/specify_cli/__init__.py` - Added ~450 lines for version mgmt and commands
+
+**Key Functions Added:**
+- `load_compatibility_matrix()` - Parse YAML config
+- `get_backlog_validated_version()` - Fetch recommended version
+- `check_backlog_installed_version()` - Detect installed version
+- `detect_package_manager()` - Auto-detect pnpm/npm
+- `compare_semver()` - Simple version comparison
+
+**Bug Fix:** Fixed version parsing to handle backlog output format (just version number).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-68 - Enable-jp-spec-kit-to-dogfood-itself-without-circular-dependency.md
+++ b/backlog/tasks/task-68 - Enable-jp-spec-kit-to-dogfood-itself-without-circular-dependency.md
@@ -1,11 +1,11 @@
 ---
 id: task-68
 title: Enable jp-spec-kit to dogfood itself without circular dependency
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2025-11-25 21:57'
-updated_date: '2025-11-25 22:14'
+updated_date: '2025-11-25 23:00'
 labels:
   - P0
   - dogfooding
@@ -24,11 +24,23 @@ Allow jp-spec-kit to use its own /speckit.* and /jpspec:* commands during develo
 <!-- AC:BEGIN -->
 - [x] #1 Create .jp-spec-kit-source marker file at repo root to identify this as the source repository
 - [x] #2 Update specify init to detect .jp-spec-kit-source and skip/warn instead of clobbering
-- [ ] #3 Create .claude/commands/speckit/ directory with symlinks to templates/commands/*.md files
-- [ ] #4 Verify all /speckit.* commands work in jp-spec-kit repo (analyze, checklist, clarify, constitution, implement, plan, specify, tasks)
-- [ ] #5 Verify all /jpspec:* commands still work (implement, operate, plan, research, specify, validate)
+- [x] #3 Create .claude/commands/speckit/ directory with symlinks to templates/commands/*.md files
+- [x] #4 Verify all /speckit.* commands work in jp-spec-kit repo (analyze, checklist, clarify, constitution, implement, plan, specify, tasks)
+- [x] #5 Verify all /jpspec:* commands still work (implement, operate, plan, research, specify, validate)
 - [ ] #6 Add specify dogfood command as alternative to manually creating symlinks (optional convenience)
-- [ ] #7 Document dogfooding setup in CONTRIBUTING.md with platform-specific notes (Windows symlink requirements)
+- [x] #7 Document dogfooding setup in CONTRIBUTING.md with platform-specific notes (Windows symlink requirements)
 - [x] #8 Test that specify upgrade also respects the .jp-spec-kit-source marker
-- [ ] #9 Ensure symlinks are tracked in git (verify .gitattributes if needed)
+- [x] #9 Ensure symlinks are tracked in git (verify .gitattributes if needed)
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented via PR #6 (merged):
+- Added .jp-spec-kit-source marker file for source repo detection
+- Updated specify init/upgrade to respect marker
+- Created symlinks in .claude/commands/speckit/ pointing to templates/commands/
+- Documented in CONTRIBUTING.md
+
+AC #6 (specify dogfood command) deferred as optional convenience feature.
+<!-- SECTION:NOTES:END -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "platformdirs",
     "readchar",
     "truststore>=0.10.4",
+    "pyyaml>=6.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Add `specify backlog install` command with pnpm/npm auto-detection
- Add `specify backlog upgrade` command for version sync
- Enhance `specify init` with `--backlog-version` flag and install prompt
- Enhance `specify upgrade` to sync backlog-md after spec-kit upgrade  
- Enhance `specify check` to show backlog-md version and compatibility
- Add backlog-md section to `.spec-kit-compatibility.yml`

## Test plan

- [x] `uv build` succeeds
- [x] `specify backlog --help` shows install/upgrade subcommands
- [x] `specify backlog install --help` shows options
- [x] `specify check` displays backlog-md version correctly
- [x] `specify init --help` shows `--backlog-version` flag
- [x] Module imports without errors

Closes task-67, task-68

🤖 Generated with [Claude Code](https://claude.com/claude-code)