### PR TITLE
feat(hooks): add pre-commit hook to validate task acceptance criteria

### DIFF
--- a/scripts/hooks/install-hooks.sh
+++ b/scripts/hooks/install-hooks.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Install git hooks for jp-spec-kit
+# Run from repository root: ./scripts/hooks/install-hooks.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOOKS_DIR="$REPO_ROOT/.git/hooks"
+
+echo "Installing git hooks..."
+
+# Install pre-commit hook
+if [ -f "$SCRIPT_DIR/pre-commit" ]; then
+    cp "$SCRIPT_DIR/pre-commit" "$HOOKS_DIR/pre-commit"
+    chmod +x "$HOOKS_DIR/pre-commit"
+    echo "  ✓ pre-commit hook installed"
+else
+    echo "  ✗ pre-commit hook not found"
+    exit 1
+fi
+
+echo ""
+echo "Git hooks installed successfully!"
+echo "The pre-commit hook will validate that task files have acceptance criteria."

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Pre-commit hook: Validate task files have acceptance criteria
+# Blocks commits that add/modify task files without at least one AC
+
+FAILED=0
+FAILED_FILES=""
+
+# Get staged task files (added or modified) and process line by line
+git diff --cached --name-only --diff-filter=AM | grep -E '^backlog/tasks/task-.*\.md$' | while IFS= read -r file; do
+    # Get the staged content (not the working directory version)
+    CONTENT=$(git show ":$file" 2>/dev/null || true)
+
+    if [ -z "$CONTENT" ]; then
+        continue
+    fi
+
+    # Check for AC section markers
+    if ! echo "$CONTENT" | grep -q '<!-- AC:BEGIN -->'; then
+        echo "ERROR: $file missing AC section (<!-- AC:BEGIN -->)"
+        echo "$file" >> /tmp/pre-commit-failed-tasks.txt
+        continue
+    fi
+
+    # Extract content between AC:BEGIN and AC:END, check for at least one checkbox
+    AC_SECTION=$(echo "$CONTENT" | sed -n '/<!-- AC:BEGIN -->/,/<!-- AC:END -->/p')
+
+    if ! echo "$AC_SECTION" | grep -qE '^\s*- \[(x| )\]'; then
+        echo "ERROR: $file has no acceptance criteria (no checkboxes found)"
+        echo "$file" >> /tmp/pre-commit-failed-tasks.txt
+    fi
+done
+
+# Check if any failures were recorded
+if [ -f /tmp/pre-commit-failed-tasks.txt ]; then
+    echo ""
+    echo "=========================================="
+    echo "COMMIT BLOCKED: Tasks missing acceptance criteria"
+    echo "=========================================="
+    echo ""
+    echo "The following task files have no acceptance criteria:"
+    cat /tmp/pre-commit-failed-tasks.txt | while IFS= read -r f; do
+        echo "  - $f"
+    done
+    echo ""
+    echo "Every task MUST have at least one acceptance criterion."
+    echo "Use: backlog task edit <id> --ac \"Your criterion here\""
+    echo ""
+    echo "To bypass (NOT RECOMMENDED): git commit --no-verify"
+    rm -f /tmp/pre-commit-failed-tasks.txt
+    exit 1
+fi
+
+rm -f /tmp/pre-commit-failed-tasks.txt
+exit 0


### PR DESCRIPTION
## Summary

- Adds pre-commit hook that blocks commits with task files missing acceptance criteria
- Includes install script for easy setup
- Prevents placeholder/demo tasks from being committed

## Files

- `scripts/hooks/pre-commit` - The validation hook
- `scripts/hooks/install-hooks.sh` - Installation script

## Usage

```bash
# Install the hook
./scripts/hooks/install-hooks.sh

# Bypass (not recommended)
git commit --no-verify
```

## Test plan

- [x] Hook blocks task files without AC section
- [x] Hook blocks task files with empty AC section  
- [x] Hook allows task files with at least one checkbox
- [x] Hook handles filenames with spaces correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)