### PR TITLE
feat(jpspec): add prune-branch command to clean stale local branches

### DIFF
--- a/.claude/commands/jpspec/prune-branch.md
+++ b/.claude/commands/jpspec/prune-branch.md
@@ -1,0 +1,156 @@
+---
+description: Prune local branches that have been merged and deleted on remote.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Execution Instructions
+
+This command safely prunes local Git branches that have been merged and deleted on remote. It helps keep your local repository clean by removing stale branches.
+
+### Arguments
+
+- No arguments or `--dry-run`: Preview branches to be deleted (default, safe mode)
+- `--force` or `-f`: Actually delete the identified branches
+
+### Protected Branches
+
+The following branches are never deleted:
+- `main`
+- `master`
+- `develop`
+- The currently checked out branch
+
+### Execution Steps
+
+**Step 1: Validate Git Repository**
+
+First, verify we're in a git repository with a remote configured:
+
+```bash
+# Check if in git repo
+git rev-parse --git-dir > /dev/null 2>&1
+
+# Check if remote exists
+git remote -v
+```
+
+If not in a git repo or no remote configured, output an error message and stop.
+
+**Step 2: Fetch from Remote with Prune**
+
+Sync local tracking info with remote:
+
+```bash
+git fetch --prune --all
+```
+
+This updates remote tracking branches and removes references to branches deleted on remote.
+
+**Step 3: Identify Branches to Prune**
+
+Identify local branches that should be pruned:
+
+1. **Gone branches**: Local branches whose upstream tracking branch no longer exists on remote:
+```bash
+git branch -vv | grep ': gone]' | awk '{print $1}'
+```
+
+2. **Merged branches**: Local branches fully merged into main/master (excluding protected branches):
+```bash
+git branch --merged main 2>/dev/null | grep -v -E '^\*|^\s*(main|master|develop)\s*$' | sed 's/^[ \t]*//'
+```
+
+**Step 4: Apply Safety Checks**
+
+Before proceeding:
+1. Get the current branch name: `git branch --show-current`
+2. Filter out protected branches (main, master, develop)
+3. Filter out the current branch
+4. Deduplicate the list (a branch might be both "gone" and "merged")
+
+**Step 5: Preview or Delete**
+
+Parse `$ARGUMENTS` to determine mode:
+
+- If `$ARGUMENTS` is empty, `--dry-run`, or doesn't contain `--force`/`-f`:
+  - Output: "**DRY RUN** - The following branches would be deleted:"
+  - List each branch with reason (gone/merged)
+  - Output: "Run with `--force` to delete these branches."
+
+- If `$ARGUMENTS` contains `--force` or `-f`:
+  - For each branch to prune:
+    ```bash
+    git branch -D <branch-name>
+    ```
+  - Output success/failure for each branch
+
+**Step 6: Output Summary**
+
+Provide a clear summary:
+- Number of branches deleted (or would be deleted in dry-run)
+- Number of branches skipped with reasons
+- Any errors encountered
+
+### Example Output
+
+**Dry Run Mode:**
+```
+Fetching from remote...
+Done.
+
+Analyzing local branches...
+
+DRY RUN - The following branches would be deleted:
+
+  - feature/old-feature (reason: upstream gone)
+  - bugfix/fixed-issue (reason: merged into main)
+  - experiment/test (reason: upstream gone)
+
+Protected branches skipped:
+  - main
+  - develop
+
+Summary: 3 branches would be pruned, 2 protected branches skipped.
+
+Run with --force to delete these branches.
+```
+
+**Force Mode:**
+```
+Fetching from remote...
+Done.
+
+Pruning branches...
+
+  Deleted: feature/old-feature (upstream gone)
+  Deleted: bugfix/fixed-issue (merged into main)
+  Deleted: experiment/test (upstream gone)
+
+Summary: 3 branches pruned successfully.
+```
+
+**No Branches to Prune:**
+```
+Fetching from remote...
+Done.
+
+Analyzing local branches...
+
+No branches to prune. Your local repository is clean!
+```
+
+### Error Handling
+
+- **Not a git repository**: "Error: Not in a git repository. Please run this command from within a git project."
+- **No remote configured**: "Error: No git remote configured. Please add a remote first."
+- **Current branch would be pruned**: "Warning: Cannot delete the currently checked out branch '<branch>'. Switch to another branch first."
+- **Branch deletion failed**: "Error: Failed to delete branch '<branch>': <error message>"
+
+### Implementation Notes
+
+Execute the git commands directly using the Bash tool. Process the output to build the lists of branches, apply safety filters, and format the output clearly for the user.

--- a/backlog/tasks/task-135 - Implement-jpspec-prune-branch-slash-command.md
+++ b/backlog/tasks/task-135 - Implement-jpspec-prune-branch-slash-command.md
@@ -1,0 +1,63 @@
+---
+id: task-135
+title: 'Implement /jpspec:prune-branch slash command'
+status: Done
+assignee:
+  - '@claude'
+created_date: '2025-11-28 17:25'
+updated_date: '2025-11-28 17:26'
+labels:
+  - feature
+  - git
+  - developer-experience
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a slash command that safely prunes local branches that have been merged and deleted on remote. The command should fetch from remote, identify stale branches, and provide a safe dry-run preview before deletion.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 #1 Command fetches from remote with --prune flag to sync remote tracking info
+- [x] #2 #2 Command identifies local branches whose upstream tracking branch is 'gone'
+- [x] #3 #3 Command identifies local branches fully merged into main/master
+- [x] #4 #4 By default (no args), shows dry-run preview of branches to be deleted without deleting
+- [x] #5 #5 With --force or -f argument, actually deletes the identified branches
+- [x] #6 #6 Never deletes the current branch - errors with helpful message if current branch would be pruned
+- [x] #7 #7 Never deletes protected branches (main, master, develop)
+- [x] #8 #8 Outputs clear summary showing: branches deleted, branches skipped with reasons
+- [x] #9 #9 Handles edge cases gracefully: no branches to prune, not in git repo, no remote configured
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Create slash command file at .claude/commands/jpspec/prune-branch.md
+2. Implement git fetch --prune logic
+3. Implement detection of gone/merged branches
+4. Implement dry-run vs force mode logic
+5. Add safety checks for protected branches
+6. Add clear output formatting
+7. Test with current repo state
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented /jpspec:prune-branch slash command that:
+
+- Fetches from all remotes with --prune to sync tracking info
+- Identifies branches with upstream "gone" status
+- Identifies branches fully merged into main/master
+- Provides safe dry-run preview by default
+- Supports --force/-f flag for actual deletion
+- Protects main, master, develop, and current branch
+- Includes clear output formatting with reasons
+- Handles edge cases (not in git repo, no remote, no branches to prune)
+
+Tested git commands against current repo - found stale branch jpspec-backlog-integration-tasks-v2 that would be correctly identified for pruning.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary

- Add `/jpspec:prune-branch` slash command that safely prunes local Git branches
- Identifies branches with upstream "gone" status and branches merged into main/master
- Provides safe dry-run preview by default, with `--force` flag for actual deletion
- Protects main, master, develop, and current branch from deletion

## Features

- **Safe by default**: Shows preview without deleting unless `--force` is used
- **Comprehensive detection**: Finds both "gone" branches and merged branches
- **Protected branches**: Never deletes main, master, develop, or current branch
- **Clear output**: Shows reason for each branch deletion (gone/merged)
- **Edge case handling**: Graceful errors for non-git repos, no remote, etc.

## Test plan

- [ ] Run `/jpspec:prune-branch` in a repo with stale branches to verify dry-run output
- [ ] Run `/jpspec:prune-branch --force` to verify branches are deleted
- [ ] Verify protected branches are not deleted
- [ ] Verify current branch cannot be deleted
- [ ] Test in non-git directory to verify error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)