### PR TITLE
fix(diagrams): address review feedback for export scripts

### DIFF
--- a/docs/diagrams/export-to-png.js
+++ b/docs/diagrams/export-to-png.js
@@ -5,6 +5,9 @@
  *
  * This script uses Puppeteer to render the Excalidraw diagram in a headless browser
  * and export it as a PNG image at high resolution.
+ *
+ * Requirements:
+ *     npm install puppeteer
  */
 
 const fs = require('fs');
@@ -205,7 +208,7 @@ async function exportToPng() {
     await page.waitForFunction(() => window.renderComplete, { timeout: 10000 });
 
     // Add small delay for final render
-    await page.waitForTimeout(1000);
+    await new Promise(resolve => setTimeout(resolve, 1000));
 
     console.log('Taking screenshot...');
     const canvas = await page.$('#canvas');

--- a/docs/diagrams/export-to-png.py
+++ b/docs/diagrams/export-to-png.py
@@ -4,6 +4,9 @@ Export Excalidraw diagram to PNG
 
 This script renders the Excalidraw JSON diagram to a PNG image
 using PIL (Pillow) for high-quality output.
+
+Requirements:
+    pip install Pillow
 """
 
 import json
@@ -85,18 +88,30 @@ def render_excalidraw_to_png():
     def transform_y(y):
         return int((y - min_y + PADDING) * SCALE)
 
-    # Load font
+    # Load font with cross-platform support
     try:
         font_cache = {}
         def get_font(size):
             size_scaled = int(size * SCALE)
             if size_scaled not in font_cache:
-                try:
-                    font_cache[size_scaled] = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", size_scaled)
-                except:
+                # Try multiple font paths for cross-platform support
+                font_paths = [
+                    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",  # Linux
+                    "/Library/Fonts/Arial.ttf",                         # macOS
+                    "C:\\Windows\\Fonts\\arial.ttf",                    # Windows
+                    "/usr/share/fonts/truetype/freefont/FreeSans.ttf",  # Linux alternative
+                ]
+                for font_path in font_paths:
+                    try:
+                        font_cache[size_scaled] = ImageFont.truetype(font_path, size_scaled)
+                        break
+                    except Exception:
+                        continue
+                else:
+                    # Fallback to default font if none found
                     font_cache[size_scaled] = ImageFont.load_default()
             return font_cache[size_scaled]
-    except:
+    except Exception:
         get_font = lambda size: ImageFont.load_default()
 
     print('Rendering elements...')


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #33:
- Add cross-platform font path support (Linux/macOS/Windows)
- Fix bare except clauses to use Exception
- Update deprecated waitForTimeout to Promise
- Add dependency documentation (Pillow, puppeteer)

## Changes
### Python Script (export-to-png.py)
1. **Cross-platform font support**: Now tries multiple font paths in order:
   - `/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf` (Linux)
   - `/Library/Fonts/Arial.ttf` (macOS)
   - `C:\Windows\Fonts\arial.ttf` (Windows)
   - `/usr/share/fonts/truetype/freefont/FreeSans.ttf` (Linux alternative)
   - Falls back to default font if none found

2. **Fixed bare except clauses**: Changed `except:` to `except Exception:` to allow SystemExit/KeyboardInterrupt

3. **Added dependency documentation**: Added `pip install Pillow` requirement in docstring

### JavaScript Script (export-to-png.js)
1. **Fixed deprecated waitForTimeout**: Changed `await page.waitForTimeout(1000)` to `await new Promise(resolve => setTimeout(resolve, 1000))`

2. **Added dependency documentation**: Added `npm install puppeteer` requirement in JSDoc

## Test plan
- [x] Python script runs on Linux (with DejaVu fonts)
- [x] Bare except replaced with Exception
- [x] waitForTimeout replaced with Promise
- [x] Dependencies documented in both scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)