### PR TITLE
feat: enforce design→implement workflow for design tasks

### DIFF
--- a/.claude/commands/jpspec/plan.md
+++ b/.claude/commands/jpspec/plan.md
@@ -256,3 +256,38 @@ After both agents complete:
    - Updated /speckit.constitution
    - ADRs for key decisions
    - Implementation readiness assessment
+
+### ⚠️ MANDATORY: Design→Implement Workflow
+
+**This is a DESIGN command. Design tasks MUST create implementation tasks before completion.**
+
+After the architecture and platform agents complete their work:
+
+1. **Create implementation tasks** for each architectural component:
+   ```bash
+   # Example: Create tasks from architecture decisions
+   backlog task create "Implement [Component Name] Service" \
+     -d "Implementation based on architecture from /jpspec:plan" \
+     --ac "Implement service per architecture doc section X" \
+     --ac "Follow integration patterns from ADR-001" \
+     --ac "Add observability per platform requirements" \
+     --ac "Write integration tests" \
+     -l implement,architecture,backend \
+     --priority high
+
+   backlog task create "Implement [Infrastructure Component]" \
+     -d "Infrastructure implementation per platform design" \
+     --ac "Configure CI/CD per platform architecture" \
+     --ac "Set up monitoring per observability requirements" \
+     --ac "Implement security controls per ADR" \
+     -l implement,infrastructure,devops
+   ```
+
+2. **Update planning task notes** with follow-up references:
+   ```bash
+   backlog task edit <plan-task-id> --append-notes $'Follow-up Implementation Tasks:\n- task-XXX: Implement service A\n- task-YYY: Implement infrastructure\n- task-ZZZ: Configure CI/CD pipeline'
+   ```
+
+3. **Only then mark the planning task as Done**
+
+**Architecture without implementation tasks is incomplete design work.**

--- a/.claude/commands/jpspec/research.md
+++ b/.claude/commands/jpspec/research.md
@@ -150,3 +150,38 @@ Deliver a structured validation report with:
 ### Final Output
 
 Consolidate both reports into a comprehensive research and validation package that enables informed decision-making.
+
+### ⚠️ MANDATORY: Design→Implement Workflow
+
+**This is a DESIGN command. Research tasks MUST create implementation tasks before completion.**
+
+After the research and business validation agents complete their work:
+
+1. **Create implementation tasks** based on research findings and recommendations:
+   ```bash
+   # Example: Create tasks from research recommendations
+   backlog task create "Implement [Recommended Solution]" \
+     -d "Implementation based on research findings from /jpspec:research" \
+     --ac "Implement approach recommended in research report" \
+     --ac "Address feasibility concerns identified in validation" \
+     --ac "Monitor metrics identified in business case" \
+     -l implement,research-followup \
+     --priority high
+
+   backlog task create "Technical Spike: [Validate Key Assumption]" \
+     -d "Validation spike based on research critical assumptions" \
+     --ac "Validate assumption X from research report" \
+     --ac "Document findings and update implementation plan" \
+     -l spike,research-followup
+   ```
+
+2. **Update research task notes** with follow-up references:
+   ```bash
+   backlog task edit <research-task-id> --append-notes $'Research Outcome: Go/No-Go/Proceed with Caution\n\nFollow-up Implementation Tasks:\n- task-XXX: Implement recommended solution\n- task-YYY: Validation spike for assumption A'
+   ```
+
+3. **Only then mark the research task as Done**
+
+**Research without actionable follow-up tasks provides no value. Every research effort must produce implementation direction.**
+
+**Note**: If research concludes with "No-Go" recommendation, create a documentation task to record the decision and rationale for future reference.

--- a/.claude/commands/jpspec/specify.md
+++ b/.claude/commands/jpspec/specify.md
@@ -171,3 +171,37 @@ Please ensure the PRD is:
 ### Output
 
 The agent will produce a comprehensive PRD that integrates with /speckit.tasks and provides clear direction for the planning and implementation phases.
+
+### ⚠️ MANDATORY: Design→Implement Workflow
+
+**This is a DESIGN command. Design tasks MUST create implementation tasks before completion.**
+
+After the PRD agent completes its work:
+
+1. **Create implementation tasks** for each major deliverable:
+   ```bash
+   # Example: Create tasks from PRD sections
+   backlog task create "Implement [Feature Core Functionality]" \
+     -d "Implementation based on PRD from /jpspec:specify" \
+     --ac "Implement core feature per PRD section 4" \
+     --ac "Add validation per NFR section" \
+     --ac "Write unit tests" \
+     -l implement,backend \
+     --priority high
+
+   backlog task create "Implement [Feature UI Components]" \
+     -d "Frontend implementation per PRD user stories" \
+     --ac "Build UI components per PRD wireframes" \
+     --ac "Implement accessibility per WCAG 2.1 AA" \
+     --ac "Add integration tests" \
+     -l implement,frontend
+   ```
+
+2. **Update specification task notes** with follow-up references:
+   ```bash
+   backlog task edit <spec-task-id> --append-notes $'Follow-up Implementation Tasks:\n- task-XXX: Implement core functionality\n- task-YYY: Implement UI components'
+   ```
+
+3. **Only then mark the specification task as Done**
+
+**Failure to create implementation tasks means the specification work is incomplete.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -921,6 +921,93 @@ Bad Example (Implementation Step):
 
 ---
 
+## 4.5. Design Tasks vs Implementation Tasks (Design→Implement Workflow)
+
+### What is a Design Task?
+
+A **design task** produces artifacts (documents, diagrams, architecture decisions, research findings) that require follow-up implementation. Design tasks are identified by:
+
+**Labels** (any of these indicate a design task):
+- `design` - Architecture, system design, UI/UX design
+- `audit` - Analysis that produces recommendations
+- `architecture` - System architecture decisions
+- `research` - Research that produces actionable findings
+- `spike` - Technical exploration/proof of concept
+- `planning` - Planning that produces actionable plans
+
+**Title patterns** (any of these indicate a design task):
+- "Design ..." - e.g., "Design authentication flow"
+- "... Architecture" - e.g., "Plugin Architecture"
+- "Audit ..." - e.g., "Audit API endpoints"
+- "Research ..." - e.g., "Research caching strategies"
+- "Spike: ..." - e.g., "Spike: GraphQL performance"
+
+### ⚠️ CRITICAL: Design Tasks MUST Create Implementation Tasks
+
+**Design tasks CANNOT be marked Done without corresponding implementation task(s).**
+
+When completing a design task:
+
+1. **Before marking Done**, create implementation tasks that:
+   - Reference the design task as a dependency
+   - Have specific, actionable acceptance criteria
+   - Cover all actionable items from the design deliverables
+
+2. **Implementation Notes MUST include**:
+   - "Follow-up Implementation Tasks:" section listing created task IDs
+   - Summary of key design decisions
+   - Files/artifacts created
+
+### Design Task Completion Workflow
+
+```bash
+# 1. Complete design work (produce artifacts, documents, etc.)
+
+# 2. Create implementation tasks BEFORE marking design task Done
+backlog task create "Implement [specific feature from design]" \
+  -d "Implementation based on task-106 design" \
+  --ac "Implement X per ADR-001" \
+  --ac "Add tests for X" \
+  --dep task-106 \
+  -l implement,backend
+
+# 3. Add implementation notes with follow-up task references
+backlog task edit 106 --notes $'Designed comprehensive architecture.\n\nDeliverables:\n- ADR-001: Architecture decision record\n- templates/auth-flow.md: Flow diagram\n\nFollow-up Implementation Tasks:\n- task-107: Implement auth service\n- task-108: Implement auth middleware\n- task-109: Add auth tests'
+
+# 4. Only NOW mark design task as Done
+backlog task edit 106 -s Done
+```
+
+### Design Task Definition of Done
+
+A design task is **Done** only when **ALL** of the following are complete:
+
+1. ✅ All acceptance criteria checked
+2. ✅ Design artifacts created (ADRs, diagrams, specs)
+3. ✅ **Implementation tasks created** (MANDATORY for design tasks)
+4. ✅ Implementation notes include "Follow-up Implementation Tasks:" section
+5. ✅ Status set to Done
+
+### Naming Convention for Follow-up Tasks
+
+Implementation tasks should clearly reference their design origin:
+
+| Design Task | Implementation Task(s) |
+|------------|------------------------|
+| Design authentication flow | Implement auth service, Implement auth middleware |
+| Audit API endpoints | Update deprecated endpoints, Add missing validation |
+| Research caching strategy | Implement Redis caching layer, Add cache invalidation |
+| Spike: GraphQL performance | Implement DataLoader pattern, Add query complexity limits |
+
+### Why This Matters
+
+- **Traceability**: Every design decision has corresponding implementation
+- **No orphaned designs**: Prevents valuable design work from being forgotten
+- **Clear dependencies**: Implementation tasks can reference design artifacts
+- **Audit trail**: Easy to trace from requirement → design → implementation
+
+---
+
 ## 5. Implementing Tasks
 
 ### 5.1. First step when implementing a task

--- a/backlog/tasks/task-105 - Audit-jpspec-commands-for-task-management-patterns.md
+++ b/backlog/tasks/task-105 - Audit-jpspec-commands-for-task-management-patterns.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude-agent-1'
 created_date: '2025-11-28 16:53'
-updated_date: '2025-11-28 18:17'
+updated_date: '2025-11-28 19:44'
 labels:
   - jpspec
   - backlog-integration
@@ -48,4 +48,11 @@ Deliverables:
 - Integration requirements checklist per command
 - Recommended 3-phase implementation strategy
 - Complete agent roster (15+ agents documented)
+
+Follow-up Implementation Tasks (from this audit):
+- task-106: Design backlog.md integration architecture
+- task-107: Create shared backlog.md instructions template
+- task-108: Create test framework for backlog.md integration
+- task-109 to task-114: Update all jpspec commands to use backlog.md CLI
+- task-115: End-to-end integration tests
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-106 - Design-backlog.md-integration-architecture-for-jpspec.md
+++ b/backlog/tasks/task-106 - Design-backlog.md-integration-architecture-for-jpspec.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude-agent-4'
 created_date: '2025-11-28 16:54'
-updated_date: '2025-11-28 18:31'
+updated_date: '2025-11-28 19:44'
 labels:
   - jpspec
   - backlog-integration
@@ -60,4 +60,16 @@ Impact:
 - Reduces manual task management overhead
 - Preserves agent independence and flexibility
 - Supports incremental adoption
+
+Follow-up Implementation Tasks (from this design):
+- task-107: Create shared backlog.md instructions template
+- task-108: Create test framework for backlog.md integration
+- task-109: Update jpspec:specify to use backlog.md CLI
+- task-110: Update jpspec:plan to use backlog.md CLI
+- task-111: Update jpspec:research to use backlog.md CLI
+- task-112: Update jpspec:implement to use backlog.md CLI
+- task-113: Update jpspec:validate to use backlog.md CLI
+- task-114: Update jpspec:operate to use backlog.md CLI
+- task-115: End-to-end integration tests
+- task-116: Update documentation for integration
 <!-- SECTION:NOTES:END -->

--- a/templates/commands/jpspec/plan.md
+++ b/templates/commands/jpspec/plan.md
@@ -65,3 +65,40 @@ This command executes the planning workflow using two specialized agents:
 - This command is a placeholder for future agent implementation
 - Full Project Architect and Platform Engineer agent integration will be completed in a future task
 - Builds out and updates /speckit.constitution
+
+---
+
+## ⚠️ MANDATORY: Design→Implement Workflow
+
+**This is a DESIGN command. Planning tasks MUST create implementation tasks before completion.**
+
+After the architecture and platform agents complete their work:
+
+1. **Create implementation tasks** for each architectural component:
+   ```bash
+   # Example: Create tasks from architecture decisions
+   backlog task create "Implement [Component Name] Service" \
+     -d "Implementation based on architecture from /jpspec:plan" \
+     --ac "Implement service per architecture doc section X" \
+     --ac "Follow integration patterns from ADR-001" \
+     --ac "Add observability per platform requirements" \
+     --ac "Write integration tests" \
+     -l implement,architecture,backend \
+     --priority high
+
+   backlog task create "Implement [Infrastructure Component]" \
+     -d "Infrastructure implementation per platform design" \
+     --ac "Configure CI/CD per platform architecture" \
+     --ac "Set up monitoring per observability requirements" \
+     --ac "Implement security controls per ADR" \
+     -l implement,infrastructure,devops
+   ```
+
+2. **Update planning task notes** with follow-up references:
+   ```bash
+   backlog task edit <plan-task-id> --append-notes $'Follow-up Implementation Tasks:\n- task-XXX: Implement service A\n- task-YYY: Implement infrastructure\n- task-ZZZ: Configure CI/CD pipeline'
+   ```
+
+3. **Only then mark the planning task as Done**
+
+**Architecture without implementation tasks is incomplete design work.**

--- a/templates/commands/jpspec/research.md
+++ b/templates/commands/jpspec/research.md
@@ -49,3 +49,40 @@ This command orchestrates research and business validation using two specialized
 
 - This command is a placeholder for future agent implementation
 - Full agent integration will be completed in a future task
+
+---
+
+## ⚠️ MANDATORY: Design→Implement Workflow
+
+**This is a DESIGN command. Research tasks MUST create implementation tasks before completion.**
+
+After the research and business validation agents complete their work:
+
+1. **Create implementation tasks** based on research findings and recommendations:
+   ```bash
+   # Example: Create tasks from research recommendations
+   backlog task create "Implement [Recommended Solution]" \
+     -d "Implementation based on research findings from /jpspec:research" \
+     --ac "Implement approach recommended in research report" \
+     --ac "Address feasibility concerns identified in validation" \
+     --ac "Monitor metrics identified in business case" \
+     -l implement,research-followup \
+     --priority high
+
+   backlog task create "Technical Spike: [Validate Key Assumption]" \
+     -d "Validation spike based on research critical assumptions" \
+     --ac "Validate assumption X from research report" \
+     --ac "Document findings and update implementation plan" \
+     -l spike,research-followup
+   ```
+
+2. **Update research task notes** with follow-up references:
+   ```bash
+   backlog task edit <research-task-id> --append-notes $'Research Outcome: Go/No-Go/Proceed with Caution\n\nFollow-up Implementation Tasks:\n- task-XXX: Implement recommended solution\n- task-YYY: Validation spike for assumption A'
+   ```
+
+3. **Only then mark the research task as Done**
+
+**Research without actionable follow-up tasks provides no value. Every research effort must produce implementation direction.**
+
+**Note**: If research concludes with "No-Go" recommendation, create a documentation task to record the decision and rationale for future reference.

--- a/templates/commands/jpspec/specify.md
+++ b/templates/commands/jpspec/specify.md
@@ -47,3 +47,39 @@ This command creates feature specifications using a specialized PM (Product Mana
 - This command is a placeholder for future agent implementation
 - Full PM Planner agent integration will be completed in a future task
 - Manages interaction with /speckit.tasks workflow
+
+---
+
+## ⚠️ MANDATORY: Design→Implement Workflow
+
+**This is a DESIGN command. Specification tasks MUST create implementation tasks before completion.**
+
+After the PM Planner agent completes its work:
+
+1. **Create implementation tasks** for each major deliverable:
+   ```bash
+   # Example: Create tasks from PRD sections
+   backlog task create "Implement [Feature Core Functionality]" \
+     -d "Implementation based on PRD from /jpspec:specify" \
+     --ac "Implement core feature per PRD section 4" \
+     --ac "Add validation per NFR section" \
+     --ac "Write unit tests" \
+     -l implement,backend \
+     --priority high
+
+   backlog task create "Implement [Feature UI Components]" \
+     -d "Frontend implementation per PRD user stories" \
+     --ac "Build UI components per PRD wireframes" \
+     --ac "Implement accessibility per WCAG 2.1 AA" \
+     --ac "Add integration tests" \
+     -l implement,frontend
+   ```
+
+2. **Update specification task notes** with follow-up references:
+   ```bash
+   backlog task edit <spec-task-id> --append-notes $'Follow-up Implementation Tasks:\n- task-XXX: Implement core functionality\n- task-YYY: Implement UI components'
+   ```
+
+3. **Only then mark the specification task as Done**
+
+**Failure to create implementation tasks means the specification work is incomplete.**

--- a/templates/partials/backlog-instructions.md
+++ b/templates/partials/backlog-instructions.md
@@ -171,6 +171,93 @@ A task is considered **Done** when:
 
 ---
 
+## Design Tasks vs Implementation Tasks (Design→Implement Workflow)
+
+### What is a Design Task?
+
+A **design task** produces artifacts (documents, diagrams, architecture decisions, research findings) that require follow-up implementation. Design tasks are identified by:
+
+**Labels** (any of these indicate a design task):
+- `design` - Architecture, system design, UI/UX design
+- `audit` - Analysis that produces recommendations
+- `architecture` - System architecture decisions
+- `research` - Research that produces actionable findings
+- `spike` - Technical exploration/proof of concept
+- `planning` - Planning that produces actionable plans
+
+**Title patterns** (any of these indicate a design task):
+- "Design ..." - e.g., "Design authentication flow"
+- "... Architecture" - e.g., "Plugin Architecture"
+- "Audit ..." - e.g., "Audit API endpoints"
+- "Research ..." - e.g., "Research caching strategies"
+- "Spike: ..." - e.g., "Spike: GraphQL performance"
+
+### ⚠️ CRITICAL: Design Tasks MUST Create Implementation Tasks
+
+**Design tasks CANNOT be marked Done without corresponding implementation task(s).**
+
+When completing a design task:
+
+1. **Before marking Done**, create implementation tasks that:
+   - Reference the design task as a dependency
+   - Have specific, actionable acceptance criteria
+   - Cover all actionable items from the design deliverables
+
+2. **Implementation Notes MUST include**:
+   - "Follow-up Implementation Tasks:" section listing created task IDs
+   - Summary of key design decisions
+   - Files/artifacts created
+
+### Design Task Completion Workflow
+
+```bash
+# 1. Complete design work (produce artifacts, documents, etc.)
+
+# 2. Create implementation tasks BEFORE marking design task Done
+backlog task create "Implement [specific feature from design]" \
+  -d "Implementation based on task-106 design" \
+  --ac "Implement X per ADR-001" \
+  --ac "Add tests for X" \
+  --dep task-106 \
+  -l implement,backend
+
+# 3. Add implementation notes with follow-up task references
+backlog task edit 106 --notes $'Designed comprehensive architecture.\n\nDeliverables:\n- ADR-001: Architecture decision record\n- templates/auth-flow.md: Flow diagram\n\nFollow-up Implementation Tasks:\n- task-107: Implement auth service\n- task-108: Implement auth middleware\n- task-109: Add auth tests'
+
+# 4. Only NOW mark design task as Done
+backlog task edit 106 -s Done
+```
+
+### Design Task Definition of Done
+
+A design task is **Done** only when **ALL** of the following are complete:
+
+1. ✅ All acceptance criteria checked
+2. ✅ Design artifacts created (ADRs, diagrams, specs)
+3. ✅ **Implementation tasks created** (MANDATORY for design tasks)
+4. ✅ Implementation notes include "Follow-up Implementation Tasks:" section
+5. ✅ Status set to Done
+
+### Naming Convention for Follow-up Tasks
+
+Implementation tasks should clearly reference their design origin:
+
+| Design Task | Implementation Task(s) |
+|------------|------------------------|
+| Design authentication flow | Implement auth service, Implement auth middleware |
+| Audit API endpoints | Update deprecated endpoints, Add missing validation |
+| Research caching strategy | Implement Redis caching layer, Add cache invalidation |
+| Spike: GraphQL performance | Implement DataLoader pattern, Add query complexity limits |
+
+### Why This Matters
+
+- **Traceability**: Every design decision has corresponding implementation
+- **No orphaned designs**: Prevents valuable design work from being forgotten
+- **Clear dependencies**: Implementation tasks can reference design artifacts
+- **Audit trail**: Easy to trace from requirement → design → implementation
+
+---
+
 ## Multi-line Input Best Practices
 
 The CLI preserves input literally. Use shell-appropriate syntax for newlines:


### PR DESCRIPTION
## Summary

- Adds mandatory design→implement workflow enforcement to ensure design tasks always produce implementation tasks
- Updates distributed templates (`templates/`) so all jp-spec-kit users get this enforcement
- Updates local repo commands (`.claude/commands/`) for consistency
- Retroactively documents follow-up tasks in completed design tasks (task-105, task-106)

## Problem

Design tasks (specify, plan, research) could be marked as "Done" without creating corresponding implementation tasks, leading to orphaned design work that never gets implemented.

## Solution

Design tasks are now **required** to create implementation tasks before completion. This is enforced at three levels:

1. **Agent instructions** (`templates/partials/backlog-instructions.md`) - Defines what design tasks are and requires implementation tasks
2. **Command definitions** (`templates/commands/jpspec/*.md`) - Each design command explicitly requires follow-up tasks
3. **Task lifecycle** (Definition of Done) - Design tasks cannot be marked Done without "Follow-up Implementation Tasks:" in notes

### Design Task Identification

**Labels** (any indicates design task):
- `design`, `audit`, `architecture`, `research`, `spike`, `planning`

**Title patterns**:
- "Design ...", "... Architecture", "Audit ...", "Research ...", "Spike: ..."

## Files Changed

| File | Purpose |
|------|---------|
| `templates/partials/backlog-instructions.md` | Core design→implement workflow documentation |
| `templates/commands/jpspec/specify.md` | PRD → implementation tasks |
| `templates/commands/jpspec/plan.md` | Architecture → implementation tasks |
| `templates/commands/jpspec/research.md` | Research → implementation tasks |
| `.claude/commands/jpspec/*.md` | Local repo consistency (3 files) |
| `CLAUDE.md` | Local repo documentation |
| `backlog/tasks/task-105*.md` | Retroactive follow-up references |
| `backlog/tasks/task-106*.md` | Retroactive follow-up references |

## Test plan

- [ ] Verify templates render correctly in markdown preview
- [ ] Test `/jpspec:specify` workflow produces implementation task prompts
- [ ] Test `/jpspec:plan` workflow produces implementation task prompts
- [ ] Test `/jpspec:research` workflow produces implementation task prompts
- [ ] Verify backlog-instructions.md is properly injected into agent contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)