### PR TITLE
chore: mark task-107 as complete with implementation notes

### DIFF
--- a/backlog/tasks/task-107 - Create-shared-backlog.md-instructions-template-for-agents.md
+++ b/backlog/tasks/task-107 - Create-shared-backlog.md-instructions-template-for-agents.md
@@ -1,12 +1,12 @@
-
 ---
 priority: high
 id: task-107
 title: Create shared backlog.md instructions template for agents
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2025-11-28 16:55'
-updated_date: '2025-11-28 16:56'
+updated_date: '2025-11-29'
 labels:
   - jpspec
   - backlog-integration
@@ -14,6 +14,7 @@ labels:
   - template
 dependencies:
   - task-106
+---
 
 ## Description
 
@@ -23,10 +24,26 @@ Create a reusable _backlog-instructions.md template that can be injected into al
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Template file created at .claude/commands/jpspec/_backlog-instructions.md
-- [ ] #2 Template includes task discovery instructions (backlog search, backlog task list)
-- [ ] #3 Template includes task assignment workflow (backlog task edit -a)
-- [ ] #4 Template includes AC tracking instructions (--check-ac pattern)
-- [ ] #5 Template includes implementation notes pattern
-- [ ] #6 Template includes Definition of Done checklist
+- [x] #1 Template file created at .claude/commands/jpspec/_backlog-instructions.md
+- [x] #2 Template includes task discovery instructions (backlog search, backlog task list)
+- [x] #3 Template includes task assignment workflow (backlog task edit -a)
+- [x] #4 Template includes AC tracking instructions (--check-ac pattern)
+- [x] #5 Template includes implementation notes pattern
+- [x] #6 Template includes Definition of Done checklist
 <!-- AC:END -->
+
+## Implementation Notes
+<!-- NOTES:BEGIN -->
+Implemented shared backlog.md instructions template for all jpspec agents.
+
+Deliverables:
+- Created .claude/commands/jpspec/_backlog-instructions.md with comprehensive instructions
+- Template includes task discovery (search, list commands)
+- Template includes task assignment workflow with -a flag
+- Template includes AC tracking with --check-ac pattern
+- Template includes implementation notes patterns
+- Template includes full Definition of Done checklist
+- Also created templates/partials/backlog-instructions.md (alternate location)
+
+The template is now used by all jpspec agent prompts for consistent backlog.md CLI usage.
+<!-- NOTES:END -->


### PR DESCRIPTION
## Summary
- Task-107 (Create shared backlog.md instructions template) was already implemented but not marked as Done in the backlog
- Updated status from "To Do" to "Done" with all 6 ACs checked
- Added implementation notes documenting the deliverables
- Fixed YAML frontmatter issue (leading blank line + missing closing `---`)

## Review Findings

Reviewed all completed tasks in the backlog (100s range) against the codebase:

| Task | Description | Verification |
|------|-------------|--------------|
| task-73 | Backlog flush testing | ✅ scripts/bash/flush-backlog.sh exists |
| task-89 | Test execution & result mapping | ✅ src/specify_cli/test_executor.py exists |
| task-105 | Audit jpspec commands | ✅ docs/audits/jpspec-command-audit.md exists |
| task-106 | Design backlog.md integration | ✅ docs/adr/ADR-001-backlog-md-integration.md exists |
| task-107 | Shared backlog instructions | ✅ Template exists but was not marked Done → **Fixed** |
| task-108 | Test framework for backlog | ✅ tests/test_jpspec_backlog_integration.py exists |
| task-109 | jpspec:specify backlog | ✅ Backlog CLI integration in specify.md |
| task-112 | jpspec:implement backlog | ✅ Backlog CLI integration in implement.md |
| task-114 | jpspec:operate backlog | ✅ Backlog CLI integration in operate.md |
| task-131 | Mermaid.js workflow diagram | ✅ docs/diagrams/jpspec-workflow.md exists |
| task-135 | prune-branch command | ✅ .claude/commands/jpspec/prune-branch.md exists |
| task-137-144 | Voice/Pipecat tasks | ✅ src/specify_cli/voice/* module exists |

Only task-107 needed status update.

## Test plan
- [x] Verified template exists at .claude/commands/jpspec/_backlog-instructions.md
- [x] Verified alternate location at templates/partials/backlog-instructions.md
- [x] Verified backlog CLI now parses task-107 correctly
- [x] All ACs match actual implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)