### PR TITLE
feat(dogfood): add VS Code Copilot support to dogfood command

### DIFF
--- a/.github/prompts/jpspec.implement.prompt.md
+++ b/.github/prompts/jpspec.implement.prompt.md
@@ -1,0 +1,1 @@
+../../templates/commands/jpspec/implement.md

--- a/.github/prompts/jpspec.operate.prompt.md
+++ b/.github/prompts/jpspec.operate.prompt.md
@@ -1,0 +1,1 @@
+../../templates/commands/jpspec/operate.md

--- a/.github/prompts/jpspec.plan.prompt.md
+++ b/.github/prompts/jpspec.plan.prompt.md
@@ -1,0 +1,1 @@
+../../templates/commands/jpspec/plan.md

--- a/.github/prompts/jpspec.research.prompt.md
+++ b/.github/prompts/jpspec.research.prompt.md
@@ -1,0 +1,1 @@
+../../templates/commands/jpspec/research.md

--- a/.github/prompts/jpspec.specify.prompt.md
+++ b/.github/prompts/jpspec.specify.prompt.md
@@ -1,0 +1,1 @@
+../../templates/commands/jpspec/specify.md

--- a/.github/prompts/jpspec.validate.prompt.md
+++ b/.github/prompts/jpspec.validate.prompt.md
@@ -1,0 +1,1 @@
+../../templates/commands/jpspec/validate.md

--- a/.github/prompts/speckit.analyze.prompt.md
+++ b/.github/prompts/speckit.analyze.prompt.md
@@ -1,0 +1,1 @@
+../../templates/commands/analyze.md

--- a/.github/prompts/speckit.checklist.prompt.md
+++ b/.github/prompts/speckit.checklist.prompt.md
@@ -1,0 +1,1 @@
+../../templates/commands/checklist.md

--- a/.github/prompts/speckit.clarify.prompt.md
+++ b/.github/prompts/speckit.clarify.prompt.md
@@ -1,0 +1,1 @@
+../../templates/commands/clarify.md

--- a/.github/prompts/speckit.constitution.prompt.md
+++ b/.github/prompts/speckit.constitution.prompt.md
@@ -1,0 +1,1 @@
+../../templates/commands/constitution.md

--- a/.github/prompts/speckit.implement.prompt.md
+++ b/.github/prompts/speckit.implement.prompt.md
@@ -1,0 +1,1 @@
+../../templates/commands/implement.md

--- a/.github/prompts/speckit.plan.prompt.md
+++ b/.github/prompts/speckit.plan.prompt.md
@@ -1,0 +1,1 @@
+../../templates/commands/plan.md

--- a/.github/prompts/speckit.specify.prompt.md
+++ b/.github/prompts/speckit.specify.prompt.md
@@ -1,0 +1,1 @@
+../../templates/commands/specify.md

--- a/.github/prompts/speckit.tasks.prompt.md
+++ b/.github/prompts/speckit.tasks.prompt.md
@@ -1,0 +1,1 @@
+../../templates/commands/tasks.md


### PR DESCRIPTION
- Add .github/prompts/ symlinks for speckit.* and jpspec.* prompts
- Update dogfood command to create Copilot prompt symlinks
- Update dogfood command to create .vscode/settings.json with chat.promptFiles enabled
- Support both Claude Code (.claude/commands/) and VS Code Copilot (.github/prompts/)

This enables jp-spec-kit developers to use /speckit.* and /jpspec.* prompts in VS Code Copilot Chat when working on the project itself.