### PR TITLE
feat(cli): add specify gate command for pre-implementation quality checks

### DIFF
--- a/.claude/commands/jpspec/implement.md
+++ b/.claude/commands/jpspec/implement.md
@@ -45,7 +45,61 @@ tasks manually using:
 Then re-run /jpspec:implement
 ```
 
-**If tasks ARE found, proceed to Phase 1.**
+**If tasks ARE found, proceed to Phase 0.**
+
+### Phase 0: Quality Gate (MANDATORY)
+
+**⚠️ CRITICAL: Spec quality must pass before implementation begins.**
+
+Before starting implementation, you MUST run the quality gate:
+
+```bash
+# Run quality gate on spec.md
+specify gate
+
+# Alternative: Override threshold if needed
+specify gate --threshold 60
+
+# Emergency bypass (NOT RECOMMENDED - use only with explicit user approval)
+specify gate --force
+```
+
+**Quality Gate Exit Codes:**
+- `0` = PASSED - Proceed to Phase 1
+- `1` = FAILED - Spec quality below threshold
+- `2` = ERROR - Missing spec.md or validation error
+
+**If gate PASSES (exit code 0):**
+```
+✅ Quality gate passed
+Proceeding with implementation...
+```
+
+**If gate FAILS (exit code 1):**
+```
+❌ Quality gate failed: Spec quality is X/100 (minimum: 70)
+
+Recommendations:
+  • Add missing section: ## Description
+  • Add missing section: ## User Story
+  • Reduce vague terms (currently: Y instances)
+  • Add measurable acceptance criteria
+
+Action Required:
+1. Improve spec quality using recommendations
+2. Re-run: specify quality .specify/spec.md
+3. When quality ≥70, re-run: /jpspec:implement
+
+OR (not recommended without user approval):
+  specify gate --force
+```
+
+**--force Bypass:**
+- Only use with explicit user approval
+- Warns that bypassing quality checks may lead to unclear requirements
+- Logs the bypass decision
+
+**Proceed to Phase 1 ONLY if quality gate passes or user explicitly approves --force bypass.**
 
 ### Phase 1: Implementation (Parallel Execution)
 

--- a/backlog/tasks/task-084 - Spec-Quality-Metrics-Command.md
+++ b/backlog/tasks/task-084 - Spec-Quality-Metrics-Command.md
@@ -4,7 +4,7 @@ title: Spec Quality Metrics Command
 status: To Do
 assignee: []
 created_date: '2025-11-27 21:54'
-updated_date: '2025-11-29 05:38'
+updated_date: '2025-11-30 16:53'
 labels:
   - specify-cli
   - feature
@@ -29,5 +29,11 @@ Add 'specify quality' command for automated spec assessment. Measures: Completen
 - [ ] #6 Implement ambiguity marker detection
 - [ ] #7 Create rich output format (table with scores + recommendations)
 - [ ] #8 Add customizable thresholds via .specify/quality-config.json
-- [ ] #9 Integrate with pre-implementation gates
+- [x] #9 Integrate with pre-implementation gates
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+AC #9: Implemented specify gate command with exit codes 0/1/2. Integrated into /jpspec:implement as Phase 0 (mandatory quality gate before implementation).
+<!-- SECTION:NOTES:END -->

--- a/docs/specs/task-084-ac9-quality-gates.md
+++ b/docs/specs/task-084-ac9-quality-gates.md
@@ -1,0 +1,260 @@
+# Task-084 AC #9: Pre-Implementation Quality Gates
+
+## Overview
+Integrate `specify quality` command as a pre-implementation gate that validates spec quality before coding begins.
+
+## Requirements
+
+### 1. Gate Integration Points
+- **Slash command integration**: `/jpspec:implement` should run quality check first
+- **CLI integration**: New `specify gate` command that runs quality + blocks on failure
+- **Threshold configuration**: Use existing `.specify/quality-config.json` thresholds
+
+### 2. Behavior
+- Run `specify quality` on spec.md before implementation
+- If overall score < threshold (default 70): BLOCK with recommendations
+- If score >= threshold: PROCEED with summary
+- `--force` flag to bypass gate (with warning)
+
+### 3. Implementation Approach
+
+**Recommended: Option C (Both CLI command + Slash command integration)**
+
+#### Option A: CLI `specify gate` Command
+- Add new `gate` command to CLI
+- Wraps existing quality check logic
+- Returns exit code 0 (pass) or 1 (fail)
+- Displays pass/fail status with recommendations
+
+#### Option B: Modify `/jpspec:implement` Slash Command
+- Add quality gate check at start of implementation workflow
+- Uses existing `specify quality` via subprocess
+- Blocks implementation if gate fails
+- Allows `--force` flag to bypass
+
+#### Option C: Both (Recommended)
+- Implement standalone `specify gate` command for manual use
+- Integrate gate check into `/jpspec:implement` workflow
+- Provides both programmatic (exit codes) and interactive (slash command) interfaces
+- Maximizes reusability and flexibility
+
+### 4. Exit Codes
+
+For `specify gate` command:
+- **0**: Quality gate passed (score >= threshold)
+- **1**: Quality gate failed (score < threshold)
+- **2**: Error running quality check (file not found, invalid config, etc.)
+
+### 5. Output Format
+
+#### Success Case
+```
+🔍 Running pre-implementation quality gate...
+
+Quality Assessment: spec.md
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Overall Score: 85/100 ✅ PASSED (minimum: 70)
+
+Dimension Scores:
+• Completeness:   90/100
+• Clarity:        85/100
+• Traceability:   80/100
+• Constitutional: 85/100
+• Ambiguity:      90/100
+
+✅ Quality gate passed. Proceeding with implementation...
+```
+
+#### Failure Case
+```
+🔍 Running pre-implementation quality gate...
+
+Quality Assessment: spec.md
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Overall Score: 45/100 ❌ FAILED (minimum: 70)
+
+Dimension Scores:
+• Completeness:   30/100 ⚠️
+• Clarity:        50/100 ⚠️
+• Traceability:   40/100 ⚠️
+• Constitutional: 60/100
+• Ambiguity:      45/100 ⚠️
+
+Top Recommendations:
+1. Add missing section: ## Technical Requirements
+2. Add missing section: ## Acceptance Criteria
+3. Improve clarity: Remove vague terms like "etc", "various"
+4. Add clear acceptance criteria to specification
+5. Resolve ambiguity: TBD items in section 3
+
+❌ Quality gate failed. Implementation blocked.
+
+Fix the issues above or run with --force to bypass (not recommended).
+```
+
+#### Force Bypass
+```
+🔍 Running pre-implementation quality gate...
+
+Quality Assessment: spec.md
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Overall Score: 45/100 ❌ FAILED (minimum: 70)
+
+⚠️  WARNING: Quality gate bypassed with --force flag
+Proceeding with implementation despite low quality score.
+This may lead to implementation issues and rework.
+```
+
+### 6. Configuration
+
+Uses existing `QualityConfig.find_config()` to locate `.specify/quality-config.json`:
+
+```json
+{
+  "thresholds": {
+    "passing": 70,
+    "excellent": 90
+  },
+  "weights": {
+    "completeness": 0.30,
+    "clarity": 0.25,
+    "traceability": 0.20,
+    "constitutional": 0.15,
+    "ambiguity": 0.10
+  }
+}
+```
+
+If no config file exists, uses default threshold of 70.
+
+### 7. Implementation Details
+
+#### CLI Command Structure
+```python
+# src/specify_cli/__init__.py
+
+@app.command()
+def gate(
+    spec_path: Path = typer.Option(None, "--spec", help="Path to spec.md"),
+    force: bool = typer.Option(False, "--force", help="Bypass quality gate"),
+    threshold: Optional[int] = typer.Option(None, "--threshold", help="Override threshold"),
+) -> None:
+    """Run pre-implementation quality gate on specification."""
+
+    # Find spec.md if not provided
+    # Load quality config
+    # Run quality check
+    # Display results
+    # Exit with appropriate code
+```
+
+#### Slash Command Integration
+Modify `/jpspec:implement` to include quality gate check before Phase 1:
+
+```markdown
+## Phase 0: Pre-Implementation Quality Gate
+
+Before launching engineer agents, validate specification quality:
+
+```bash
+specify gate
+
+# If gate fails, stop here and fix issues
+# If gate passes, continue to Phase 1
+```
+
+If quality gate fails and user wants to proceed anyway:
+```bash
+specify gate --force
+```
+```
+
+### 8. Error Handling
+
+- **Spec file not found**: Exit code 2, clear error message
+- **Invalid config file**: Exit code 2, show config path and error
+- **Missing required sections**: Reported in recommendations, exit code 1
+- **Config validation fails**: Exit code 2, explain weight sum error
+
+## Acceptance Criteria
+
+- [ ] AC #9.1: `specify gate` command implemented with quality check
+- [ ] AC #9.2: Exit code 0 on pass (score >= threshold), 1 on fail, 2 on error
+- [ ] AC #9.3: Respects threshold from `.specify/quality-config.json` or uses default 70
+- [ ] AC #9.4: `--force` flag bypasses gate with warning (exit code 0)
+- [ ] AC #9.5: Clear pass/fail output with dimension scores
+- [ ] AC #9.6: Recommendations displayed on failure (top 5)
+- [ ] AC #9.7: `/jpspec:implement` slash command includes quality gate check
+- [ ] AC #9.8: Documentation updated with gate usage examples
+
+## Test Plan
+
+### Unit Tests
+- [ ] Test with high-quality spec (score 85) - should pass
+- [ ] Test with low-quality spec (score 45) - should fail
+- [ ] Test with threshold = 60, score = 65 - should pass
+- [ ] Test with threshold = 80, score = 75 - should fail
+- [ ] Test `--force` flag - should always pass (exit code 0)
+- [ ] Test custom threshold via `--threshold` flag
+- [ ] Test spec file not found - exit code 2
+- [ ] Test invalid config file - exit code 2
+
+### Integration Tests
+- [ ] Test with real spec.md from sample project
+- [ ] Test config file discovery (walks up directory tree)
+- [ ] Test default config when no config file exists
+- [ ] Test `/jpspec:implement` with quality gate enabled
+
+### Edge Cases
+- [ ] Empty spec file
+- [ ] Spec file with only one section
+- [ ] Config file with invalid JSON
+- [ ] Config weights don't sum to 1.0
+- [ ] Spec path is a directory, not a file
+
+## Implementation Notes
+
+### Files to Modify
+1. **`src/specify_cli/__init__.py`** - Add `gate()` command
+2. **`.claude/commands/jpspec/implement.md`** - Add Phase 0 quality gate
+3. **`tests/test_quality_gate.py`** - New test file for gate command
+4. **`docs/reference/quality-gates.md`** - New documentation
+
+### Files to Reference (Existing Code)
+1. **`src/specify_cli/quality/scorer.py`** - `QualityScorer` class
+2. **`src/specify_cli/quality/config.py`** - `QualityConfig.find_config()`
+3. **`src/specify_cli/quality/assessors.py`** - Assessment functions
+
+### Dependencies
+- No new dependencies required
+- Reuses existing quality assessment infrastructure
+- Integrates with Rich for formatted output
+
+## Out of Scope
+
+- Web UI for quality gates
+- Git hooks integration (separate task)
+- CI/CD integration (separate task)
+- Historical quality tracking
+- Automated spec fixing
+
+## Questions for Approval
+
+1. **Should the gate check plan.md and tasks.md as well, or only spec.md?**
+   - Current design: Only spec.md (as it's the source of truth)
+   - Alternative: Check all three if they exist
+
+2. **Should we add a `--quiet` flag for CI/CD use cases?**
+   - Output only exit code, no pretty formatting
+   - Useful for automation scripts
+
+3. **Should the slash command integration be optional or mandatory?**
+   - Current design: Mandatory (always runs)
+   - Alternative: Add `--skip-gate` flag to `/jpspec:implement`
+
+## Success Metrics
+
+- Quality gate reduces implementation rework by catching spec issues early
+- Gate pass rate increases over time as teams learn quality standards
+- Time spent in specification reviews decreases (gate does first-pass check)
+- Implementation velocity increases (fewer mid-implementation spec clarifications)

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -1,0 +1,120 @@
+"""Tests for specify gate command."""
+
+from typer.testing import CliRunner
+
+from specify_cli import app
+
+
+class TestGateCommand:
+    """Test the specify gate command."""
+
+    def test_gate_passes_high_quality_spec(self, tmp_path, monkeypatch):
+        """Gate passes when spec quality is above threshold."""
+        # Create a high-quality spec that includes all required sections
+        specify_dir = tmp_path / ".specify"
+        specify_dir.mkdir()
+        spec = specify_dir / "spec.md"
+        spec.write_text("""# Feature: User Authentication
+
+## Description
+This feature enables secure user authentication using email and password credentials
+with session management capabilities.
+
+## User Story
+As a user, I need secure authentication so that I can safely access the system
+and protect my account from unauthorized access.
+
+## Problem Statement
+Users need a secure authentication mechanism to access the system while ensuring
+their credentials and sessions are properly protected.
+
+## Technical Requirements
+1. Email validation must check format using standard RFC 5322 pattern
+2. Password strength must require minimum 8 characters including uppercase, lowercase, and numbers
+3. Session tokens must use cryptographically secure random generation
+4. Sessions must expire after 24 hours of inactivity
+5. All authentication endpoints must be tested using pytest
+6. Code must be formatted using ruff
+
+## Acceptance Criteria
+- [ ] Login form validates email format according to RFC 5322
+- [ ] Password requires minimum 8 characters with mixed case and numbers
+- [ ] Session token is cryptographically generated and stored securely
+- [ ] Session expires after exactly 24 hours
+- [ ] All endpoints have pytest test coverage
+- [ ] Code is formatted with ruff
+""")
+
+        # Change to the tmp_path directory
+        monkeypatch.chdir(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["gate"])
+        assert result.exit_code == 0
+        assert "PASSED" in result.output or "passed" in result.output.lower()
+
+    def test_gate_fails_low_quality_spec(self, tmp_path, monkeypatch):
+        """Gate fails when spec quality is below threshold."""
+        specify_dir = tmp_path / ".specify"
+        specify_dir.mkdir()
+        spec = specify_dir / "spec.md"
+        spec.write_text("# TODO\nSome vague stuff maybe later")
+
+        monkeypatch.chdir(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["gate"])
+        assert result.exit_code == 1
+        assert "FAILED" in result.output or "failed" in result.output.lower()
+
+    def test_gate_force_bypasses_failure(self, tmp_path, monkeypatch):
+        """--force flag allows bypassing failed gate."""
+        specify_dir = tmp_path / ".specify"
+        specify_dir.mkdir()
+        spec = specify_dir / "spec.md"
+        spec.write_text("# TODO\nVague")
+
+        monkeypatch.chdir(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["gate", "--force"])
+        assert result.exit_code == 0
+        assert "bypass" in result.output.lower() or "force" in result.output.lower()
+
+    def test_gate_custom_threshold(self, tmp_path, monkeypatch):
+        """--threshold flag overrides config threshold."""
+        specify_dir = tmp_path / ".specify"
+        specify_dir.mkdir()
+        spec = specify_dir / "spec.md"
+        spec.write_text("# Feature\nBasic description")
+
+        monkeypatch.chdir(tmp_path)
+
+        runner = CliRunner()
+        # Very low threshold should pass
+        result = runner.invoke(app, ["gate", "--threshold", "10"])
+        assert result.exit_code == 0
+
+    def test_gate_no_spec_file_error(self, tmp_path, monkeypatch):
+        """Gate returns error code when spec.md doesn't exist."""
+        monkeypatch.chdir(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["gate"])
+        assert result.exit_code == 2  # Error code
+
+    def test_gate_shows_recommendations_on_failure(self, tmp_path, monkeypatch):
+        """Failed gate shows improvement recommendations."""
+        specify_dir = tmp_path / ".specify"
+        specify_dir.mkdir()
+        spec = specify_dir / "spec.md"
+        spec.write_text("# TODO")
+
+        monkeypatch.chdir(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["gate"])
+        assert result.exit_code == 1
+        assert (
+            "recommend" in result.output.lower() or "improve" in result.output.lower()
+        )


### PR DESCRIPTION
## Summary
- Adds `specify gate` command for pre-implementation quality validation
- Exit codes: 0 (pass), 1 (fail), 2 (error)
- Configurable threshold via `--threshold` or `.specify/quality-config.json`
- `--force` flag to bypass with warning
- Integrated into `/jpspec:implement` slash command as Phase 0

Completes AC #9 for task-084.

## Test plan
- [x] Tests pass for high-quality spec (exit 0)
- [x] Tests pass for low-quality spec (exit 1)
- [x] Tests pass for missing spec (exit 2)
- [x] Tests pass for --force bypass
- [x] Tests pass for custom threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)