### PR TITLE
chore: remove context7 and figma MCP servers

### DIFF
--- a/.agents/ai-ml-engineer.md
+++ b/.agents/ai-ml-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: ai-ml-engineer
 description: Expert AI/ML engineer specializing in MLOps, model development, deployment, monitoring, and AI system integration with focus on production-ready machine learning
-tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__context7__*, mcp__serena__*
+tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__serena__*
 model: sonnet
 color: purple
 loop: inner

--- a/.agents/backend-code-reviewer.md
+++ b/.agents/backend-code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: backend-code-reviewer
 description: Expert backend code reviewer specializing in Go, TypeScript, and Python with focus on code quality, security, performance, scalability, and maintainability
-tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__context7__*, mcp__serena__*, mcp__trivy__*, mcp__semgrep__*
+tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__serena__*, mcp__trivy__*, mcp__semgrep__*
 model: sonnet
 color: red
 loop: inner

--- a/.agents/backend-engineer.md
+++ b/.agents/backend-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: backend-engineer
 description: Expert backend engineer specializing in Go, TypeScript, and Python development for CLI tools, APIs, and middleware with focus on scalability, reliability, and maintainability
-tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__context7__*, mcp__serena__*
+tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__serena__*
 model: sonnet
 color: orange
 loop: inner

--- a/.agents/business-validator.md
+++ b/.agents/business-validator.md
@@ -1,7 +1,7 @@
 ---
 name: business-validator
 description: Business viability assessment specialist providing realistic validation based on market potential, financial feasibility, operational constraints, and risk analysis
-tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__context7__*, mcp__serena__*
+tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__serena__*
 model: sonnet
 color: green
 loop: inner

--- a/.agents/frontend-code-reviewer.md
+++ b/.agents/frontend-code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: frontend-code-reviewer
 description: Expert frontend code reviewer specializing in React and mobile code review with focus on code quality, performance, accessibility, security, and maintainability
-tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__context7__*, mcp__serena__*, mcp__trivy__*, mcp__semgrep__*, mcp__figma__*, mcp__shadcn-ui__*, mcp__playwright-test__*, mcp__chrome-devtools__*
+tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__serena__*, mcp__trivy__*, mcp__semgrep__*, mcp__shadcn-ui__*, mcp__playwright-test__*, mcp__chrome-devtools__*
 model: sonnet
 color: yellow
 loop: inner

--- a/.agents/frontend-engineer.md
+++ b/.agents/frontend-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: frontend-engineer
 description: Expert frontend engineer specializing in React and mobile development with focus on modern web standards, performance, accessibility, and user experience
-tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__context7__*, mcp__serena__*, mcp__figma__*, mcp__shadcn-ui__*, mcp__playwright-test__*, mcp__chrome-devtools__*
+tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__serena__*, mcp__shadcn-ui__*, mcp__playwright-test__*, mcp__chrome-devtools__*
 model: sonnet
 color: blue
 loop: inner

--- a/.agents/platform-engineer-enhanced.md
+++ b/.agents/platform-engineer-enhanced.md
@@ -1,7 +1,7 @@
 ---
 name: platform-engineer-enhanced
 description: DevOps/CI/CD expert specializing in high-performance systems and regulatory compliance
-tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__context7__*, mcp__serena__*
+tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__serena__*
 model: sonnet
 color: blue
 loop: inner

--- a/.agents/product-requirements-manager-enhanced.md
+++ b/.agents/product-requirements-manager-enhanced.md
@@ -1,7 +1,7 @@
 ---
 name: product-requirements-manager-enhanced
 description: Product management expert specializing in SVPG principles and strategic product development
-tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__context7__*, mcp__serena__*
+tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__serena__*
 model: sonnet
 color: green
 loop: inner

--- a/.agents/quality-guardian.md
+++ b/.agents/quality-guardian.md
@@ -1,7 +1,7 @@
 ---
 name: quality-guardian
 description: Use this agent when you need comprehensive risk analysis, quality assessment, or critical evaluation of technical proposals, system designs, or implementation plans. Examples: <example>Context: User has just received a technical proposal for a new authentication system and wants thorough risk analysis before proceeding. user: 'Here's our plan for implementing biometric authentication with behavioral analysis. Can you review this for potential issues?' assistant: 'I'll use the quality-guardian agent to perform a comprehensive risk analysis of this authentication system proposal.' <commentary>Since the user is requesting risk analysis of a technical proposal, use the quality-guardian agent to identify security vulnerabilities, privacy concerns, technical risks, and mitigation strategies.</commentary></example> <example>Context: Development team has completed initial system design and needs critical review before implementation begins. user: 'We've finished our database architecture design. Before we start coding, what risks should we consider?' assistant: 'Let me engage the quality-guardian agent to conduct a thorough evaluation of your database architecture for potential failure modes and operational concerns.' <commentary>The user needs critical evaluation of system design before implementation, which is exactly when the quality-guardian should be used to identify technical risks, performance concerns, and operational challenges.</commentary></example>
-tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__context7__*, mcp__serena__*, mcp__chrome-devtools__*
+tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__serena__*, mcp__chrome-devtools__*
 model: sonnet
 color: red
 loop: inner

--- a/.agents/release-manager.md
+++ b/.agents/release-manager.md
@@ -1,7 +1,7 @@
 ---
 name: release-manager
 description: Expert release manager responsible for validating code quality, coordinating releases, managing deployments, and ensuring production readiness with human approval checkpoints for critical decisions
-tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__context7__*, mcp__serena__*, mcp__trivy__*
+tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__serena__*, mcp__trivy__*
 model: sonnet
 color: green
 loop: outer

--- a/.agents/researcher.md
+++ b/.agents/researcher.md
@@ -1,7 +1,7 @@
 ---
 name: researcher
 description: Market and technical research specialist conducting comprehensive research on ideas, technologies, competitive landscape, industry trends, and technical feasibility
-tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__context7__*, mcp__serena__*
+tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__serena__*
 model: sonnet
 color: purple
 loop: inner

--- a/.agents/secure-by-design-engineer.md
+++ b/.agents/secure-by-design-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: secure-by-design-engineer
 description: Use this agent when you need comprehensive security analysis, threat modeling, secure architecture review, security code review, or guidance on implementing security-by-design principles. This agent should be consulted proactively during the design phase of new features, when reviewing code changes that handle sensitive data, when integrating third-party services, or when security vulnerabilities are discovered. Examples: <example>Context: User is developing a new authentication system for a financial application. user: 'I'm building a new login system that will handle user credentials and session management. Can you review my approach?' assistant: 'I'll use the secure-by-design-engineer agent to conduct a comprehensive security review of your authentication system design, focusing on threat modeling and secure implementation practices.'</example> <example>Context: User has completed a new API endpoint that processes payment data. user: 'I just finished implementing a payment processing endpoint. Here's the code...' assistant: 'Let me engage the secure-by-design-engineer agent to perform a thorough security code review of your payment processing implementation, checking for common vulnerabilities and compliance requirements.'</example>
-tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__context7__*, mcp__serena__*, mcp__trivy__*, mcp__semgrep__*
+tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__serena__*, mcp__trivy__*, mcp__semgrep__*
 model: sonnet
 color: cyan
 loop: inner

--- a/.agents/software-architect-enhanced.md
+++ b/.agents/software-architect-enhanced.md
@@ -1,7 +1,7 @@
 ---
 name: software-architect-enhanced
 description: Enterprise architect using Hohpe's principles from The Software Architect Elevator, Enterprise Integration Patterns, Cloud Strategy, and Platform Strategy. Expert in bridging business strategy with technical implementation, architectural decision-making, and organizational transformation.
-tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__context7__*, mcp__serena__*
+tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__serena__*
 model: sonnet
 color: red
 loop: inner

--- a/.agents/sre-agent.md
+++ b/.agents/sre-agent.md
@@ -1,7 +1,7 @@
 ---
 name: sre-agent
 description: Expert Site Reliability Engineer specializing in CI/CD (GitHub Actions), Kubernetes, DevSecOps, observability, and system reliability with focus on automation, scalability, and operational excellence
-tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__context7__*, mcp__serena__*, mcp__chrome-devtools__*
+tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__serena__*, mcp__chrome-devtools__*
 model: sonnet
 color: blue
 loop: outer

--- a/.agents/tech-writer.md
+++ b/.agents/tech-writer.md
@@ -1,7 +1,7 @@
 ---
 name: tech-writer
 description: Expert technical writer specializing in software documentation, API references, user guides, tutorials, and technical blogs with focus on clarity, accuracy, and audience-appropriate content
-tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__context7__*, mcp__serena__*
+tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__serena__*
 model: sonnet
 color: teal
 loop: inner

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -156,7 +156,7 @@
   },
   "notes": {
     "languageSupport": "Includes language-specific agent personas for C, C++, C#, Go, Java, Kotlin, Python, Rust, TypeScript/JavaScript, and Mobile (Dart/Flutter)",
-    "mcpServers": "Pre-configured with 9 MCP servers: GitHub, Serena, Context7, Playwright, Trivy, Semgrep, Figma, shadcn-ui, Chrome DevTools",
+    "mcpServers": "Pre-configured with 7 MCP servers: GitHub, Serena, Playwright, Trivy, Semgrep, shadcn-ui, Chrome DevTools",
     "dualDistribution": "Also available as Specify CLI (pip install specify-cli) for multi-agent support (Copilot, Gemini, Cursor, etc.)"
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -8,17 +8,9 @@
     },
     "serena": {
       "command": "uvx",
-      "args": ["--from", "git+https://github.com/oraios/serena", "serena-mcp-server", "--project", "${PROJECT_ROOT}"],
+      "args": ["--from", "git+https://github.com/oraios/serena", "serena-mcp-server", "--project", "/Users/jasonpoley/ps/jp-spec-kit"],
       "env": {},
       "description": "LSP-grade code understanding & safe semantic edits"
-    },
-    "context7": {
-      "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp"],
-      "env": {
-        "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"
-      },
-      "description": "Up-to-date, version-specific library documentation"
     },
     "playwright-test": {
       "command": "npx",
@@ -37,14 +29,6 @@
       "args": ["-y", "@returntocorp/semgrep-mcp"],
       "env": {},
       "description": "SAST code scanning for security vulnerabilities"
-    },
-    "figma": {
-      "command": "npx",
-      "args": ["-y", "figma-developer-mcp"],
-      "env": {
-        "FIGMA_API_KEY": "${FIGMA_API_KEY}"
-      },
-      "description": "Figma API integration for design files and components"
     },
     "shadcn-ui": {
       "command": "npx",
@@ -66,11 +50,6 @@
     }
   },
   "_notes": {
-    "environment_variables": [
-      "CONTEXT7_API_KEY: Required for Context7 MCP server",
-      "FIGMA_API_KEY: Required for Figma MCP server",
-      "PROJECT_ROOT: Automatically set to current working directory for Serena"
-    ],
     "missing_mcps": [
       "DAST (Dynamic Application Security Testing): No specific MCP server found - consider using OWASP ZAP directly",
       "Binary Signing: No specific MCP server found - use cosign/sigstore CLI tools directly",

--- a/docs/MCP-CONFIGURATION.md
+++ b/docs/MCP-CONFIGURATION.md
@@ -8,31 +8,9 @@ This project uses Model Context Protocol (MCP) servers to extend Claude Code cap
 
 MCP servers are configured in `.mcp.json` at the project root. This file is checked into version control so all team members have access to the same tools.
 
-## Environment Variables Required
+## Environment Variables
 
-Create a `.env` file in the project root with the following variables:
-
-```bash
-# Context7 - Required for up-to-date library documentation
-CONTEXT7_API_KEY=your_context7_api_key_here
-
-# Figma - Required for design file access (frontend agents)
-FIGMA_API_KEY=your_figma_api_key_here
-
-# PROJECT_ROOT is automatically set to current working directory
-```
-
-### Getting API Keys
-
-**Context7 API Key:**
-1. Visit: https://github.com/upstash/context7
-2. Follow the setup instructions to get your API key
-3. Add to `.env` file
-
-**Figma API Key:**
-1. Visit: https://www.figma.com/developers/api#access-tokens
-2. Generate a personal access token
-3. Add to `.env` file
+No additional environment variables are required for the base MCP configuration. All configured MCP servers work without API keys.
 
 ## Installed MCP Servers
 
@@ -48,30 +26,19 @@ FIGMA_API_KEY=your_figma_api_key_here
 - **Package**: `git+https://github.com/oraios/serena`
 - **Requirements**: Python with `uv` installed
 
-**3. Context7 (`mcp__context7__*`)**
-- **Purpose**: Up-to-date, version-specific library documentation
-- **Package**: `@upstash/context7-mcp`
-- **Requirements**: `CONTEXT7_API_KEY` environment variable
-
 ### Frontend-Specific MCPs
 
-**4. Playwright (`mcp__playwright-test__*`)**
+**3. Playwright (`mcp__playwright-test__*`)**
 - **Purpose**: Browser automation for testing and E2E workflows
 - **Package**: `@playwright/mcp`
 - **Agents**: frontend-engineer, frontend-code-reviewer, js-ts-expert-developer, js-ts-expert-developer-enhanced, playwright test agents
 
-**5. Figma (`mcp__figma__*`)**
-- **Purpose**: Figma API integration for design files and components
-- **Package**: `figma-developer-mcp`
-- **Requirements**: `FIGMA_API_KEY` environment variable
-- **Agents**: frontend-engineer, frontend-code-reviewer, js-ts-expert-developer, js-ts-expert-developer-enhanced
-
-**6. shadcn-ui (`mcp__shadcn-ui__*`)**
+**4. shadcn-ui (`mcp__shadcn-ui__*`)**
 - **Purpose**: shadcn/ui component library access and installation
 - **Package**: `@heilgar/shadcn-ui-mcp-server`
 - **Agents**: frontend-engineer, frontend-code-reviewer, js-ts-expert-developer, js-ts-expert-developer-enhanced
 
-**7. Chrome DevTools (`mcp__chrome-devtools__*`)**
+**5. Chrome DevTools (`mcp__chrome-devtools__*`)**
 - **Purpose**: Browser inspection, performance analysis, console logs, network monitoring, and UI testing via Chrome DevTools Protocol
 - **Package**: `chrome-devtools-mcp`
 - **Requirements**: Chrome browser installed, Node.js ≥20.19
@@ -86,12 +53,12 @@ FIGMA_API_KEY=your_figma_api_key_here
 
 ### Security-Specific MCPs
 
-**8. Trivy (`mcp__trivy__*`)**
+**6. Trivy (`mcp__trivy__*`)**
 - **Purpose**: Container/IaC security scans and SBOM generation
 - **Package**: `@aquasecurity/trivy-mcp`
 - **Agents**: secure-by-design-engineer, all code reviewers, release-manager
 
-**9. Semgrep (`mcp__semgrep__*`)**
+**7. Semgrep (`mcp__semgrep__*`)**
 - **Purpose**: SAST (Static Application Security Testing) code scanning
 - **Package**: `@returntocorp/semgrep-mcp`
 - **Agents**: secure-by-design-engineer, all code reviewers
@@ -100,7 +67,6 @@ FIGMA_API_KEY=your_figma_api_key_here
 
 ### All Agents (31 total)
 - `mcp__github__*` - GitHub API
-- `mcp__context7__*` - Documentation
 - `mcp__serena__*` - Code understanding
 
 ### Frontend Agents (4)
@@ -110,7 +76,6 @@ FIGMA_API_KEY=your_figma_api_key_here
 - js-ts-expert-developer-enhanced
 
 **Additional Tools:**
-- `mcp__figma__*`
 - `mcp__shadcn-ui__*`
 - `mcp__playwright-test__*`
 - `mcp__chrome-devtools__*` (frontend-engineer, frontend-code-reviewer only)
@@ -207,18 +172,6 @@ The following capabilities do not have dedicated MCP servers and should be handl
 - **Agents Affected**: secure-by-design-engineer
 
 ## Troubleshooting
-
-### Context7 API Key Missing
-```
-Error: CONTEXT7_API_KEY environment variable not set
-Solution: Add CONTEXT7_API_KEY to .env file
-```
-
-### Figma API Key Missing
-```
-Error: FIGMA_API_KEY environment variable not set
-Solution: Add FIGMA_API_KEY to .env file (required for frontend agents)
-```
 
 ### Serena Installation Issues
 ```

--- a/docs/reference/agent-mcp-integrations.md
+++ b/docs/reference/agent-mcp-integrations.md
@@ -35,11 +35,9 @@ flowchart TB
 
     subgraph MCP["MCP Servers"]
         github["github<br/>GitHub API"]
-        context7["context7<br/>Library Docs"]
         serena["serena<br/>LSP Code Intel"]
         trivy["trivy<br/>Security Scan"]
         semgrep["semgrep<br/>SAST"]
-        figma["figma<br/>Design Files"]
         shadcn["shadcn-ui<br/>UI Components"]
         playwright["playwright-test<br/>E2E Testing"]
         chrome["chrome-devtools<br/>Browser Debug"]
@@ -55,7 +53,6 @@ flowchart TB
 
     %% Core MCPs (all agents)
     PRM & SA & PE & RES & BV & FE & BE & AI & FCR & BCR & QG & SDE & TW & RM & SRE -.-> github
-    PRM & SA & PE & RES & BV & FE & BE & AI & FCR & BCR & QG & SDE & TW & RM & SRE -.-> context7
     PRM & SA & PE & RES & BV & FE & BE & AI & FCR & BCR & QG & SDE & TW & RM & SRE -.-> serena
 
     %% Security MCPs
@@ -63,7 +60,6 @@ flowchart TB
     FCR & BCR & SDE -.-> semgrep
 
     %% Frontend MCPs
-    FE & FCR -.-> figma
     FE & FCR -.-> shadcn
     FE & FCR -.-> playwright
     FE & FCR & QG & SRE -.-> chrome
@@ -75,46 +71,46 @@ flowchart TB
 
 | Agent | Description | MCP Servers |
 |-------|-------------|-------------|
-| **product-requirements-manager** | Product management using SVPG principles, outcomes over outputs | github, context7, serena |
+| **product-requirements-manager** | Product management using SVPG principles, outcomes over outputs | github, serena |
 
 ### `/jpspec:plan` - Architecture (Parallel Execution)
 
 | Agent | Description | MCP Servers |
 |-------|-------------|-------------|
-| **software-architect** | Enterprise architect using Hohpe's principles, Enterprise Integration Patterns | github, context7, serena |
-| **platform-engineer** | DevOps/CI/CD expert, DORA metrics, NIST/SSDF compliance | github, context7, serena |
+| **software-architect** | Enterprise architect using Hohpe's principles, Enterprise Integration Patterns | github, serena |
+| **platform-engineer** | DevOps/CI/CD expert, DORA metrics, NIST/SSDF compliance | github, serena |
 
 ### `/jpspec:research` - Research & Validation (Parallel Execution)
 
 | Agent | Description | MCP Servers |
 |-------|-------------|-------------|
-| **researcher** | Market research, competitive intelligence, technical feasibility | github, context7, serena |
-| **business-validator** | Business viability, financial feasibility, TAM/SAM/SOM analysis | github, context7, serena |
+| **researcher** | Market research, competitive intelligence, technical feasibility | github, serena |
+| **business-validator** | Business viability, financial feasibility, TAM/SAM/SOM analysis | github, serena |
 
 ### `/jpspec:implement` - Development
 
 | Agent | Description | MCP Servers |
 |-------|-------------|-------------|
-| **frontend-engineer** | React, React Native, TypeScript, performance, accessibility | github, context7, serena, figma, shadcn-ui, playwright-test, chrome-devtools |
-| **backend-engineer** | Go, TypeScript, Python, CLI tools, APIs, middleware | github, context7, serena |
-| **ai-ml-engineer** | MLOps, model development, deployment, monitoring | github, context7, serena |
-| **frontend-code-reviewer** | Frontend code review: quality, performance, accessibility, security | github, context7, serena, trivy, semgrep, figma, shadcn-ui, playwright-test, chrome-devtools |
-| **backend-code-reviewer** | Backend code review: security, performance, scalability | github, context7, serena, trivy, semgrep |
+| **frontend-engineer** | React, React Native, TypeScript, performance, accessibility | github, serena, shadcn-ui, playwright-test, chrome-devtools |
+| **backend-engineer** | Go, TypeScript, Python, CLI tools, APIs, middleware | github, serena |
+| **ai-ml-engineer** | MLOps, model development, deployment, monitoring | github, serena |
+| **frontend-code-reviewer** | Frontend code review: quality, performance, accessibility, security | github, serena, trivy, semgrep, shadcn-ui, playwright-test, chrome-devtools |
+| **backend-code-reviewer** | Backend code review: security, performance, scalability | github, serena, trivy, semgrep |
 
 ### `/jpspec:validate` - Quality Assurance
 
 | Agent | Description | MCP Servers |
 |-------|-------------|-------------|
-| **quality-guardian** | Risk analysis, quality assessment, critical evaluation | github, context7, serena, chrome-devtools |
-| **secure-by-design-engineer** | Security analysis, threat modeling, compliance | github, context7, serena, trivy, semgrep |
-| **tech-writer** | Documentation, API references, user guides, tutorials | github, context7, serena |
-| **release-manager** | Release coordination, quality validation, deployment management | github, context7, serena, trivy |
+| **quality-guardian** | Risk analysis, quality assessment, critical evaluation | github, serena, chrome-devtools |
+| **secure-by-design-engineer** | Security analysis, threat modeling, compliance | github, serena, trivy, semgrep |
+| **tech-writer** | Documentation, API references, user guides, tutorials | github, serena |
+| **release-manager** | Release coordination, quality validation, deployment management | github, serena, trivy |
 
 ### `/jpspec:operate` - Operations
 
 | Agent | Description | MCP Servers |
 |-------|-------------|-------------|
-| **sre-agent** | CI/CD (GitHub Actions), Kubernetes, DevSecOps, observability | github, context7, serena, chrome-devtools |
+| **sre-agent** | CI/CD (GitHub Actions), Kubernetes, DevSecOps, observability | github, serena, chrome-devtools |
 
 ## MCP Server Reference
 
@@ -125,7 +121,6 @@ These MCP servers are available to every agent:
 | Server | Description | Use Cases |
 |--------|-------------|-----------|
 | **github** | GitHub API integration | Repos, issues, PRs, code search, workflows |
-| **context7** | Up-to-date library documentation | Version-specific docs, API references |
 | **serena** | LSP-grade code understanding | Semantic code analysis, safe refactoring |
 
 ### Security Servers
@@ -139,7 +134,6 @@ These MCP servers are available to every agent:
 
 | Server | Description | Available To |
 |--------|-------------|--------------|
-| **figma** | Figma API for design files and components | frontend-engineer, frontend-code-reviewer |
 | **shadcn-ui** | shadcn/ui component library access | frontend-engineer, frontend-code-reviewer |
 | **playwright-test** | Browser automation for E2E testing | frontend-engineer, frontend-code-reviewer |
 | **chrome-devtools** | Chrome DevTools Protocol for debugging | frontend-engineer, frontend-code-reviewer, quality-guardian, sre-agent |
@@ -216,7 +210,7 @@ MCP servers are configured in `.mcp.json` at the project root. Each agent's avai
 ---
 name: frontend-engineer
 description: Expert frontend engineer specializing in React and mobile development
-tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__context7__*, mcp__serena__*, mcp__figma__*, mcp__shadcn-ui__*, mcp__playwright-test__*, mcp__chrome-devtools__*
+tools: Glob, Grep, Read, Write, Edit, mcp__github__*, mcp__serena__*, mcp__shadcn-ui__*, mcp__playwright-test__*, mcp__chrome-devtools__*
 model: sonnet
 color: blue
 ---
@@ -231,10 +225,6 @@ color: blue
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-github"]
     },
-    "context7": {
-      "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp"]
-    },
     "serena": {
       "command": "uvx",
       "args": ["--from", "git+https://github.com/oraios/serena", "serena-mcp-server"]
@@ -245,23 +235,23 @@ color: blue
 
 ## Quick Reference Matrix
 
-| Agent | github | context7 | serena | trivy | semgrep | figma | shadcn | playwright | chrome |
-|-------|:------:|:--------:|:------:|:-----:|:-------:|:-----:|:------:|:----------:|:------:|
-| product-requirements-manager | ✓ | ✓ | ✓ | | | | | | |
-| software-architect | ✓ | ✓ | ✓ | | | | | | |
-| platform-engineer | ✓ | ✓ | ✓ | | | | | | |
-| researcher | ✓ | ✓ | ✓ | | | | | | |
-| business-validator | ✓ | ✓ | ✓ | | | | | | |
-| frontend-engineer | ✓ | ✓ | ✓ | | | ✓ | ✓ | ✓ | ✓ |
-| backend-engineer | ✓ | ✓ | ✓ | | | | | | |
-| ai-ml-engineer | ✓ | ✓ | ✓ | | | | | | |
-| frontend-code-reviewer | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| backend-code-reviewer | ✓ | ✓ | ✓ | ✓ | ✓ | | | | |
-| quality-guardian | ✓ | ✓ | ✓ | | | | | | ✓ |
-| secure-by-design-engineer | ✓ | ✓ | ✓ | ✓ | ✓ | | | | |
-| tech-writer | ✓ | ✓ | ✓ | | | | | | |
-| release-manager | ✓ | ✓ | ✓ | ✓ | | | | | |
-| sre-agent | ✓ | ✓ | ✓ | | | | | | ✓ |
+| Agent | github | serena | trivy | semgrep | shadcn | playwright | chrome |
+|-------|:------:|:------:|:-----:|:-------:|:------:|:----------:|:------:|
+| product-requirements-manager | ✓ | ✓ | | | | | |
+| software-architect | ✓ | ✓ | | | | | |
+| platform-engineer | ✓ | ✓ | | | | | |
+| researcher | ✓ | ✓ | | | | | |
+| business-validator | ✓ | ✓ | | | | | |
+| frontend-engineer | ✓ | ✓ | | | ✓ | ✓ | ✓ |
+| backend-engineer | ✓ | ✓ | | | | | |
+| ai-ml-engineer | ✓ | ✓ | | | | | |
+| frontend-code-reviewer | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| backend-code-reviewer | ✓ | ✓ | ✓ | ✓ | | | |
+| quality-guardian | ✓ | ✓ | | | | | ✓ |
+| secure-by-design-engineer | ✓ | ✓ | ✓ | ✓ | | | |
+| tech-writer | ✓ | ✓ | | | | | |
+| release-manager | ✓ | ✓ | ✓ | | | | |
+| sre-agent | ✓ | ✓ | | | | | ✓ |
 
 ## See Also
 


### PR DESCRIPTION
## Summary
- Remove context7 and figma MCP servers due to missing/invalid API keys
- Fix Serena project root path configuration
- Update all agent configurations and documentation

## Changes
- **`.mcp.json`**: Removed context7 and figma servers, fixed Serena path from `${PROJECT_ROOT}` to actual path
- **15 agent files**: Removed `mcp__context7__*` references from all agents
- **2 agent files**: Also removed `mcp__figma__*` from frontend-engineer and frontend-code-reviewer  
- **`.claude-plugin/plugin.json`**: Updated MCP count from 9 to 7
- **`docs/reference/agent-mcp-integrations.md`**: Updated mermaid diagram, tables, and matrix
- **`docs/MCP-CONFIGURATION.md`**: Removed env vars section, troubleshooting, and renumbered

## Test plan
- [ ] Verify MCP servers still load correctly after restart
- [ ] Confirm Serena MCP connects to correct project root
- [ ] Validate remaining 7 MCP servers function as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)