### PR TITLE
feat: extend specify init to configure workflow transition validation modes

### DIFF
--- a/src/specify_cli/workflow/transition.py
+++ b/src/specify_cli/workflow/transition.py
@@ -1,0 +1,649 @@
+"""Workflow transition validation schema.
+
+This module defines the schema for workflow transitions including:
+- Input/output artifact definitions
+- Validation mode types (NONE, KEYWORD, PULL_REQUEST)
+- Transition validation logic
+
+Every workflow transition MUST define:
+1. Input artifacts - What must exist before transition
+2. Output artifacts - What is produced by the workflow
+3. Validation mode - NONE, KEYWORD["..."], or PULL_REQUEST
+
+Example:
+    >>> from specify_cli.workflow.transition import (
+    ...     TransitionSchema, ValidationMode, Artifact
+    ... )
+    >>> schema = TransitionSchema(
+    ...     name="specify",
+    ...     from_state="Assessed",
+    ...     to_state="Specified",
+    ...     input_artifacts=[Artifact(type="assessment_report", path="./docs/assess/{feature}.md")],
+    ...     output_artifacts=[Artifact(type="prd", path="./docs/prd/{feature}.md")],
+    ...     validation=ValidationMode.NONE,
+    ... )
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class ValidationMode(Enum):
+    """Validation mode for workflow transitions.
+
+    Determines how a transition is gated before proceeding.
+
+    Attributes:
+        NONE: No gate - transition proceeds automatically after artifacts created.
+        KEYWORD: User must type exact keyword to proceed (e.g., "APPROVED").
+        PULL_REQUEST: Transition blocked until PR containing artifact is merged.
+    """
+
+    NONE = "NONE"
+    KEYWORD = "KEYWORD"
+    PULL_REQUEST = "PULL_REQUEST"
+
+
+@dataclass
+class Artifact:
+    """Definition of an artifact in the workflow.
+
+    Artifacts are files or directories produced or consumed by workflow transitions.
+    Path patterns support variables: {feature}, {NNN}, {slug}.
+
+    Attributes:
+        type: Artifact type identifier (e.g., "prd", "adr", "assessment_report").
+        path: File path pattern with optional variables.
+        required: Whether this artifact must exist for transition (default: True).
+        multiple: Whether multiple files of this type are expected (default: False).
+
+    Path Pattern Variables:
+        - {feature}: Feature name slug (e.g., "user-authentication")
+        - {NNN}: Zero-padded number (e.g., "001", "002")
+        - {slug}: Title slug derived from feature name
+
+    Example:
+        >>> artifact = Artifact(
+        ...     type="adr",
+        ...     path="./docs/adr/ADR-{NNN}-{slug}.md",
+        ...     multiple=True,
+        ... )
+    """
+
+    type: str
+    path: str = ""
+    required: bool = True
+    multiple: bool = False
+
+    def __post_init__(self) -> None:
+        """Validate artifact definition."""
+        if not self.type:
+            raise ValueError("Artifact type cannot be empty")
+
+    def resolve_path(
+        self,
+        feature: str = "",
+        number: int = 1,
+        slug: str = "",
+    ) -> str:
+        """Resolve path pattern with actual values.
+
+        Args:
+            feature: Feature name for {feature} variable.
+            number: Number for {NNN} variable (zero-padded to 3 digits).
+            slug: Slug for {slug} variable (defaults to feature if not provided).
+
+        Returns:
+            Resolved path with variables substituted.
+
+        Example:
+            >>> artifact = Artifact(type="adr", path="./docs/adr/ADR-{NNN}-{slug}.md")
+            >>> artifact.resolve_path(feature="auth", number=1, slug="oauth-strategy")
+            './docs/adr/ADR-001-oauth-strategy.md'
+        """
+        if not self.path:
+            return ""
+
+        resolved = self.path
+        if feature:
+            resolved = resolved.replace("{feature}", feature)
+        if slug or feature:
+            resolved = resolved.replace("{slug}", slug or feature)
+        resolved = resolved.replace("{NNN}", f"{number:03d}")
+
+        return resolved
+
+    def matches_pattern(self, file_path: str) -> bool:
+        """Check if a file path matches this artifact's pattern.
+
+        Args:
+            file_path: Actual file path to check.
+
+        Returns:
+            True if the file path matches the pattern.
+        """
+        if not self.path:
+            return False
+
+        # Convert glob pattern to regex
+        pattern = self.path
+        pattern = pattern.replace(".", r"\.")
+        pattern = pattern.replace("*", ".*")
+        pattern = pattern.replace("{feature}", r"[\w-]+")
+        pattern = pattern.replace("{NNN}", r"\d{3}")
+        pattern = pattern.replace("{slug}", r"[\w-]+")
+        pattern = f"^{pattern}$"
+
+        return bool(re.match(pattern, file_path))
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Artifact:
+        """Create Artifact from dictionary representation.
+
+        Args:
+            data: Dictionary with artifact fields.
+
+        Returns:
+            Artifact instance.
+        """
+        return cls(
+            type=data.get("type", ""),
+            path=data.get("path", ""),
+            required=data.get("required", True),
+            multiple=data.get("multiple", False),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary representation.
+
+        Returns:
+            Dictionary with artifact fields.
+        """
+        result: dict[str, Any] = {"type": self.type}
+        if self.path:
+            result["path"] = self.path
+        if not self.required:
+            result["required"] = False
+        if self.multiple:
+            result["multiple"] = True
+        return result
+
+
+@dataclass
+class KeywordValidation:
+    """KEYWORD validation mode configuration.
+
+    Requires user to type an exact keyword to approve the transition.
+
+    Attributes:
+        keyword: The exact keyword the user must type (case-sensitive).
+
+    Example:
+        >>> validation = KeywordValidation(keyword="PRD_APPROVED")
+    """
+
+    keyword: str
+
+    def __post_init__(self) -> None:
+        """Validate keyword configuration."""
+        if not self.keyword:
+            raise ValueError("Keyword cannot be empty for KEYWORD validation mode")
+
+    def __str__(self) -> str:
+        """Return YAML-compatible string representation."""
+        return f'KEYWORD["{self.keyword}"]'
+
+
+def parse_validation_mode(value: str | None) -> tuple[ValidationMode, str | None]:
+    """Parse validation mode from string representation.
+
+    Supports the following formats:
+    - "NONE" -> (ValidationMode.NONE, None)
+    - 'KEYWORD["APPROVED"]' -> (ValidationMode.KEYWORD, "APPROVED")
+    - "PULL_REQUEST" -> (ValidationMode.PULL_REQUEST, None)
+
+    Args:
+        value: String representation of validation mode.
+
+    Returns:
+        Tuple of (ValidationMode, optional keyword string).
+
+    Raises:
+        ValueError: If the format is invalid.
+
+    Example:
+        >>> parse_validation_mode('KEYWORD["APPROVED"]')
+        (ValidationMode.KEYWORD, 'APPROVED')
+        >>> parse_validation_mode("NONE")
+        (ValidationMode.NONE, None)
+    """
+    if not value or value.upper() == "NONE":
+        return (ValidationMode.NONE, None)
+
+    if value.upper() == "PULL_REQUEST":
+        return (ValidationMode.PULL_REQUEST, None)
+
+    # Parse KEYWORD["..."] format
+    keyword_match = re.match(r'KEYWORD\["([^"]+)"\]', value, re.IGNORECASE)
+    if keyword_match:
+        return (ValidationMode.KEYWORD, keyword_match.group(1))
+
+    raise ValueError(
+        f"Invalid validation mode: '{value}'. "
+        'Expected NONE, KEYWORD["<string>"], or PULL_REQUEST'
+    )
+
+
+def format_validation_mode(mode: ValidationMode, keyword: str | None = None) -> str:
+    """Format validation mode to string representation.
+
+    Args:
+        mode: The validation mode enum value.
+        keyword: Optional keyword for KEYWORD mode.
+
+    Returns:
+        String representation for YAML.
+
+    Raises:
+        ValueError: If KEYWORD mode is used without a keyword.
+    """
+    if mode == ValidationMode.NONE:
+        return "NONE"
+    if mode == ValidationMode.PULL_REQUEST:
+        return "PULL_REQUEST"
+    if mode == ValidationMode.KEYWORD:
+        if not keyword:
+            raise ValueError("KEYWORD validation mode requires a keyword")
+        return f'KEYWORD["{keyword}"]'
+    return "NONE"
+
+
+@dataclass
+class TransitionSchema:
+    """Schema definition for a workflow transition.
+
+    Defines the complete specification for transitioning between workflow states,
+    including required input artifacts, produced output artifacts, and validation mode.
+
+    Attributes:
+        name: Unique transition name (e.g., "specify", "plan", "implement").
+        from_state: Source state for the transition.
+        to_state: Destination state for the transition.
+        via: Workflow command that triggers this transition.
+        input_artifacts: Artifacts required before transition can proceed.
+        output_artifacts: Artifacts produced by this transition.
+        validation: Validation mode (NONE, KEYWORD, PULL_REQUEST).
+        validation_keyword: Keyword for KEYWORD validation mode.
+        description: Human-readable description of the transition.
+
+    Example:
+        >>> schema = TransitionSchema(
+        ...     name="specify",
+        ...     from_state="Assessed",
+        ...     to_state="Specified",
+        ...     via="specify",
+        ...     input_artifacts=[
+        ...         Artifact(type="assessment_report", path="./docs/assess/{feature}.md"),
+        ...     ],
+        ...     output_artifacts=[
+        ...         Artifact(type="prd", path="./docs/prd/{feature}.md"),
+        ...         Artifact(type="backlog_tasks", path="./backlog/tasks/*.md"),
+        ...     ],
+        ...     validation=ValidationMode.NONE,
+        ... )
+    """
+
+    name: str
+    from_state: str | list[str]
+    to_state: str
+    via: str = ""
+    input_artifacts: list[Artifact] = field(default_factory=list)
+    output_artifacts: list[Artifact] = field(default_factory=list)
+    validation: ValidationMode = ValidationMode.NONE
+    validation_keyword: str | None = None
+    description: str = ""
+
+    def __post_init__(self) -> None:
+        """Validate transition schema."""
+        if not self.name:
+            raise ValueError("Transition name cannot be empty")
+        if not self.from_state:
+            raise ValueError("Transition from_state cannot be empty")
+        if not self.to_state:
+            raise ValueError("Transition to_state cannot be empty")
+
+        # Set via to name if not provided
+        if not self.via:
+            self.via = self.name
+
+        # Validate KEYWORD mode has keyword
+        if self.validation == ValidationMode.KEYWORD and not self.validation_keyword:
+            raise ValueError("KEYWORD validation mode requires validation_keyword")
+
+    @property
+    def from_states(self) -> list[str]:
+        """Get from_state as a list (handles both single state and list)."""
+        if isinstance(self.from_state, list):
+            return self.from_state
+        return [self.from_state]
+
+    def get_required_input_artifacts(self) -> list[Artifact]:
+        """Get only required input artifacts."""
+        return [a for a in self.input_artifacts if a.required]
+
+    def get_required_output_artifacts(self) -> list[Artifact]:
+        """Get only required output artifacts."""
+        return [a for a in self.output_artifacts if a.required]
+
+    def get_validation_string(self) -> str:
+        """Get validation mode as string representation."""
+        return format_validation_mode(self.validation, self.validation_keyword)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TransitionSchema:
+        """Create TransitionSchema from dictionary representation.
+
+        Args:
+            data: Dictionary with transition fields.
+
+        Returns:
+            TransitionSchema instance.
+        """
+        # Parse validation mode
+        validation_str = data.get("validation", "NONE")
+        validation_mode, keyword = parse_validation_mode(validation_str)
+
+        # Parse artifacts
+        input_artifacts = [
+            Artifact.from_dict(a) if isinstance(a, dict) else Artifact(type=str(a))
+            for a in data.get("input_artifacts", [])
+        ]
+        output_artifacts = [
+            Artifact.from_dict(a) if isinstance(a, dict) else Artifact(type=str(a))
+            for a in data.get("output_artifacts", [])
+        ]
+
+        return cls(
+            name=data.get("name", ""),
+            from_state=data.get("from", data.get("from_state", "")),
+            to_state=data.get("to", data.get("to_state", "")),
+            via=data.get("via", data.get("name", "")),
+            input_artifacts=input_artifacts,
+            output_artifacts=output_artifacts,
+            validation=validation_mode,
+            validation_keyword=keyword,
+            description=data.get("description", ""),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary representation for YAML serialization.
+
+        Returns:
+            Dictionary with transition fields.
+        """
+        result: dict[str, Any] = {
+            "name": self.name,
+            "from": self.from_state,
+            "to": self.to_state,
+            "via": self.via,
+        }
+
+        if self.input_artifacts:
+            result["input_artifacts"] = [a.to_dict() for a in self.input_artifacts]
+
+        if self.output_artifacts:
+            result["output_artifacts"] = [a.to_dict() for a in self.output_artifacts]
+
+        result["validation"] = self.get_validation_string()
+
+        if self.description:
+            result["description"] = self.description
+
+        return result
+
+
+# Standard workflow transitions with artifact definitions
+WORKFLOW_TRANSITIONS: list[TransitionSchema] = [
+    # Entry transition: assess
+    TransitionSchema(
+        name="assess",
+        from_state="To Do",
+        to_state="Assessed",
+        via="assess",
+        input_artifacts=[],  # Entry point - no inputs required
+        output_artifacts=[
+            Artifact(
+                type="assessment_report",
+                path="./docs/assess/{feature}-assessment.md",
+            ),
+        ],
+        validation=ValidationMode.NONE,
+        description="Evaluate SDD workflow suitability (Full/Light/Skip)",
+    ),
+    # Specify transition
+    TransitionSchema(
+        name="specify",
+        from_state="Assessed",
+        to_state="Specified",
+        via="specify",
+        input_artifacts=[
+            Artifact(
+                type="assessment_report",
+                path="./docs/assess/{feature}-assessment.md",
+                required=True,
+            ),
+        ],
+        output_artifacts=[
+            Artifact(
+                type="prd",
+                path="./docs/prd/{feature}.md",
+                required=True,
+            ),
+            Artifact(
+                type="backlog_tasks",
+                path="./backlog/tasks/*.md",
+                required=True,
+                multiple=True,
+            ),
+        ],
+        validation=ValidationMode.NONE,
+        description="Create PRD with user stories and acceptance criteria",
+    ),
+    # Research transition (optional)
+    TransitionSchema(
+        name="research",
+        from_state="Specified",
+        to_state="Researched",
+        via="research",
+        input_artifacts=[
+            Artifact(
+                type="prd",
+                path="./docs/prd/{feature}.md",
+                required=True,
+            ),
+        ],
+        output_artifacts=[
+            Artifact(
+                type="research_report",
+                path="./docs/research/{feature}-research.md",
+            ),
+            Artifact(
+                type="business_validation",
+                path="./docs/research/{feature}-validation.md",
+            ),
+        ],
+        validation=ValidationMode.NONE,
+        description="Technical and business research completed",
+    ),
+    # Plan transition (can come from Specified or Researched)
+    TransitionSchema(
+        name="plan",
+        from_state=["Specified", "Researched"],
+        to_state="Planned",
+        via="plan",
+        input_artifacts=[
+            Artifact(
+                type="prd",
+                path="./docs/prd/{feature}.md",
+                required=True,
+            ),
+        ],
+        output_artifacts=[
+            Artifact(
+                type="adr",
+                path="./docs/adr/ADR-{NNN}-{slug}.md",
+                required=True,
+                multiple=True,
+            ),
+            Artifact(
+                type="platform_design",
+                path="./docs/platform/{feature}-platform.md",
+                required=False,
+            ),
+        ],
+        validation=ValidationMode.NONE,
+        description="Architecture planned with ADRs",
+    ),
+    # Implement transition
+    TransitionSchema(
+        name="implement",
+        from_state="Planned",
+        to_state="In Implementation",
+        via="implement",
+        input_artifacts=[
+            Artifact(
+                type="adr",
+                path="./docs/adr/ADR-*.md",
+                required=True,
+            ),
+        ],
+        output_artifacts=[
+            Artifact(
+                type="source_code",
+                path="./src/",
+            ),
+            Artifact(
+                type="tests",
+                path="./tests/",
+                required=True,
+            ),
+            Artifact(
+                type="ac_coverage",
+                path="./tests/ac-coverage.json",
+                required=True,
+            ),
+        ],
+        validation=ValidationMode.NONE,
+        description="Implementation work with tests and AC coverage",
+    ),
+    # Validate transition
+    TransitionSchema(
+        name="validate",
+        from_state="In Implementation",
+        to_state="Validated",
+        via="validate",
+        input_artifacts=[
+            Artifact(type="tests", required=True),
+            Artifact(type="ac_coverage", required=True),
+        ],
+        output_artifacts=[
+            Artifact(
+                type="qa_report",
+                path="./docs/qa/{feature}-qa-report.md",
+            ),
+            Artifact(
+                type="security_report",
+                path="./docs/security/{feature}-security.md",
+            ),
+        ],
+        validation=ValidationMode.NONE,
+        description="QA, security, and documentation validated",
+    ),
+    # Operate transition
+    TransitionSchema(
+        name="operate",
+        from_state="Validated",
+        to_state="Deployed",
+        via="operate",
+        input_artifacts=[
+            Artifact(type="qa_report"),
+            Artifact(type="security_report"),
+        ],
+        output_artifacts=[
+            Artifact(
+                type="deployment_manifest",
+                path="./deploy/",
+            ),
+        ],
+        validation=ValidationMode.NONE,
+        description="Deployed to production",
+    ),
+    # Complete transition (manual)
+    TransitionSchema(
+        name="complete",
+        from_state="Deployed",
+        to_state="Done",
+        via="manual",
+        input_artifacts=[],
+        output_artifacts=[],
+        validation=ValidationMode.NONE,
+        description="Production deployment confirmed successful",
+    ),
+]
+
+
+def get_transition_by_name(name: str) -> TransitionSchema | None:
+    """Get a standard workflow transition by name.
+
+    Args:
+        name: Transition name (e.g., "specify", "plan").
+
+    Returns:
+        TransitionSchema if found, None otherwise.
+    """
+    for transition in WORKFLOW_TRANSITIONS:
+        if transition.name == name:
+            return transition
+    return None
+
+
+def get_transitions_from_state(state: str) -> list[TransitionSchema]:
+    """Get all transitions that can proceed from a given state.
+
+    Args:
+        state: Source state name.
+
+    Returns:
+        List of transitions available from this state.
+    """
+    return [t for t in WORKFLOW_TRANSITIONS if state in t.from_states]
+
+
+def validate_transition_schema(schema: TransitionSchema) -> list[str]:
+    """Validate a transition schema for completeness.
+
+    Args:
+        schema: TransitionSchema to validate.
+
+    Returns:
+        List of validation error messages (empty if valid).
+    """
+    errors: list[str] = []
+
+    # Check required fields
+    if not schema.name:
+        errors.append("Transition name is required")
+    if not schema.from_state:
+        errors.append("Transition from_state is required")
+    if not schema.to_state:
+        errors.append("Transition to_state is required")
+
+    # Check KEYWORD validation has keyword
+    if schema.validation == ValidationMode.KEYWORD and not schema.validation_keyword:
+        errors.append("KEYWORD validation mode requires a keyword")
+
+    return errors

--- a/src/specify_cli/workflow/validation_config.py
+++ b/src/specify_cli/workflow/validation_config.py
@@ -1,0 +1,299 @@
+"""Workflow transition validation configuration.
+
+This module provides interactive configuration for workflow transition validation modes.
+Used by 'specify init' to configure validation gates for each workflow transition.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from rich.console import Console
+from rich.panel import Panel
+from rich.prompt import Prompt
+
+from specify_cli.workflow.transition import (
+    WORKFLOW_TRANSITIONS,
+    ValidationMode,
+    format_validation_mode,
+)
+
+console = Console()
+
+
+def prompt_validation_mode(
+    transition_name: str, transition_description: str
+) -> tuple[ValidationMode, str | None]:
+    """Prompt user to select validation mode for a transition.
+
+    Args:
+        transition_name: Name of the transition (e.g., "assess", "specify").
+        transition_description: Human-readable description of the transition.
+
+    Returns:
+        Tuple of (ValidationMode, optional keyword string).
+
+    Example:
+        >>> mode, keyword = prompt_validation_mode("specify", "Create PRD")
+        >>> # User selects KEYWORD and enters "PRD_APPROVED"
+        >>> mode == ValidationMode.KEYWORD
+        True
+        >>> keyword
+        'PRD_APPROVED'
+    """
+    console.print(f"\n[cyan]{transition_name}:[/cyan] {transition_description}")
+    console.print("[dim]How should this transition be validated?[/dim]")
+    console.print("  [1] NONE (default) - Proceed automatically")
+    console.print("  [2] KEYWORD - Require typed keyword to proceed")
+    console.print("  [3] PULL_REQUEST - Require merged PR to proceed")
+
+    choice = Prompt.ask(
+        "Select validation mode",
+        choices=["1", "2", "3", ""],
+        default="1",
+        show_default=False,
+    )
+
+    if choice == "2":
+        console.print(
+            "[dim]Enter the keyword users must type to approve this transition:[/dim]"
+        )
+        keyword = Prompt.ask(
+            "Keyword",
+            default=f"{transition_name.upper()}_APPROVED",
+        )
+        return (ValidationMode.KEYWORD, keyword)
+    elif choice == "3":
+        return (ValidationMode.PULL_REQUEST, None)
+    else:
+        # Default or explicit choice "1"
+        return (ValidationMode.NONE, None)
+
+
+def prompt_all_transitions(
+    batch_mode: str | None = None, batch_keyword: str | None = None
+) -> dict[str, tuple[ValidationMode, str | None]]:
+    """Prompt for validation modes for all workflow transitions.
+
+    Args:
+        batch_mode: Optional batch mode (none, keyword, pull-request) to skip prompts.
+        batch_keyword: Optional keyword to use for all KEYWORD validations in batch mode.
+
+    Returns:
+        Dictionary mapping transition names to (ValidationMode, keyword) tuples.
+
+    Example:
+        >>> configs = prompt_all_transitions()
+        >>> # User interactively selects modes for each transition
+        >>> configs["specify"]
+        (ValidationMode.KEYWORD, 'PRD_APPROVED')
+    """
+    if batch_mode:
+        # Batch mode: apply same validation to all transitions
+        if batch_mode == "keyword":
+            default_keyword = batch_keyword or "APPROVED"
+            return {
+                t.name: (ValidationMode.KEYWORD, default_keyword)
+                for t in WORKFLOW_TRANSITIONS
+            }
+        elif batch_mode == "pull-request":
+            return {
+                t.name: (ValidationMode.PULL_REQUEST, None)
+                for t in WORKFLOW_TRANSITIONS
+            }
+        else:  # none
+            return {t.name: (ValidationMode.NONE, None) for t in WORKFLOW_TRANSITIONS}
+
+    # Interactive mode
+    console.print(
+        Panel(
+            "[cyan]Workflow Transition Validation Configuration[/cyan]\n\n"
+            "Configure validation gates for each workflow transition.\n"
+            "Press Enter to accept default (NONE).",
+            border_style="cyan",
+            padding=(1, 2),
+        )
+    )
+
+    configs: dict[str, tuple[ValidationMode, str | None]] = {}
+    for transition in WORKFLOW_TRANSITIONS:
+        mode, keyword = prompt_validation_mode(
+            transition.name,
+            transition.description or f"Transition to {transition.to_state}",
+        )
+        configs[transition.name] = (mode, keyword)
+
+    return configs
+
+
+def generate_workflow_yaml(
+    configs: dict[str, tuple[ValidationMode, str | None]], output_path: Path
+) -> None:
+    """Generate jpspec_workflow.yml with configured validation modes.
+
+    Args:
+        configs: Dictionary mapping transition names to (ValidationMode, keyword) tuples.
+        output_path: Path where jpspec_workflow.yml should be written.
+
+    Example:
+        >>> configs = {
+        ...     "specify": (ValidationMode.KEYWORD, "PRD_APPROVED"),
+        ...     "plan": (ValidationMode.NONE, None),
+        ... }
+        >>> generate_workflow_yaml(configs, Path("./jpspec_workflow.yml"))
+    """
+    # Build workflow data structure
+    workflow_data: dict[str, Any] = {
+        "version": "1.0",
+        "workflow": {"name": "jpspec", "description": "JP Spec Kit Workflow"},
+        "transitions": [],
+    }
+
+    for transition in WORKFLOW_TRANSITIONS:
+        mode, keyword = configs.get(transition.name, (ValidationMode.NONE, None))
+
+        # Update transition with configured validation
+        transition.validation = mode
+        transition.validation_keyword = keyword
+
+        # Convert to dict for YAML
+        workflow_data["transitions"].append(transition.to_dict())
+
+    # Write YAML file
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as f:
+        yaml.dump(
+            workflow_data,
+            f,
+            default_flow_style=False,
+            sort_keys=False,
+            allow_unicode=True,
+        )
+
+    console.print(
+        f"\n[green]Workflow configuration saved to:[/green] {output_path.relative_to(Path.cwd()) if output_path.is_relative_to(Path.cwd()) else output_path}"
+    )
+
+
+def display_validation_summary(
+    configs: dict[str, tuple[ValidationMode, str | None]],
+) -> None:
+    """Display summary of configured validation modes.
+
+    Args:
+        configs: Dictionary mapping transition names to (ValidationMode, keyword) tuples.
+
+    Example:
+        >>> configs = {
+        ...     "specify": (ValidationMode.KEYWORD, "PRD_APPROVED"),
+        ...     "plan": (ValidationMode.NONE, None),
+        ... }
+        >>> display_validation_summary(configs)
+    """
+    lines = ["[cyan]Validation Mode Summary:[/cyan]", ""]
+
+    for transition in WORKFLOW_TRANSITIONS:
+        mode, keyword = configs.get(transition.name, (ValidationMode.NONE, None))
+        mode_str = format_validation_mode(mode, keyword)
+
+        # Format display
+        if mode == ValidationMode.KEYWORD:
+            display = f"[yellow]{mode_str}[/yellow]"
+        elif mode == ValidationMode.PULL_REQUEST:
+            display = f"[magenta]{mode_str}[/magenta]"
+        else:
+            display = f"[dim]{mode_str}[/dim]"
+
+        lines.append(f"  {transition.name:<15} → {display}")
+
+    console.print(
+        Panel(
+            "\n".join(lines),
+            title="[cyan]Configured Validation Modes[/cyan]",
+            border_style="cyan",
+            padding=(1, 2),
+        )
+    )
+
+
+def configure_validation_modes(
+    project_path: Path,
+    batch_mode: str | None = None,
+    batch_keyword: str | None = None,
+    no_prompts: bool = False,
+) -> None:
+    """Configure validation modes for workflow transitions.
+
+    Main entry point for validation configuration, called by 'specify init'.
+
+    Args:
+        project_path: Path to the project directory.
+        batch_mode: Optional batch mode (none, keyword, pull-request).
+        batch_keyword: Optional keyword for batch KEYWORD mode.
+        no_prompts: If True, use NONE for all transitions (skip prompts).
+
+    Example:
+        >>> configure_validation_modes(Path("./my-project"))
+        # Interactive prompts for each transition
+        >>> configure_validation_modes(
+        ...     Path("./my-project"),
+        ...     batch_mode="keyword",
+        ...     batch_keyword="APPROVED"
+        ... )
+        # All transitions use KEYWORD["APPROVED"]
+    """
+    if no_prompts:
+        # Skip all prompts, use NONE
+        configs = {t.name: (ValidationMode.NONE, None) for t in WORKFLOW_TRANSITIONS}
+    elif batch_mode:
+        # Batch mode
+        configs = prompt_all_transitions(
+            batch_mode=batch_mode, batch_keyword=batch_keyword
+        )
+    else:
+        # Interactive mode
+        configs = prompt_all_transitions()
+
+    # Generate workflow YAML
+    workflow_path = project_path / "jpspec_workflow.yml"
+    generate_workflow_yaml(configs, workflow_path)
+
+    # Display summary
+    if not no_prompts:
+        display_validation_summary(configs)
+
+
+# CLI command for reconfiguration
+def reconfigure_validation_modes(
+    batch_mode: str | None = None,
+    batch_keyword: str | None = None,
+) -> None:
+    """Reconfigure validation modes for existing project.
+
+    Used by 'specify config validation' command.
+
+    Args:
+        batch_mode: Optional batch mode (none, keyword, pull-request).
+        batch_keyword: Optional keyword for batch KEYWORD mode.
+
+    Example:
+        >>> reconfigure_validation_modes()
+        # Interactive prompts
+        >>> reconfigure_validation_modes(batch_mode="none")
+        # Set all to NONE
+    """
+    project_path = Path.cwd()
+    workflow_path = project_path / "jpspec_workflow.yml"
+
+    if not workflow_path.exists():
+        console.print(
+            f"[yellow]Warning:[/yellow] {workflow_path} not found. Creating new configuration."
+        )
+
+    configure_validation_modes(
+        project_path, batch_mode=batch_mode, batch_keyword=batch_keyword
+    )
+
+    console.print("[green]Validation configuration updated successfully![/green]")

--- a/tests/test_validation_config.py
+++ b/tests/test_validation_config.py
@@ -1,0 +1,345 @@
+"""Tests for workflow validation configuration module."""
+
+from unittest.mock import patch
+
+import yaml
+
+from specify_cli.workflow.transition import ValidationMode
+from specify_cli.workflow.validation_config import (
+    configure_validation_modes,
+    display_validation_summary,
+    generate_workflow_yaml,
+    prompt_all_transitions,
+    prompt_validation_mode,
+)
+
+
+class TestPromptValidationMode:
+    """Test interactive validation mode prompts."""
+
+    @patch("specify_cli.workflow.validation_config.Prompt.ask")
+    def test_prompt_none_default(self, mock_ask):
+        """Test selecting NONE (default) validation mode."""
+        # Simulate pressing Enter (empty input, uses default)
+        mock_ask.return_value = ""
+
+        mode, keyword = prompt_validation_mode("specify", "Create PRD")
+
+        assert mode == ValidationMode.NONE
+        assert keyword is None
+
+    @patch("specify_cli.workflow.validation_config.Prompt.ask")
+    def test_prompt_none_explicit(self, mock_ask):
+        """Test explicitly selecting NONE validation mode."""
+        mock_ask.return_value = "1"
+
+        mode, keyword = prompt_validation_mode("specify", "Create PRD")
+
+        assert mode == ValidationMode.NONE
+        assert keyword is None
+
+    @patch("specify_cli.workflow.validation_config.Prompt.ask")
+    def test_prompt_keyword_with_custom_keyword(self, mock_ask):
+        """Test selecting KEYWORD mode with custom keyword."""
+        # First call returns "2" for KEYWORD, second returns the keyword
+        mock_ask.side_effect = ["2", "PRD_REVIEWED"]
+
+        mode, keyword = prompt_validation_mode("specify", "Create PRD")
+
+        assert mode == ValidationMode.KEYWORD
+        assert keyword == "PRD_REVIEWED"
+
+    @patch("specify_cli.workflow.validation_config.Prompt.ask")
+    def test_prompt_keyword_with_default_keyword(self, mock_ask):
+        """Test selecting KEYWORD mode with default keyword."""
+        # First call returns "2" for KEYWORD, second uses default
+        mock_ask.side_effect = ["2", "SPECIFY_APPROVED"]
+
+        mode, keyword = prompt_validation_mode("specify", "Create PRD")
+
+        assert mode == ValidationMode.KEYWORD
+        assert keyword == "SPECIFY_APPROVED"
+
+    @patch("specify_cli.workflow.validation_config.Prompt.ask")
+    def test_prompt_pull_request(self, mock_ask):
+        """Test selecting PULL_REQUEST validation mode."""
+        mock_ask.return_value = "3"
+
+        mode, keyword = prompt_validation_mode("plan", "Create architecture")
+
+        assert mode == ValidationMode.PULL_REQUEST
+        assert keyword is None
+
+
+class TestPromptAllTransitions:
+    """Test prompting for all workflow transitions."""
+
+    def test_batch_mode_none(self):
+        """Test batch mode with NONE for all transitions."""
+        configs = prompt_all_transitions(batch_mode="none")
+
+        assert len(configs) > 0
+        for transition_name, (mode, keyword) in configs.items():
+            assert mode == ValidationMode.NONE
+            assert keyword is None
+
+    def test_batch_mode_keyword_default(self):
+        """Test batch mode with KEYWORD using default keyword."""
+        configs = prompt_all_transitions(batch_mode="keyword")
+
+        assert len(configs) > 0
+        for transition_name, (mode, keyword) in configs.items():
+            assert mode == ValidationMode.KEYWORD
+            assert keyword == "APPROVED"
+
+    def test_batch_mode_keyword_custom(self):
+        """Test batch mode with KEYWORD using custom keyword."""
+        configs = prompt_all_transitions(
+            batch_mode="keyword", batch_keyword="TEAM_APPROVED"
+        )
+
+        assert len(configs) > 0
+        for transition_name, (mode, keyword) in configs.items():
+            assert mode == ValidationMode.KEYWORD
+            assert keyword == "TEAM_APPROVED"
+
+    def test_batch_mode_pull_request(self):
+        """Test batch mode with PULL_REQUEST for all transitions."""
+        configs = prompt_all_transitions(batch_mode="pull-request")
+
+        assert len(configs) > 0
+        for transition_name, (mode, keyword) in configs.items():
+            assert mode == ValidationMode.PULL_REQUEST
+            assert keyword is None
+
+
+class TestGenerateWorkflowYaml:
+    """Test YAML workflow file generation."""
+
+    def test_generate_yaml_with_mixed_modes(self, tmp_path):
+        """Test generating YAML with mixed validation modes."""
+        configs = {
+            "assess": (ValidationMode.NONE, None),
+            "specify": (ValidationMode.KEYWORD, "PRD_APPROVED"),
+            "plan": (ValidationMode.PULL_REQUEST, None),
+        }
+
+        output_path = tmp_path / "jpspec_workflow.yml"
+        generate_workflow_yaml(configs, output_path)
+
+        # Verify file was created
+        assert output_path.exists()
+
+        # Load and verify YAML structure
+        with open(output_path) as f:
+            data = yaml.safe_load(f)
+
+        assert data["version"] == "1.0"
+        assert "workflow" in data
+        assert data["workflow"]["name"] == "jpspec"
+        assert "transitions" in data
+        assert len(data["transitions"]) > 0
+
+        # Verify specific transitions
+        transitions_by_name = {t["name"]: t for t in data["transitions"]}
+
+        # Check assess (NONE)
+        if "assess" in transitions_by_name:
+            assert transitions_by_name["assess"]["validation"] == "NONE"
+
+        # Check specify (KEYWORD)
+        if "specify" in transitions_by_name:
+            assert (
+                transitions_by_name["specify"]["validation"]
+                == 'KEYWORD["PRD_APPROVED"]'
+            )
+
+        # Check plan (PULL_REQUEST)
+        if "plan" in transitions_by_name:
+            assert transitions_by_name["plan"]["validation"] == "PULL_REQUEST"
+
+    def test_generate_yaml_all_none(self, tmp_path):
+        """Test generating YAML with all NONE validation."""
+        configs = {
+            "assess": (ValidationMode.NONE, None),
+            "specify": (ValidationMode.NONE, None),
+            "plan": (ValidationMode.NONE, None),
+        }
+
+        output_path = tmp_path / "jpspec_workflow.yml"
+        generate_workflow_yaml(configs, output_path)
+
+        assert output_path.exists()
+
+        with open(output_path) as f:
+            data = yaml.safe_load(f)
+
+        for transition in data["transitions"]:
+            assert transition["validation"] == "NONE"
+
+
+class TestDisplayValidationSummary:
+    """Test validation summary display."""
+
+    @patch("specify_cli.workflow.validation_config.console")
+    def test_display_summary_mixed_modes(self, mock_console):
+        """Test displaying summary with mixed validation modes."""
+        configs = {
+            "assess": (ValidationMode.NONE, None),
+            "specify": (ValidationMode.KEYWORD, "PRD_APPROVED"),
+            "plan": (ValidationMode.PULL_REQUEST, None),
+        }
+
+        display_validation_summary(configs)
+
+        # Verify console.print was called
+        assert mock_console.print.called
+
+
+class TestConfigureValidationModes:
+    """Test main configuration function."""
+
+    def test_configure_with_no_prompts(self, tmp_path):
+        """Test configuration with --no-validation-prompts flag."""
+        configure_validation_modes(tmp_path, no_prompts=True)
+
+        workflow_path = tmp_path / "jpspec_workflow.yml"
+        assert workflow_path.exists()
+
+        with open(workflow_path) as f:
+            data = yaml.safe_load(f)
+
+        # All transitions should be NONE
+        for transition in data["transitions"]:
+            assert transition["validation"] == "NONE"
+
+    def test_configure_batch_mode_keyword(self, tmp_path):
+        """Test configuration with batch mode keyword."""
+        configure_validation_modes(tmp_path, batch_mode="keyword")
+
+        workflow_path = tmp_path / "jpspec_workflow.yml"
+        assert workflow_path.exists()
+
+        with open(workflow_path) as f:
+            data = yaml.safe_load(f)
+
+        # All transitions should be KEYWORD
+        for transition in data["transitions"]:
+            assert transition["validation"].startswith("KEYWORD")
+
+    def test_configure_batch_mode_pull_request(self, tmp_path):
+        """Test configuration with batch mode pull-request."""
+        configure_validation_modes(tmp_path, batch_mode="pull-request")
+
+        workflow_path = tmp_path / "jpspec_workflow.yml"
+        assert workflow_path.exists()
+
+        with open(workflow_path) as f:
+            data = yaml.safe_load(f)
+
+        # All transitions should be PULL_REQUEST
+        for transition in data["transitions"]:
+            assert transition["validation"] == "PULL_REQUEST"
+
+    def test_configure_batch_mode_none(self, tmp_path):
+        """Test configuration with batch mode none."""
+        configure_validation_modes(tmp_path, batch_mode="none")
+
+        workflow_path = tmp_path / "jpspec_workflow.yml"
+        assert workflow_path.exists()
+
+        with open(workflow_path) as f:
+            data = yaml.safe_load(f)
+
+        # All transitions should be NONE
+        for transition in data["transitions"]:
+            assert transition["validation"] == "NONE"
+
+    def test_workflow_yaml_structure(self, tmp_path):
+        """Test that generated YAML has correct structure."""
+        configure_validation_modes(tmp_path, batch_mode="none")
+
+        workflow_path = tmp_path / "jpspec_workflow.yml"
+        with open(workflow_path) as f:
+            data = yaml.safe_load(f)
+
+        # Verify required top-level keys
+        assert "version" in data
+        assert "workflow" in data
+        assert "transitions" in data
+
+        # Verify workflow section
+        assert "name" in data["workflow"]
+        assert "description" in data["workflow"]
+
+        # Verify transitions structure
+        assert isinstance(data["transitions"], list)
+        assert len(data["transitions"]) > 0
+
+        # Verify each transition has required fields
+        for transition in data["transitions"]:
+            assert "name" in transition
+            assert "from" in transition
+            assert "to" in transition
+            assert "via" in transition
+            assert "validation" in transition
+
+
+class TestIntegrationScenarios:
+    """Integration tests for real-world scenarios."""
+
+    def test_init_flow_no_prompts(self, tmp_path):
+        """Test typical init flow with --no-validation-prompts."""
+        project_path = tmp_path / "test-project"
+        project_path.mkdir()
+
+        configure_validation_modes(project_path, no_prompts=True)
+
+        workflow_path = project_path / "jpspec_workflow.yml"
+        assert workflow_path.exists()
+
+        # Verify it's valid YAML
+        with open(workflow_path) as f:
+            data = yaml.safe_load(f)
+            assert data is not None
+
+    def test_init_flow_batch_keyword(self, tmp_path):
+        """Test init flow with --validation-mode keyword."""
+        project_path = tmp_path / "test-project"
+        project_path.mkdir()
+
+        configure_validation_modes(
+            project_path, batch_mode="keyword", batch_keyword="APPROVED"
+        )
+
+        workflow_path = project_path / "jpspec_workflow.yml"
+        assert workflow_path.exists()
+
+        with open(workflow_path) as f:
+            data = yaml.safe_load(f)
+
+        # Spot check a transition
+        transitions_by_name = {t["name"]: t for t in data["transitions"]}
+        if "specify" in transitions_by_name:
+            assert transitions_by_name["specify"]["validation"] == 'KEYWORD["APPROVED"]'
+
+    def test_reconfigure_existing_project(self, tmp_path):
+        """Test reconfiguring an existing project."""
+        project_path = tmp_path / "existing-project"
+        project_path.mkdir()
+
+        # Initial configuration
+        configure_validation_modes(project_path, batch_mode="none")
+
+        # Reconfigure with different mode
+        configure_validation_modes(project_path, batch_mode="keyword")
+
+        workflow_path = project_path / "jpspec_workflow.yml"
+        assert workflow_path.exists()
+
+        with open(workflow_path) as f:
+            data = yaml.safe_load(f)
+
+        # Should now have KEYWORD validation
+        for transition in data["transitions"]:
+            assert transition["validation"].startswith("KEYWORD")


### PR DESCRIPTION
## Summary

Extends `specify init` command to configure validation modes for workflow transitions, enabling users to set validation gates (NONE, KEYWORD, PULL_REQUEST) during project initialization or reconfigure them later.

This implementation provides:
- **Interactive configuration**: Prompts for validation mode per transition
- **Batch configuration**: CLI flags for non-interactive setup
- **Reconfiguration**: `specify config validation` command
- **YAML generation**: Creates `jpspec_workflow.yml` with configured modes

## Implementation Details

### New Modules
1. **`src/specify_cli/workflow/transition.py`** (649 lines)
   - Workflow transition schema with ValidationMode enum
   - Artifact definitions for input/output
   - Standard workflow transitions (assess → specify → plan → implement → validate → operate → complete)
   - Validation mode parsing and formatting

2. **`src/specify_cli/workflow/validation_config.py`** (299 lines)
   - Interactive validation mode prompts
   - Batch mode configuration
   - YAML workflow file generation
   - Configuration summary display

### CLI Enhancements
1. **`specify init` command**:
   - Added `--validation-mode {none|keyword|pull-request}` flag for batch configuration
   - Added `--no-validation-prompts` flag to skip prompts (default to NONE)
   - Integrated validation configuration step after project initialization

2. **`specify config validation` command** (new):
   - Reconfigure validation modes for existing projects
   - Supports same flags as `specify init`

### Test Coverage
- **20 passing tests** covering:
  - Interactive prompt flows (NONE, KEYWORD, PULL_REQUEST)
  - Batch mode configurations
  - YAML generation with mixed modes
  - Integration scenarios
  - Reconfiguration workflows

## Usage Examples

### Interactive Mode (default)
```bash
specify init my-project
# ... after AI agent selection ...
# Interactive prompts for each transition:
# "assess: [1] NONE (default) [2] KEYWORD [3] PULL_REQUEST"
```

### Batch Mode - All NONE
```bash
specify init my-project --no-validation-prompts
```

### Batch Mode - All KEYWORD
```bash
specify init my-project --validation-mode keyword
# All transitions use KEYWORD["APPROVED"]
```

### Batch Mode - All PULL_REQUEST
```bash
specify init my-project --validation-mode pull-request
```

### Reconfiguration
```bash
cd my-project
specify config validation                    # Interactive
specify config validation --validation-mode none
```

## Test Results

```
============================= test session starts ==============================
tests/test_validation_config.py::TestPromptValidationMode::test_prompt_none_default PASSED
tests/test_validation_config.py::TestPromptValidationMode::test_prompt_none_explicit PASSED
tests/test_validation_config.py::TestPromptValidationMode::test_prompt_keyword_with_custom_keyword PASSED
tests/test_validation_config.py::TestPromptValidationMode::test_prompt_keyword_with_default_keyword PASSED
tests/test_validation_config.py::TestPromptValidationMode::test_prompt_pull_request PASSED
tests/test_validation_config.py::TestPromptAllTransitions::test_batch_mode_none PASSED
tests/test_validation_config.py::TestPromptAllTransitions::test_batch_mode_keyword_default PASSED
tests/test_validation_config.py::TestPromptAllTransitions::test_batch_mode_keyword_custom PASSED
tests/test_validation_config.py::TestPromptAllTransitions::test_batch_mode_pull_request PASSED
tests/test_validation_config.py::TestGenerateWorkflowYaml::test_generate_yaml_with_mixed_modes PASSED
tests/test_validation_config.py::TestGenerateWorkflowYaml::test_generate_yaml_all_none PASSED
tests/test_validation_config.py::TestDisplayValidationSummary::test_display_summary_mixed_modes PASSED
tests/test_validation_config.py::TestConfigureValidationModes::test_configure_with_no_prompts PASSED
tests/test_validation_config.py::TestConfigureValidationModes::test_configure_batch_mode_keyword PASSED
tests/test_validation_config.py::TestConfigureValidationModes::test_configure_batch_mode_pull_request PASSED
tests/test_validation_config.py::TestConfigureValidationModes::test_configure_batch_mode_none PASSED
tests/test_validation_config.py::TestConfigureValidationModes::test_workflow_yaml_structure PASSED
tests/test_validation_config.py::TestIntegrationScenarios::test_init_flow_no_prompts PASSED
tests/test_validation_config.py::TestIntegrationScenarios::test_init_flow_batch_keyword PASSED
tests/test_validation_config.py::TestIntegrationScenarios::test_reconfigure_existing_project PASSED

============================== 20 passed in 0.17s
```

## Acceptance Criteria

All acceptance criteria from task-182 are met:

- ✅ **AC1**: Add validation mode prompts to specify init command
- ✅ **AC2**: Support NONE selection (default, press Enter)
- ✅ **AC3**: Support KEYWORD selection with custom keyword input
- ✅ **AC4**: Support PULL_REQUEST selection
- ✅ **AC5**: Generate jpspec_workflow.yml with configured validation modes
- ✅ **AC6**: Add `--validation-mode {none|keyword|pull-request}` flag for batch config
- ✅ **AC7**: Add `--no-validation-prompts` flag to skip questions (use NONE)
- ✅ **AC8**: Display summary of configured validation modes at end
- ✅ **AC9**: Support reconfiguration via `specify config validation`

## Files Changed

- **Modified**: `src/specify_cli/__init__.py` (+75 lines)
  - Added validation mode flags to `init` command
  - Integrated validation configuration step
  - Added `config` command with `validation` subcommand

- **Added**: `src/specify_cli/workflow/transition.py` (+649 lines)
  - Workflow transition schema
  - ValidationMode enum and parsing

- **Added**: `src/specify_cli/workflow/validation_config.py` (+299 lines)
  - Interactive and batch configuration
  - YAML generation
  - Reconfiguration support

- **Added**: `tests/test_validation_config.py` (+345 lines)
  - 20 comprehensive tests

**Total**: 4 files changed, 1,368 insertions(+)

## Foundation

This PR builds on the workflow transition schema from task-172, copying `transition.py` as the foundation for validation configuration.

## Related

- Implements task-182
- Foundation: task-172 (workflow transition schema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)