### PR TITLE
feat(workflow): add transition validation schema with artifact definitions

### DIFF
--- a/docs/reference/artifact-path-patterns.md
+++ b/docs/reference/artifact-path-patterns.md
@@ -1,0 +1,116 @@
+# Artifact Path Patterns Reference
+
+This document describes the path pattern variables used in workflow artifact definitions.
+
+## Overview
+
+Workflow transitions define input and output artifacts using path patterns. These patterns support variable substitution to enable dynamic file paths based on the feature being developed.
+
+## Path Pattern Variables
+
+| Variable | Description | Example Value |
+|----------|-------------|---------------|
+| `{feature}` | Feature name slug (lowercase, hyphenated) | `user-authentication` |
+| `{NNN}` | Zero-padded 3-digit number | `001`, `002`, `042` |
+| `{slug}` | Title slug (defaults to feature if not provided) | `oauth-strategy` |
+
+## Standard Artifact Locations
+
+### Assessment Artifacts
+| Artifact Type | Path Pattern | Example |
+|--------------|--------------|---------|
+| Assessment Report | `./docs/assess/{feature}-assessment.md` | `./docs/assess/user-auth-assessment.md` |
+
+### Specification Artifacts
+| Artifact Type | Path Pattern | Example |
+|--------------|--------------|---------|
+| PRD | `./docs/prd/{feature}.md` | `./docs/prd/user-auth.md` |
+| Backlog Tasks | `./backlog/tasks/*.md` | `./backlog/tasks/task-123-*.md` |
+
+### Research Artifacts
+| Artifact Type | Path Pattern | Example |
+|--------------|--------------|---------|
+| Research Report | `./docs/research/{feature}-research.md` | `./docs/research/user-auth-research.md` |
+| Business Validation | `./docs/research/{feature}-validation.md` | `./docs/research/user-auth-validation.md` |
+
+### Architecture Artifacts
+| Artifact Type | Path Pattern | Example |
+|--------------|--------------|---------|
+| ADR | `./docs/adr/ADR-{NNN}-{slug}.md` | `./docs/adr/ADR-001-oauth-strategy.md` |
+| Platform Design | `./docs/platform/{feature}-platform.md` | `./docs/platform/user-auth-platform.md` |
+
+### Implementation Artifacts
+| Artifact Type | Path Pattern | Example |
+|--------------|--------------|---------|
+| Source Code | `./src/` | Project-specific |
+| Tests | `./tests/` | Project-specific |
+| AC Coverage | `./tests/ac-coverage.json` | Fixed location |
+
+### Validation Artifacts
+| Artifact Type | Path Pattern | Example |
+|--------------|--------------|---------|
+| QA Report | `./docs/qa/{feature}-qa-report.md` | `./docs/qa/user-auth-qa-report.md` |
+| Security Report | `./docs/security/{feature}-security.md` | `./docs/security/user-auth-security.md` |
+
+### Deployment Artifacts
+| Artifact Type | Path Pattern | Example |
+|--------------|--------------|---------|
+| Deployment Manifest | `./deploy/` | Project-specific |
+
+## Usage in Code
+
+```python
+from specify_cli.workflow import Artifact
+
+# Create artifact with path pattern
+artifact = Artifact(
+    type="adr",
+    path="./docs/adr/ADR-{NNN}-{slug}.md",
+    required=True,
+    multiple=True,
+)
+
+# Resolve path with actual values
+resolved = artifact.resolve_path(
+    feature="user-auth",
+    number=1,
+    slug="oauth-strategy",
+)
+# Result: "./docs/adr/ADR-001-oauth-strategy.md"
+```
+
+## Pattern Matching
+
+Artifacts support pattern matching to verify if a file matches the expected pattern:
+
+```python
+artifact = Artifact(type="adr", path="./docs/adr/ADR-{NNN}-{slug}.md")
+
+# Check if files match pattern
+artifact.matches_pattern("./docs/adr/ADR-001-oauth.md")  # True
+artifact.matches_pattern("./docs/adr/ADR-042-jwt.md")    # True
+artifact.matches_pattern("./docs/prd/feature.md")        # False
+```
+
+## Wildcard Support
+
+Path patterns support glob-style wildcards:
+
+| Pattern | Matches |
+|---------|---------|
+| `*.md` | Any markdown file |
+| `./docs/adr/ADR-*.md` | Any ADR file |
+| `./backlog/tasks/*.md` | Any task file |
+
+## Best Practices
+
+1. **Use lowercase, hyphenated slugs**: Convert "User Authentication" to `user-authentication`
+2. **Use {NNN} for sequential numbering**: ADRs, task IDs
+3. **Use {feature} for feature-specific paths**: Keeps artifacts organized by feature
+4. **Use {slug} when title differs from feature**: For ADR titles that are more specific
+
+## See Also
+
+- [Workflow Artifact Flow](./workflow-artifact-flow.md)
+- [TransitionSchema API](../api/workflow/transition.md)
+- [jpspec_workflow.yml Configuration](../configuration/workflow-config.md)

--- a/src/specify_cli/workflow/__init__.py
+++ b/src/specify_cli/workflow/__init__.py
@@ -1,4 +1,14 @@
-"""Workflow configuration and validation module."""
+"""Workflow configuration and validation module.
+
+This module provides workflow configuration loading, validation, and
+transition schema definitions for JPSpec workflows.
+
+Key components:
+- WorkflowConfig: Load and query workflow configuration from YAML
+- WorkflowValidator: Semantic validation of workflow configuration
+- TransitionSchema: Define input/output artifacts and validation modes
+- ValidationMode: Transition gate types (NONE, KEYWORD, PULL_REQUEST)
+"""
 
 from specify_cli.workflow.config import WorkflowConfig
 from specify_cli.workflow.exceptions import (
@@ -7,6 +17,18 @@ from specify_cli.workflow.exceptions import (
     WorkflowConfigValidationError,
     WorkflowNotFoundError,
     WorkflowStateError,
+)
+from specify_cli.workflow.transition import (
+    WORKFLOW_TRANSITIONS,
+    Artifact,
+    KeywordValidation,
+    TransitionSchema,
+    ValidationMode,
+    format_validation_mode,
+    get_transition_by_name,
+    get_transitions_from_state,
+    parse_validation_mode,
+    validate_transition_schema,
 )
 from specify_cli.workflow.validator import (
     ValidationIssue,
@@ -25,6 +47,17 @@ __all__ = [
     "WorkflowConfigValidationError",
     "WorkflowNotFoundError",
     "WorkflowStateError",
+    # Transition Schema
+    "Artifact",
+    "KeywordValidation",
+    "TransitionSchema",
+    "ValidationMode",
+    "WORKFLOW_TRANSITIONS",
+    "format_validation_mode",
+    "get_transition_by_name",
+    "get_transitions_from_state",
+    "parse_validation_mode",
+    "validate_transition_schema",
     # Validation
     "ValidationSeverity",
     "ValidationIssue",

--- a/src/specify_cli/workflow/transition.py
+++ b/src/specify_cli/workflow/transition.py
@@ -1,0 +1,649 @@
+"""Workflow transition validation schema.
+
+This module defines the schema for workflow transitions including:
+- Input/output artifact definitions
+- Validation mode types (NONE, KEYWORD, PULL_REQUEST)
+- Transition validation logic
+
+Every workflow transition MUST define:
+1. Input artifacts - What must exist before transition
+2. Output artifacts - What is produced by the workflow
+3. Validation mode - NONE, KEYWORD["..."], or PULL_REQUEST
+
+Example:
+    >>> from specify_cli.workflow.transition import (
+    ...     TransitionSchema, ValidationMode, Artifact
+    ... )
+    >>> schema = TransitionSchema(
+    ...     name="specify",
+    ...     from_state="Assessed",
+    ...     to_state="Specified",
+    ...     input_artifacts=[Artifact(type="assessment_report", path="./docs/assess/{feature}.md")],
+    ...     output_artifacts=[Artifact(type="prd", path="./docs/prd/{feature}.md")],
+    ...     validation=ValidationMode.NONE,
+    ... )
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class ValidationMode(Enum):
+    """Validation mode for workflow transitions.
+
+    Determines how a transition is gated before proceeding.
+
+    Attributes:
+        NONE: No gate - transition proceeds automatically after artifacts created.
+        KEYWORD: User must type exact keyword to proceed (e.g., "APPROVED").
+        PULL_REQUEST: Transition blocked until PR containing artifact is merged.
+    """
+
+    NONE = "NONE"
+    KEYWORD = "KEYWORD"
+    PULL_REQUEST = "PULL_REQUEST"
+
+
+@dataclass
+class Artifact:
+    """Definition of an artifact in the workflow.
+
+    Artifacts are files or directories produced or consumed by workflow transitions.
+    Path patterns support variables: {feature}, {NNN}, {slug}.
+
+    Attributes:
+        type: Artifact type identifier (e.g., "prd", "adr", "assessment_report").
+        path: File path pattern with optional variables.
+        required: Whether this artifact must exist for transition (default: True).
+        multiple: Whether multiple files of this type are expected (default: False).
+
+    Path Pattern Variables:
+        - {feature}: Feature name slug (e.g., "user-authentication")
+        - {NNN}: Zero-padded number (e.g., "001", "002")
+        - {slug}: Title slug derived from feature name
+
+    Example:
+        >>> artifact = Artifact(
+        ...     type="adr",
+        ...     path="./docs/adr/ADR-{NNN}-{slug}.md",
+        ...     multiple=True,
+        ... )
+    """
+
+    type: str
+    path: str = ""
+    required: bool = True
+    multiple: bool = False
+
+    def __post_init__(self) -> None:
+        """Validate artifact definition."""
+        if not self.type:
+            raise ValueError("Artifact type cannot be empty")
+
+    def resolve_path(
+        self,
+        feature: str = "",
+        number: int = 1,
+        slug: str = "",
+    ) -> str:
+        """Resolve path pattern with actual values.
+
+        Args:
+            feature: Feature name for {feature} variable.
+            number: Number for {NNN} variable (zero-padded to 3 digits).
+            slug: Slug for {slug} variable (defaults to feature if not provided).
+
+        Returns:
+            Resolved path with variables substituted.
+
+        Example:
+            >>> artifact = Artifact(type="adr", path="./docs/adr/ADR-{NNN}-{slug}.md")
+            >>> artifact.resolve_path(feature="auth", number=1, slug="oauth-strategy")
+            './docs/adr/ADR-001-oauth-strategy.md'
+        """
+        if not self.path:
+            return ""
+
+        resolved = self.path
+        if feature:
+            resolved = resolved.replace("{feature}", feature)
+        if slug or feature:
+            resolved = resolved.replace("{slug}", slug or feature)
+        resolved = resolved.replace("{NNN}", f"{number:03d}")
+
+        return resolved
+
+    def matches_pattern(self, file_path: str) -> bool:
+        """Check if a file path matches this artifact's pattern.
+
+        Args:
+            file_path: Actual file path to check.
+
+        Returns:
+            True if the file path matches the pattern.
+        """
+        if not self.path:
+            return False
+
+        # Convert glob pattern to regex
+        pattern = self.path
+        pattern = pattern.replace(".", r"\.")
+        pattern = pattern.replace("*", ".*")
+        pattern = pattern.replace("{feature}", r"[\w-]+")
+        pattern = pattern.replace("{NNN}", r"\d{3}")
+        pattern = pattern.replace("{slug}", r"[\w-]+")
+        pattern = f"^{pattern}$"
+
+        return bool(re.match(pattern, file_path))
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Artifact:
+        """Create Artifact from dictionary representation.
+
+        Args:
+            data: Dictionary with artifact fields.
+
+        Returns:
+            Artifact instance.
+        """
+        return cls(
+            type=data.get("type", ""),
+            path=data.get("path", ""),
+            required=data.get("required", True),
+            multiple=data.get("multiple", False),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary representation.
+
+        Returns:
+            Dictionary with artifact fields.
+        """
+        result: dict[str, Any] = {"type": self.type}
+        if self.path:
+            result["path"] = self.path
+        if not self.required:
+            result["required"] = False
+        if self.multiple:
+            result["multiple"] = True
+        return result
+
+
+@dataclass
+class KeywordValidation:
+    """KEYWORD validation mode configuration.
+
+    Requires user to type an exact keyword to approve the transition.
+
+    Attributes:
+        keyword: The exact keyword the user must type (case-sensitive).
+
+    Example:
+        >>> validation = KeywordValidation(keyword="PRD_APPROVED")
+    """
+
+    keyword: str
+
+    def __post_init__(self) -> None:
+        """Validate keyword configuration."""
+        if not self.keyword:
+            raise ValueError("Keyword cannot be empty for KEYWORD validation mode")
+
+    def __str__(self) -> str:
+        """Return YAML-compatible string representation."""
+        return f'KEYWORD["{self.keyword}"]'
+
+
+def parse_validation_mode(value: str | None) -> tuple[ValidationMode, str | None]:
+    """Parse validation mode from string representation.
+
+    Supports the following formats:
+    - "NONE" -> (ValidationMode.NONE, None)
+    - 'KEYWORD["APPROVED"]' -> (ValidationMode.KEYWORD, "APPROVED")
+    - "PULL_REQUEST" -> (ValidationMode.PULL_REQUEST, None)
+
+    Args:
+        value: String representation of validation mode.
+
+    Returns:
+        Tuple of (ValidationMode, optional keyword string).
+
+    Raises:
+        ValueError: If the format is invalid.
+
+    Example:
+        >>> parse_validation_mode('KEYWORD["APPROVED"]')
+        (ValidationMode.KEYWORD, 'APPROVED')
+        >>> parse_validation_mode("NONE")
+        (ValidationMode.NONE, None)
+    """
+    if not value or value.upper() == "NONE":
+        return (ValidationMode.NONE, None)
+
+    if value.upper() == "PULL_REQUEST":
+        return (ValidationMode.PULL_REQUEST, None)
+
+    # Parse KEYWORD["..."] format
+    keyword_match = re.match(r'KEYWORD\["([^"]+)"\]', value, re.IGNORECASE)
+    if keyword_match:
+        return (ValidationMode.KEYWORD, keyword_match.group(1))
+
+    raise ValueError(
+        f"Invalid validation mode: '{value}'. "
+        'Expected NONE, KEYWORD["<string>"], or PULL_REQUEST'
+    )
+
+
+def format_validation_mode(mode: ValidationMode, keyword: str | None = None) -> str:
+    """Format validation mode to string representation.
+
+    Args:
+        mode: The validation mode enum value.
+        keyword: Optional keyword for KEYWORD mode.
+
+    Returns:
+        String representation for YAML.
+
+    Raises:
+        ValueError: If KEYWORD mode is used without a keyword.
+    """
+    if mode == ValidationMode.NONE:
+        return "NONE"
+    if mode == ValidationMode.PULL_REQUEST:
+        return "PULL_REQUEST"
+    if mode == ValidationMode.KEYWORD:
+        if not keyword:
+            raise ValueError("KEYWORD validation mode requires a keyword")
+        return f'KEYWORD["{keyword}"]'
+    return "NONE"
+
+
+@dataclass
+class TransitionSchema:
+    """Schema definition for a workflow transition.
+
+    Defines the complete specification for transitioning between workflow states,
+    including required input artifacts, produced output artifacts, and validation mode.
+
+    Attributes:
+        name: Unique transition name (e.g., "specify", "plan", "implement").
+        from_state: Source state for the transition.
+        to_state: Destination state for the transition.
+        via: Workflow command that triggers this transition.
+        input_artifacts: Artifacts required before transition can proceed.
+        output_artifacts: Artifacts produced by this transition.
+        validation: Validation mode (NONE, KEYWORD, PULL_REQUEST).
+        validation_keyword: Keyword for KEYWORD validation mode.
+        description: Human-readable description of the transition.
+
+    Example:
+        >>> schema = TransitionSchema(
+        ...     name="specify",
+        ...     from_state="Assessed",
+        ...     to_state="Specified",
+        ...     via="specify",
+        ...     input_artifacts=[
+        ...         Artifact(type="assessment_report", path="./docs/assess/{feature}.md"),
+        ...     ],
+        ...     output_artifacts=[
+        ...         Artifact(type="prd", path="./docs/prd/{feature}.md"),
+        ...         Artifact(type="backlog_tasks", path="./backlog/tasks/*.md"),
+        ...     ],
+        ...     validation=ValidationMode.NONE,
+        ... )
+    """
+
+    name: str
+    from_state: str | list[str]
+    to_state: str
+    via: str = ""
+    input_artifacts: list[Artifact] = field(default_factory=list)
+    output_artifacts: list[Artifact] = field(default_factory=list)
+    validation: ValidationMode = ValidationMode.NONE
+    validation_keyword: str | None = None
+    description: str = ""
+
+    def __post_init__(self) -> None:
+        """Validate transition schema."""
+        if not self.name:
+            raise ValueError("Transition name cannot be empty")
+        if not self.from_state:
+            raise ValueError("Transition from_state cannot be empty")
+        if not self.to_state:
+            raise ValueError("Transition to_state cannot be empty")
+
+        # Set via to name if not provided
+        if not self.via:
+            self.via = self.name
+
+        # Validate KEYWORD mode has keyword
+        if self.validation == ValidationMode.KEYWORD and not self.validation_keyword:
+            raise ValueError("KEYWORD validation mode requires validation_keyword")
+
+    @property
+    def from_states(self) -> list[str]:
+        """Get from_state as a list (handles both single state and list)."""
+        if isinstance(self.from_state, list):
+            return self.from_state
+        return [self.from_state]
+
+    def get_required_input_artifacts(self) -> list[Artifact]:
+        """Get only required input artifacts."""
+        return [a for a in self.input_artifacts if a.required]
+
+    def get_required_output_artifacts(self) -> list[Artifact]:
+        """Get only required output artifacts."""
+        return [a for a in self.output_artifacts if a.required]
+
+    def get_validation_string(self) -> str:
+        """Get validation mode as string representation."""
+        return format_validation_mode(self.validation, self.validation_keyword)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TransitionSchema:
+        """Create TransitionSchema from dictionary representation.
+
+        Args:
+            data: Dictionary with transition fields.
+
+        Returns:
+            TransitionSchema instance.
+        """
+        # Parse validation mode
+        validation_str = data.get("validation", "NONE")
+        validation_mode, keyword = parse_validation_mode(validation_str)
+
+        # Parse artifacts
+        input_artifacts = [
+            Artifact.from_dict(a) if isinstance(a, dict) else Artifact(type=str(a))
+            for a in data.get("input_artifacts", [])
+        ]
+        output_artifacts = [
+            Artifact.from_dict(a) if isinstance(a, dict) else Artifact(type=str(a))
+            for a in data.get("output_artifacts", [])
+        ]
+
+        return cls(
+            name=data.get("name", ""),
+            from_state=data.get("from", data.get("from_state", "")),
+            to_state=data.get("to", data.get("to_state", "")),
+            via=data.get("via", data.get("name", "")),
+            input_artifacts=input_artifacts,
+            output_artifacts=output_artifacts,
+            validation=validation_mode,
+            validation_keyword=keyword,
+            description=data.get("description", ""),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary representation for YAML serialization.
+
+        Returns:
+            Dictionary with transition fields.
+        """
+        result: dict[str, Any] = {
+            "name": self.name,
+            "from": self.from_state,
+            "to": self.to_state,
+            "via": self.via,
+        }
+
+        if self.input_artifacts:
+            result["input_artifacts"] = [a.to_dict() for a in self.input_artifacts]
+
+        if self.output_artifacts:
+            result["output_artifacts"] = [a.to_dict() for a in self.output_artifacts]
+
+        result["validation"] = self.get_validation_string()
+
+        if self.description:
+            result["description"] = self.description
+
+        return result
+
+
+# Standard workflow transitions with artifact definitions
+WORKFLOW_TRANSITIONS: list[TransitionSchema] = [
+    # Entry transition: assess
+    TransitionSchema(
+        name="assess",
+        from_state="To Do",
+        to_state="Assessed",
+        via="assess",
+        input_artifacts=[],  # Entry point - no inputs required
+        output_artifacts=[
+            Artifact(
+                type="assessment_report",
+                path="./docs/assess/{feature}-assessment.md",
+            ),
+        ],
+        validation=ValidationMode.NONE,
+        description="Evaluate SDD workflow suitability (Full/Light/Skip)",
+    ),
+    # Specify transition
+    TransitionSchema(
+        name="specify",
+        from_state="Assessed",
+        to_state="Specified",
+        via="specify",
+        input_artifacts=[
+            Artifact(
+                type="assessment_report",
+                path="./docs/assess/{feature}-assessment.md",
+                required=True,
+            ),
+        ],
+        output_artifacts=[
+            Artifact(
+                type="prd",
+                path="./docs/prd/{feature}.md",
+                required=True,
+            ),
+            Artifact(
+                type="backlog_tasks",
+                path="./backlog/tasks/*.md",
+                required=True,
+                multiple=True,
+            ),
+        ],
+        validation=ValidationMode.NONE,
+        description="Create PRD with user stories and acceptance criteria",
+    ),
+    # Research transition (optional)
+    TransitionSchema(
+        name="research",
+        from_state="Specified",
+        to_state="Researched",
+        via="research",
+        input_artifacts=[
+            Artifact(
+                type="prd",
+                path="./docs/prd/{feature}.md",
+                required=True,
+            ),
+        ],
+        output_artifacts=[
+            Artifact(
+                type="research_report",
+                path="./docs/research/{feature}-research.md",
+            ),
+            Artifact(
+                type="business_validation",
+                path="./docs/research/{feature}-validation.md",
+            ),
+        ],
+        validation=ValidationMode.NONE,
+        description="Technical and business research completed",
+    ),
+    # Plan transition (can come from Specified or Researched)
+    TransitionSchema(
+        name="plan",
+        from_state=["Specified", "Researched"],
+        to_state="Planned",
+        via="plan",
+        input_artifacts=[
+            Artifact(
+                type="prd",
+                path="./docs/prd/{feature}.md",
+                required=True,
+            ),
+        ],
+        output_artifacts=[
+            Artifact(
+                type="adr",
+                path="./docs/adr/ADR-{NNN}-{slug}.md",
+                required=True,
+                multiple=True,
+            ),
+            Artifact(
+                type="platform_design",
+                path="./docs/platform/{feature}-platform.md",
+                required=False,
+            ),
+        ],
+        validation=ValidationMode.NONE,
+        description="Architecture planned with ADRs",
+    ),
+    # Implement transition
+    TransitionSchema(
+        name="implement",
+        from_state="Planned",
+        to_state="In Implementation",
+        via="implement",
+        input_artifacts=[
+            Artifact(
+                type="adr",
+                path="./docs/adr/ADR-*.md",
+                required=True,
+            ),
+        ],
+        output_artifacts=[
+            Artifact(
+                type="source_code",
+                path="./src/",
+            ),
+            Artifact(
+                type="tests",
+                path="./tests/",
+                required=True,
+            ),
+            Artifact(
+                type="ac_coverage",
+                path="./tests/ac-coverage.json",
+                required=True,
+            ),
+        ],
+        validation=ValidationMode.NONE,
+        description="Implementation work with tests and AC coverage",
+    ),
+    # Validate transition
+    TransitionSchema(
+        name="validate",
+        from_state="In Implementation",
+        to_state="Validated",
+        via="validate",
+        input_artifacts=[
+            Artifact(type="tests", required=True),
+            Artifact(type="ac_coverage", required=True),
+        ],
+        output_artifacts=[
+            Artifact(
+                type="qa_report",
+                path="./docs/qa/{feature}-qa-report.md",
+            ),
+            Artifact(
+                type="security_report",
+                path="./docs/security/{feature}-security.md",
+            ),
+        ],
+        validation=ValidationMode.NONE,
+        description="QA, security, and documentation validated",
+    ),
+    # Operate transition
+    TransitionSchema(
+        name="operate",
+        from_state="Validated",
+        to_state="Deployed",
+        via="operate",
+        input_artifacts=[
+            Artifact(type="qa_report"),
+            Artifact(type="security_report"),
+        ],
+        output_artifacts=[
+            Artifact(
+                type="deployment_manifest",
+                path="./deploy/",
+            ),
+        ],
+        validation=ValidationMode.NONE,
+        description="Deployed to production",
+    ),
+    # Complete transition (manual)
+    TransitionSchema(
+        name="complete",
+        from_state="Deployed",
+        to_state="Done",
+        via="manual",
+        input_artifacts=[],
+        output_artifacts=[],
+        validation=ValidationMode.NONE,
+        description="Production deployment confirmed successful",
+    ),
+]
+
+
+def get_transition_by_name(name: str) -> TransitionSchema | None:
+    """Get a standard workflow transition by name.
+
+    Args:
+        name: Transition name (e.g., "specify", "plan").
+
+    Returns:
+        TransitionSchema if found, None otherwise.
+    """
+    for transition in WORKFLOW_TRANSITIONS:
+        if transition.name == name:
+            return transition
+    return None
+
+
+def get_transitions_from_state(state: str) -> list[TransitionSchema]:
+    """Get all transitions that can proceed from a given state.
+
+    Args:
+        state: Source state name.
+
+    Returns:
+        List of transitions available from this state.
+    """
+    return [t for t in WORKFLOW_TRANSITIONS if state in t.from_states]
+
+
+def validate_transition_schema(schema: TransitionSchema) -> list[str]:
+    """Validate a transition schema for completeness.
+
+    Args:
+        schema: TransitionSchema to validate.
+
+    Returns:
+        List of validation error messages (empty if valid).
+    """
+    errors: list[str] = []
+
+    # Check required fields
+    if not schema.name:
+        errors.append("Transition name is required")
+    if not schema.from_state:
+        errors.append("Transition from_state is required")
+    if not schema.to_state:
+        errors.append("Transition to_state is required")
+
+    # Check KEYWORD validation has keyword
+    if schema.validation == ValidationMode.KEYWORD and not schema.validation_keyword:
+        errors.append("KEYWORD validation mode requires a keyword")
+
+    return errors

--- a/tests/test_workflow_transition.py
+++ b/tests/test_workflow_transition.py
@@ -1,0 +1,527 @@
+"""Tests for workflow transition schema.
+
+Tests cover:
+- ValidationMode enum
+- Artifact creation and path resolution
+- TransitionSchema creation and validation
+- Parsing and formatting validation modes
+- Standard workflow transitions (WORKFLOW_TRANSITIONS)
+"""
+
+import pytest
+
+from specify_cli.workflow.transition import (
+    WORKFLOW_TRANSITIONS,
+    Artifact,
+    KeywordValidation,
+    TransitionSchema,
+    ValidationMode,
+    format_validation_mode,
+    get_transition_by_name,
+    get_transitions_from_state,
+    parse_validation_mode,
+    validate_transition_schema,
+)
+
+
+class TestValidationMode:
+    """Tests for ValidationMode enum."""
+
+    def test_validation_mode_values(self):
+        """AC3: Validation mode enum has NONE, KEYWORD, PULL_REQUEST."""
+        assert ValidationMode.NONE.value == "NONE"
+        assert ValidationMode.KEYWORD.value == "KEYWORD"
+        assert ValidationMode.PULL_REQUEST.value == "PULL_REQUEST"
+
+    def test_validation_mode_count(self):
+        """Exactly 3 validation modes exist."""
+        assert len(ValidationMode) == 3
+
+
+class TestArtifact:
+    """Tests for Artifact dataclass."""
+
+    def test_artifact_creation_minimal(self):
+        """Artifact can be created with just type."""
+        artifact = Artifact(type="prd")
+        assert artifact.type == "prd"
+        assert artifact.path == ""
+        assert artifact.required is True
+        assert artifact.multiple is False
+
+    def test_artifact_creation_full(self):
+        """Artifact can be created with all fields."""
+        artifact = Artifact(
+            type="adr",
+            path="./docs/adr/ADR-{NNN}-{slug}.md",
+            required=True,
+            multiple=True,
+        )
+        assert artifact.type == "adr"
+        assert artifact.path == "./docs/adr/ADR-{NNN}-{slug}.md"
+        assert artifact.required is True
+        assert artifact.multiple is True
+
+    def test_artifact_empty_type_raises(self):
+        """Artifact with empty type raises ValueError."""
+        with pytest.raises(ValueError, match="Artifact type cannot be empty"):
+            Artifact(type="")
+
+    def test_artifact_resolve_path_feature(self):
+        """AC7: Path pattern resolves {feature} variable."""
+        artifact = Artifact(type="prd", path="./docs/prd/{feature}.md")
+        resolved = artifact.resolve_path(feature="user-auth")
+        assert resolved == "./docs/prd/user-auth.md"
+
+    def test_artifact_resolve_path_nnn(self):
+        """AC7: Path pattern resolves {NNN} variable with zero-padding."""
+        artifact = Artifact(type="adr", path="./docs/adr/ADR-{NNN}-auth.md")
+        assert artifact.resolve_path(number=1) == "./docs/adr/ADR-001-auth.md"
+        assert artifact.resolve_path(number=42) == "./docs/adr/ADR-042-auth.md"
+        assert artifact.resolve_path(number=999) == "./docs/adr/ADR-999-auth.md"
+
+    def test_artifact_resolve_path_slug(self):
+        """AC7: Path pattern resolves {slug} variable."""
+        artifact = Artifact(type="adr", path="./docs/adr/ADR-001-{slug}.md")
+        resolved = artifact.resolve_path(slug="oauth-strategy")
+        assert resolved == "./docs/adr/ADR-001-oauth-strategy.md"
+
+    def test_artifact_resolve_path_all_variables(self):
+        """AC7: Path pattern resolves all variables together."""
+        artifact = Artifact(type="adr", path="./docs/adr/{feature}/ADR-{NNN}-{slug}.md")
+        resolved = artifact.resolve_path(feature="auth", number=2, slug="jwt-tokens")
+        assert resolved == "./docs/adr/auth/ADR-002-jwt-tokens.md"
+
+    def test_artifact_resolve_path_slug_defaults_to_feature(self):
+        """Slug defaults to feature if not provided."""
+        artifact = Artifact(type="test", path="./docs/{slug}-test.md")
+        resolved = artifact.resolve_path(feature="my-feature")
+        assert resolved == "./docs/my-feature-test.md"
+
+    def test_artifact_matches_pattern_exact(self):
+        """Pattern matching works for exact paths."""
+        artifact = Artifact(type="prd", path="./docs/prd/user-auth.md")
+        assert artifact.matches_pattern("./docs/prd/user-auth.md")
+        assert not artifact.matches_pattern("./docs/prd/other.md")
+
+    def test_artifact_matches_pattern_with_variables(self):
+        """Pattern matching works with path variables."""
+        artifact = Artifact(type="prd", path="./docs/prd/{feature}.md")
+        assert artifact.matches_pattern("./docs/prd/user-auth.md")
+        assert artifact.matches_pattern("./docs/prd/my-feature.md")
+        assert not artifact.matches_pattern("./docs/other/user-auth.md")
+
+    def test_artifact_matches_pattern_with_wildcard(self):
+        """Pattern matching works with wildcards."""
+        artifact = Artifact(type="adr", path="./docs/adr/ADR-*.md")
+        assert artifact.matches_pattern("./docs/adr/ADR-001-auth.md")
+        assert artifact.matches_pattern("./docs/adr/ADR-anything.md")
+
+    def test_artifact_from_dict(self):
+        """Artifact can be created from dictionary."""
+        data = {
+            "type": "prd",
+            "path": "./docs/prd/{feature}.md",
+            "required": True,
+            "multiple": False,
+        }
+        artifact = Artifact.from_dict(data)
+        assert artifact.type == "prd"
+        assert artifact.path == "./docs/prd/{feature}.md"
+        assert artifact.required is True
+        assert artifact.multiple is False
+
+    def test_artifact_to_dict(self):
+        """Artifact can be serialized to dictionary."""
+        artifact = Artifact(
+            type="adr",
+            path="./docs/adr/ADR-{NNN}-{slug}.md",
+            required=True,
+            multiple=True,
+        )
+        data = artifact.to_dict()
+        assert data["type"] == "adr"
+        assert data["path"] == "./docs/adr/ADR-{NNN}-{slug}.md"
+        assert "required" not in data  # True is default, not serialized
+        assert data["multiple"] is True
+
+
+class TestKeywordValidation:
+    """Tests for KeywordValidation dataclass."""
+
+    def test_keyword_validation_creation(self):
+        """KeywordValidation stores keyword."""
+        validation = KeywordValidation(keyword="APPROVED")
+        assert validation.keyword == "APPROVED"
+
+    def test_keyword_validation_empty_raises(self):
+        """Empty keyword raises ValueError."""
+        with pytest.raises(ValueError, match="Keyword cannot be empty"):
+            KeywordValidation(keyword="")
+
+    def test_keyword_validation_str(self):
+        """String representation is YAML-compatible."""
+        validation = KeywordValidation(keyword="PRD_APPROVED")
+        assert str(validation) == 'KEYWORD["PRD_APPROVED"]'
+
+
+class TestParseValidationMode:
+    """Tests for parse_validation_mode function."""
+
+    def test_parse_none(self):
+        """AC3: Parse NONE mode."""
+        mode, keyword = parse_validation_mode("NONE")
+        assert mode == ValidationMode.NONE
+        assert keyword is None
+
+    def test_parse_none_lowercase(self):
+        """Parse NONE is case-insensitive."""
+        mode, keyword = parse_validation_mode("none")
+        assert mode == ValidationMode.NONE
+
+    def test_parse_none_default(self):
+        """Empty/None value defaults to NONE."""
+        mode, keyword = parse_validation_mode(None)
+        assert mode == ValidationMode.NONE
+        mode, keyword = parse_validation_mode("")
+        assert mode == ValidationMode.NONE
+
+    def test_parse_pull_request(self):
+        """AC3: Parse PULL_REQUEST mode."""
+        mode, keyword = parse_validation_mode("PULL_REQUEST")
+        assert mode == ValidationMode.PULL_REQUEST
+        assert keyword is None
+
+    def test_parse_keyword(self):
+        """AC3: Parse KEYWORD mode with string."""
+        mode, keyword = parse_validation_mode('KEYWORD["APPROVED"]')
+        assert mode == ValidationMode.KEYWORD
+        assert keyword == "APPROVED"
+
+    def test_parse_keyword_different_values(self):
+        """Parse KEYWORD with various keywords."""
+        mode, keyword = parse_validation_mode('KEYWORD["PRD_READY"]')
+        assert keyword == "PRD_READY"
+
+        mode, keyword = parse_validation_mode('KEYWORD["LGTM"]')
+        assert keyword == "LGTM"
+
+    def test_parse_invalid_raises(self):
+        """Invalid format raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid validation mode"):
+            parse_validation_mode("INVALID")
+
+
+class TestFormatValidationMode:
+    """Tests for format_validation_mode function."""
+
+    def test_format_none(self):
+        """Format NONE mode."""
+        assert format_validation_mode(ValidationMode.NONE) == "NONE"
+
+    def test_format_pull_request(self):
+        """Format PULL_REQUEST mode."""
+        assert format_validation_mode(ValidationMode.PULL_REQUEST) == "PULL_REQUEST"
+
+    def test_format_keyword(self):
+        """Format KEYWORD mode with keyword."""
+        result = format_validation_mode(ValidationMode.KEYWORD, "APPROVED")
+        assert result == 'KEYWORD["APPROVED"]'
+
+    def test_format_keyword_missing_raises(self):
+        """KEYWORD mode without keyword raises ValueError."""
+        with pytest.raises(ValueError, match="requires a keyword"):
+            format_validation_mode(ValidationMode.KEYWORD)
+
+
+class TestTransitionSchema:
+    """Tests for TransitionSchema dataclass."""
+
+    def test_transition_creation_minimal(self):
+        """AC1: Transition with required fields."""
+        schema = TransitionSchema(
+            name="specify",
+            from_state="Assessed",
+            to_state="Specified",
+        )
+        assert schema.name == "specify"
+        assert schema.from_state == "Assessed"
+        assert schema.to_state == "Specified"
+        assert schema.via == "specify"  # Defaults to name
+        assert schema.validation == ValidationMode.NONE
+        assert schema.input_artifacts == []
+        assert schema.output_artifacts == []
+
+    def test_transition_creation_full(self):
+        """AC1: Transition with all fields including artifacts and validation."""
+        schema = TransitionSchema(
+            name="specify",
+            from_state="Assessed",
+            to_state="Specified",
+            via="specify",
+            input_artifacts=[
+                Artifact(type="assessment_report", path="./docs/assess/{feature}.md"),
+            ],
+            output_artifacts=[
+                Artifact(type="prd", path="./docs/prd/{feature}.md"),
+            ],
+            validation=ValidationMode.KEYWORD,
+            validation_keyword="PRD_APPROVED",
+            description="Create PRD from assessment",
+        )
+        assert len(schema.input_artifacts) == 1
+        assert len(schema.output_artifacts) == 1
+        assert schema.validation == ValidationMode.KEYWORD
+        assert schema.validation_keyword == "PRD_APPROVED"
+
+    def test_transition_empty_name_raises(self):
+        """Transition with empty name raises ValueError."""
+        with pytest.raises(ValueError, match="name cannot be empty"):
+            TransitionSchema(name="", from_state="A", to_state="B")
+
+    def test_transition_empty_from_state_raises(self):
+        """Transition with empty from_state raises ValueError."""
+        with pytest.raises(ValueError, match="from_state cannot be empty"):
+            TransitionSchema(name="test", from_state="", to_state="B")
+
+    def test_transition_keyword_without_keyword_raises(self):
+        """KEYWORD validation without keyword raises ValueError."""
+        with pytest.raises(ValueError, match="requires validation_keyword"):
+            TransitionSchema(
+                name="test",
+                from_state="A",
+                to_state="B",
+                validation=ValidationMode.KEYWORD,
+            )
+
+    def test_transition_from_states_list(self):
+        """from_states property handles list of states."""
+        schema = TransitionSchema(
+            name="plan",
+            from_state=["Specified", "Researched"],
+            to_state="Planned",
+        )
+        assert schema.from_states == ["Specified", "Researched"]
+
+    def test_transition_from_states_single(self):
+        """from_states property handles single state."""
+        schema = TransitionSchema(
+            name="specify",
+            from_state="Assessed",
+            to_state="Specified",
+        )
+        assert schema.from_states == ["Assessed"]
+
+    def test_transition_get_required_artifacts(self):
+        """Get only required input/output artifacts."""
+        schema = TransitionSchema(
+            name="test",
+            from_state="A",
+            to_state="B",
+            input_artifacts=[
+                Artifact(type="required", required=True),
+                Artifact(type="optional", required=False),
+            ],
+            output_artifacts=[
+                Artifact(type="required_out", required=True),
+                Artifact(type="optional_out", required=False),
+            ],
+        )
+        required_in = schema.get_required_input_artifacts()
+        required_out = schema.get_required_output_artifacts()
+
+        assert len(required_in) == 1
+        assert required_in[0].type == "required"
+        assert len(required_out) == 1
+        assert required_out[0].type == "required_out"
+
+    def test_transition_get_validation_string(self):
+        """Get validation mode as string."""
+        schema_none = TransitionSchema(
+            name="test", from_state="A", to_state="B", validation=ValidationMode.NONE
+        )
+        assert schema_none.get_validation_string() == "NONE"
+
+        schema_keyword = TransitionSchema(
+            name="test",
+            from_state="A",
+            to_state="B",
+            validation=ValidationMode.KEYWORD,
+            validation_keyword="APPROVED",
+        )
+        assert schema_keyword.get_validation_string() == 'KEYWORD["APPROVED"]'
+
+    def test_transition_from_dict(self):
+        """Transition can be created from dictionary."""
+        data = {
+            "name": "specify",
+            "from": "Assessed",
+            "to": "Specified",
+            "via": "specify",
+            "input_artifacts": [
+                {"type": "assessment_report", "path": "./docs/assess/{feature}.md"}
+            ],
+            "output_artifacts": [{"type": "prd", "path": "./docs/prd/{feature}.md"}],
+            "validation": 'KEYWORD["PRD_APPROVED"]',
+            "description": "Create PRD",
+        }
+        schema = TransitionSchema.from_dict(data)
+        assert schema.name == "specify"
+        assert schema.from_state == "Assessed"
+        assert schema.to_state == "Specified"
+        assert len(schema.input_artifacts) == 1
+        assert schema.validation == ValidationMode.KEYWORD
+        assert schema.validation_keyword == "PRD_APPROVED"
+
+    def test_transition_to_dict(self):
+        """Transition can be serialized to dictionary."""
+        schema = TransitionSchema(
+            name="specify",
+            from_state="Assessed",
+            to_state="Specified",
+            via="specify",
+            input_artifacts=[Artifact(type="assessment_report")],
+            output_artifacts=[Artifact(type="prd", path="./docs/prd/{feature}.md")],
+            validation=ValidationMode.NONE,
+            description="Create PRD",
+        )
+        data = schema.to_dict()
+        assert data["name"] == "specify"
+        assert data["from"] == "Assessed"
+        assert data["to"] == "Specified"
+        assert data["validation"] == "NONE"
+        assert len(data["input_artifacts"]) == 1
+        assert len(data["output_artifacts"]) == 1
+
+
+class TestWorkflowTransitions:
+    """Tests for standard WORKFLOW_TRANSITIONS."""
+
+    def test_all_transitions_defined(self):
+        """AC2: All 7+ workflow transitions are defined."""
+        # Should have: assess, specify, research, plan, implement, validate, operate, complete
+        assert len(WORKFLOW_TRANSITIONS) >= 7
+        names = [t.name for t in WORKFLOW_TRANSITIONS]
+        assert "assess" in names
+        assert "specify" in names
+        assert "research" in names
+        assert "plan" in names
+        assert "implement" in names
+        assert "validate" in names
+        assert "operate" in names
+
+    def test_all_transitions_have_validation_none(self):
+        """AC4: All transitions default to validation: NONE."""
+        for transition in WORKFLOW_TRANSITIONS:
+            assert transition.validation == ValidationMode.NONE, (
+                f"Transition '{transition.name}' should have NONE validation"
+            )
+
+    def test_assess_transition(self):
+        """AC2: Assess transition is properly defined."""
+        assess = get_transition_by_name("assess")
+        assert assess is not None
+        assert assess.from_state == "To Do"
+        assert assess.to_state == "Assessed"
+        assert len(assess.input_artifacts) == 0  # Entry point
+        assert len(assess.output_artifacts) >= 1
+        assert any(a.type == "assessment_report" for a in assess.output_artifacts)
+
+    def test_specify_transition(self):
+        """AC2: Specify transition is properly defined."""
+        specify = get_transition_by_name("specify")
+        assert specify is not None
+        assert specify.from_state == "Assessed"
+        assert specify.to_state == "Specified"
+        assert any(a.type == "prd" for a in specify.output_artifacts)
+        assert any(a.type == "backlog_tasks" for a in specify.output_artifacts)
+
+    def test_plan_transition_multiple_from_states(self):
+        """AC2: Plan transition accepts multiple from states."""
+        plan = get_transition_by_name("plan")
+        assert plan is not None
+        assert "Specified" in plan.from_states
+        assert "Researched" in plan.from_states
+        assert any(a.type == "adr" for a in plan.output_artifacts)
+
+    def test_implement_transition(self):
+        """AC2: Implement transition is properly defined."""
+        implement = get_transition_by_name("implement")
+        assert implement is not None
+        assert implement.from_state == "Planned"
+        assert implement.to_state == "In Implementation"
+        assert any(a.type == "tests" for a in implement.output_artifacts)
+        assert any(a.type == "ac_coverage" for a in implement.output_artifacts)
+
+    def test_all_transitions_have_required_fields(self):
+        """AC6: All transitions have name, from, to, validation."""
+        for transition in WORKFLOW_TRANSITIONS:
+            assert transition.name, "Transition missing name"
+            assert transition.from_state, (
+                f"Transition {transition.name} missing from_state"
+            )
+            assert transition.to_state, f"Transition {transition.name} missing to_state"
+            assert transition.validation is not None, (
+                f"Transition {transition.name} missing validation"
+            )
+
+
+class TestValidateTransitionSchema:
+    """Tests for validate_transition_schema function."""
+
+    def test_valid_transition_no_errors(self):
+        """AC6: Valid transition passes validation."""
+        schema = TransitionSchema(
+            name="test",
+            from_state="A",
+            to_state="B",
+            validation=ValidationMode.NONE,
+        )
+        errors = validate_transition_schema(schema)
+        assert len(errors) == 0
+
+    def test_empty_name_returns_error(self):
+        """AC6: Empty name returns validation error."""
+        # Can't create schema with empty name, so test would fail at creation
+        # This validates that our schema enforces the constraint
+        with pytest.raises(ValueError):
+            TransitionSchema(name="", from_state="A", to_state="B")
+
+
+class TestGetTransitionByName:
+    """Tests for get_transition_by_name function."""
+
+    def test_get_existing_transition(self):
+        """Get transition by name returns correct transition."""
+        specify = get_transition_by_name("specify")
+        assert specify is not None
+        assert specify.name == "specify"
+
+    def test_get_nonexistent_transition(self):
+        """Get nonexistent transition returns None."""
+        result = get_transition_by_name("nonexistent")
+        assert result is None
+
+
+class TestGetTransitionsFromState:
+    """Tests for get_transitions_from_state function."""
+
+    def test_get_transitions_from_to_do(self):
+        """Get transitions from 'To Do' state."""
+        transitions = get_transitions_from_state("To Do")
+        assert len(transitions) >= 1
+        names = [t.name for t in transitions]
+        assert "assess" in names
+
+    def test_get_transitions_from_specified(self):
+        """Get transitions from 'Specified' state."""
+        transitions = get_transitions_from_state("Specified")
+        names = [t.name for t in transitions]
+        # Should include research (optional) and plan
+        assert "research" in names
+        assert "plan" in names
+
+    def test_get_transitions_from_unknown_state(self):
+        """Get transitions from unknown state returns empty list."""
+        transitions = get_transitions_from_state("Unknown")
+        assert transitions == []


### PR DESCRIPTION
## Summary

- Adds `TransitionSchema` dataclass defining workflow transition structure
- Adds `Artifact` dataclass with path pattern support (`{feature}`, `{NNN}`, `{slug}`)
- Adds `ValidationMode` enum (NONE, KEYWORD, PULL_REQUEST)
- Implements 8 standard workflow transitions in `WORKFLOW_TRANSITIONS`
- Adds helper functions: `get_transition_by_name()`, `get_transitions_from_state()`
- Creates path pattern documentation at `docs/reference/artifact-path-patterns.md`

## Test Plan

- [x] 54 unit tests covering all schema components
- [x] Tests for path pattern resolution and matching
- [x] Tests for transition lookup functions
- [x] All CI checks passing (lint, test, security, build)

## Task Reference

Completes task-172: Define Workflow Transition Validation Schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)