### PR TITLE
feat(cli): add validation mode flags to specify init (task-182)

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -2198,7 +2198,7 @@ def init(
         )
 
     # Generate workflow configuration file
-    # If --no-validation-prompts is set, use NONE mode regardless of --validation-mode
+    # Use NONE mode if --no-validation-prompts is set, otherwise use the --validation-mode value
     effective_mode = "none" if no_validation_prompts else validation_mode
     generate_jpspec_workflow_yml(project_path, effective_mode)
     console.print()


### PR DESCRIPTION
## Summary

Add validation mode configuration to the `specify init` command.

### New CLI Flags

| Flag | Description |
|------|-------------|
| `--validation-mode {none\|keyword\|pull-request}` | Default validation mode for all transitions (default: none) |
| `--no-validation-prompts` | Skip prompts and use NONE mode |

### Generated File

Creates `jpspec_workflow.yml` with all 7 workflow transitions configured:
- assess, research, specify, plan, implement, validate, operate

### Validation Mode Mapping

| CLI Option | YAML Value |
|------------|------------|
| none | `NONE` |
| keyword | `KEYWORD["APPROVED"]` |
| pull-request | `PULL_REQUEST` |

### Usage Examples

```bash
# Default (NONE mode)
specify init my-project

# All transitions require keyword approval
specify init my-project --validation-mode keyword

# All transitions require merged PR
specify init my-project --validation-mode pull-request

# Skip prompts, use NONE
specify init my-project --no-validation-prompts
```

### Acceptance Criteria

- [x] AC5: Generate jpspec_workflow.yml with configured modes
- [x] AC6: Add --validation-mode flag
- [x] AC7: Add --no-validation-prompts flag

## Test plan

- [x] All 1080 tests pass
- [x] Lint passes

Implements task-182

🤖 Generated with [Claude Code](https://claude.com/claude-code)