### PR TITLE
feat(cli): add per-transition validation mode flags to specify init (task-182)

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -2250,13 +2250,8 @@ def init(
     else:
         # Build per-transition mode dict from CLI flags
         transition_modes = {
-            "assess": validation_assess,
-            "research": validation_research,
-            "specify": validation_specify,
-            "plan": validation_plan,
-            "implement": validation_implement,
-            "validate": validation_validate,
-            "operate": validation_operate,
+            t["name"]: locals()[f"validation_{t['name']}"]
+            for t in WORKFLOW_TRANSITIONS
         }
 
     generate_jpspec_workflow_yml(project_path, transition_modes)


### PR DESCRIPTION
## Summary

Adds **per-transition** validation mode flags to `specify init`, enabling different validation modes for each workflow step.

## New Flags

```bash
specify init my-project \
  --validation-assess none \
  --validation-research none \
  --validation-specify keyword \
  --validation-plan pull-request \
  --validation-implement pull-request \
  --validation-validate keyword \
  --validation-operate none
```

Each flag accepts: `none`, `keyword`, or `pull-request`

Also includes `--no-validation-prompts` to use NONE for all transitions (fast init).

## Use Case

Different phases have different review requirements:
- **Early phases** (assess, research): NONE - fast iteration
- **Design gates** (specify, plan): KEYWORD - human approval
- **Code phases** (implement, validate): PULL_REQUEST - require PR merge

## Generated Output

```yaml
# jpspec_workflow.yml
transitions:
  - name: assess
    validation: NONE
  - name: plan
    validation: PULL_REQUEST
  - name: validate
    validation: KEYWORD["APPROVED"]
```

## Test Plan

- [x] 1080 project tests pass
- [x] Lint passes

Closes task-182

🤖 Generated with [Claude Code](https://claude.com/claude-code)