### PR TITLE
docs: update CLI help text for workflow commands

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -4098,7 +4098,7 @@ def ac_coverage_command(
 # Workflow subcommand
 workflow_app = typer.Typer(
     name="workflow",
-    help="Workflow configuration validation and management",
+    help="Validate workflow configuration files",
     add_completion=False,
 )
 app.add_typer(workflow_app, name="workflow")
@@ -4129,6 +4129,11 @@ def workflow_validate(
     Validates jpspec_workflow.yml against:
     1. JSON schema (structural validation)
     2. Semantic validation (circular dependencies, reachability, etc.)
+
+    Exit codes:
+    - 0: Validation passed (warnings are non-blocking)
+    - 1: Validation errors (schema or semantic)
+    - 2: File errors (not found, invalid YAML)
 
     Examples:
         specify workflow validate                    # Validate default config


### PR DESCRIPTION
## Summary

Updated CLI help text for workflow commands to be more accurate and helpful.

### Changes

1. **Main `workflow` command help**:
   - Changed from: "Workflow configuration validation and management"
   - To: "Validate workflow configuration files"
   - **Rationale**: More accurate since only validation is implemented, not general management features

2. **`validate` command docstring**:
   - Added exit code documentation:
     - 0: Validation passed (warnings are non-blocking)
     - 1: Validation errors (schema or semantic)
     - 2: File errors (not found, invalid YAML)
   - **Rationale**: Makes it clear to users what each exit code means, which is important for CI/CD integration

### Motivation

The help text improvements align with ADR-004 documentation and improve user experience by:
- Accurately describing what the command does
- Providing essential information about exit codes for CI/CD integration
- Making the command more self-documenting

### Testing

- All workflow validation tests pass (21/21)
- All linting checks pass (ruff check + ruff format)
- Manually verified help text displays correctly:
  - `specify workflow --help`
  - `specify workflow validate --help`

### Documentation

Changes align with existing documentation:
- ADR-004: Workflow Configuration Validation CLI Command
- CLAUDE.md workflow validation section
- docs/guides/workflow-troubleshooting.md

---

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>