### PR TITLE
feat(hooks): add event emission instructions to /jpspec commands

### DIFF
--- a/.claude/commands/jpspec/assess.md
+++ b/.claude/commands/jpspec/assess.md
@@ -279,3 +279,22 @@ Before completing:
 - [ ] Recommendation is clear and justified
 - [ ] Next steps are specific and actionable
 - [ ] Override instructions are provided
+
+### Post-Completion: Emit Workflow Event
+
+After successfully completing this command, emit the workflow event to trigger any configured hooks:
+
+```bash
+# Emit the workflow.assessed event
+specify hooks emit workflow.assessed \
+  --spec-id "$FEATURE_NAME" \
+  --task-id "$TASK_ID" \
+  -f "docs/assess/${FEATURE_NAME}-assessment.md"
+```
+
+This triggers any configured hooks in `.specify/hooks/hooks.yaml`. Common use cases:
+- Auto-notify team of assessment completion
+- Update project tracking dashboards
+- Trigger downstream automation
+
+**Note**: If the `specify` CLI is not available or hooks are not configured, this step can be skipped without affecting the workflow.

--- a/.claude/commands/jpspec/implement.md
+++ b/.claude/commands/jpspec/implement.md
@@ -616,3 +616,23 @@ Include specific, actionable suggestions with examples.
 - Code review reports with resolution status
 - Integration documentation
 - Deployment-ready artifacts
+
+### Post-Completion: Emit Workflow Event
+
+After successfully completing this command, emit the workflow event to trigger any configured hooks:
+
+```bash
+# Emit the implement.completed event
+specify hooks emit implement.completed \
+  --spec-id "$FEATURE_NAME" \
+  --task-id "$TASK_ID" \
+  -f "src/**/*.{ts,tsx,py,go}"
+```
+
+This triggers any configured hooks in `.specify/hooks/hooks.yaml`. Common use cases:
+- Auto-run test suites
+- Trigger code quality analysis
+- Update CI/CD pipelines
+- Notify QA team implementation is ready for validation
+
+**Note**: If the `specify` CLI is not available or hooks are not configured, this step can be skipped without affecting the workflow.

--- a/.claude/commands/jpspec/operate.md
+++ b/.claude/commands/jpspec/operate.md
@@ -416,3 +416,25 @@ Deliver comprehensive operational package with:
 - SLI/SLO definitions and monitoring
 - Security scanning integration
 - DR and backup procedures
+
+### Post-Completion: Emit Workflow Event
+
+After successfully completing this command, emit the workflow event to trigger any configured hooks:
+
+```bash
+# Emit the deploy.completed event
+specify hooks emit deploy.completed \
+  --spec-id "$FEATURE_NAME" \
+  --task-id "$TASK_ID" \
+  -f ".github/workflows/*.yml" \
+  -f "k8s/**/*.yaml" \
+  -f "terraform/**/*.tf"
+```
+
+This triggers any configured hooks in `.specify/hooks/hooks.yaml`. Common use cases:
+- Notify on-call team of deployment
+- Update deployment tracking systems
+- Trigger smoke tests
+- Send release notifications to stakeholders
+
+**Note**: If the `specify` CLI is not available or hooks are not configured, this step can be skipped without affecting the workflow.

--- a/.claude/commands/jpspec/plan.md
+++ b/.claude/commands/jpspec/plan.md
@@ -388,3 +388,24 @@ After both agents complete:
    echo "✓ Workflow state updated to: Planned"
    echo "  Next step: /jpspec:implement"
    ```
+
+### Post-Completion: Emit Workflow Event
+
+After successfully completing this command, emit the workflow event to trigger any configured hooks:
+
+```bash
+# Emit the plan.created event
+specify hooks emit plan.created \
+  --spec-id "$FEATURE_NAME" \
+  --task-id "$TASK_ID" \
+  -f "docs/adr/*.md" \
+  -f "docs/architecture/${FEATURE_NAME}-architecture.md" \
+  -f "docs/platform/${FEATURE_NAME}-*.md"
+```
+
+This triggers any configured hooks in `.specify/hooks/hooks.yaml`. Common use cases:
+- Auto-notify architecture review board
+- Generate implementation tickets in external systems
+- Trigger security review workflows
+
+**Note**: If the `specify` CLI is not available or hooks are not configured, this step can be skipped without affecting the workflow.

--- a/.claude/commands/jpspec/research.md
+++ b/.claude/commands/jpspec/research.md
@@ -386,3 +386,23 @@ After the research and business validation agents complete their work:
 **Research without actionable follow-up tasks provides no value. Every research effort must produce implementation direction.**
 
 **Note**: If research concludes with "No-Go" recommendation, create a documentation task to record the decision and rationale for future reference.
+
+### Post-Completion: Emit Workflow Event
+
+After successfully completing this command, emit the workflow event to trigger any configured hooks:
+
+```bash
+# Emit the research.completed event
+specify hooks emit research.completed \
+  --spec-id "$FEATURE_NAME" \
+  --task-id "$TASK_ID" \
+  -f "docs/research/${FEATURE_NAME}-research.md" \
+  -f "docs/research/${FEATURE_NAME}-validation.md"
+```
+
+This triggers any configured hooks in `.specify/hooks/hooks.yaml`. Common use cases:
+- Auto-notify team of research findings
+- Update competitive analysis dashboards
+- Trigger business case review workflows
+
+**Note**: If the `specify` CLI is not available or hooks are not configured, this step can be skipped without affecting the workflow.

--- a/.claude/commands/jpspec/specify.md
+++ b/.claude/commands/jpspec/specify.md
@@ -262,3 +262,22 @@ backlog task list --plain | grep -i "<feature-keyword>"
 ```
 
 **Failure to create implementation tasks means the specification work is incomplete.**
+
+### Post-Completion: Emit Workflow Event
+
+After successfully completing this command, emit the workflow event to trigger any configured hooks:
+
+```bash
+# Emit the spec.created event
+specify hooks emit spec.created \
+  --spec-id "$FEATURE_NAME" \
+  --task-id "$TASK_ID" \
+  -f "docs/prd/${FEATURE_NAME}-prd.md"
+```
+
+This triggers any configured hooks in `.specify/hooks/hooks.yaml`. Common use cases:
+- Auto-notify stakeholders of new PRD
+- Generate architecture diagrams from spec
+- Trigger dependency analysis
+
+**Note**: If the `specify` CLI is not available or hooks are not configured, this step can be skipped without affecting the workflow.

--- a/.claude/commands/jpspec/validate.md
+++ b/.claude/commands/jpspec/validate.md
@@ -883,3 +883,24 @@ If a phase fails, fix the issue and re-run the command. The workflow will resume
 - `/jpspec:implement` - Implementation workflow
 - `/jpspec:plan` - Planning workflow
 - `backlog task` - Task management commands
+
+### Post-Completion: Emit Workflow Event
+
+After successfully completing this command (Phase 6 completes with PR creation), emit the workflow event to trigger any configured hooks:
+
+```bash
+# Emit the validate.completed event
+specify hooks emit validate.completed \
+  --spec-id "$FEATURE_NAME" \
+  --task-id "$TASK_ID" \
+  -f "docs/qa/${FEATURE_NAME}-qa-report.md" \
+  -f "docs/security/${FEATURE_NAME}-security-report.md"
+```
+
+This triggers any configured hooks in `.specify/hooks/hooks.yaml`. Common use cases:
+- Notify release management team
+- Update quality dashboards
+- Trigger deployment approval workflows
+- Archive test reports
+
+**Note**: If the `specify` CLI is not available or hooks are not configured, this step can be skipped without affecting the workflow.

--- a/backlog/tasks/task-227 - Add-event-emission-instructions-to-jpspec-slash-commands.md
+++ b/backlog/tasks/task-227 - Add-event-emission-instructions-to-jpspec-slash-commands.md
@@ -1,9 +1,11 @@
 ---
 id: task-227
 title: Add event emission instructions to /jpspec slash commands
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@backend-engineer'
 created_date: '2025-12-03 02:10'
+updated_date: '2025-12-03 02:26'
 labels:
   - hooks
   - integration
@@ -49,10 +51,75 @@ This triggers any configured hooks in `.specify/hooks/hooks.yaml`.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 All 7 /jpspec commands updated with post-completion event emission instructions
-- [ ] #2 Each command emits the correct event type for its workflow phase
-- [ ] #3 Instructions include --spec-id and --task-id parameters
-- [ ] #4 Instructions include -f flag for created artifact files
-- [ ] #5 Template added to templates/commands/jpspec/ for new project scaffolding
-- [ ] #6 Documentation updated in docs/guides/hooks-quickstart.md
+- [x] #1 All 7 /jpspec commands updated with post-completion event emission instructions
+- [x] #2 Each command emits the correct event type for its workflow phase
+- [x] #3 Instructions include --spec-id and --task-id parameters
+- [x] #4 Instructions include -f flag for created artifact files
+- [x] #5 Template added to templates/commands/jpspec/ for new project scaffolding
+- [x] #6 Documentation updated in docs/guides/hooks-quickstart.md
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add "Post-Completion: Emit Workflow Event" section to each /jpspec command
+2. Update .claude/commands/jpspec/*.md files (7 files)
+3. Update templates/commands/jpspec/*.md files (7 files)
+4. Update docs/guides/hooks-quickstart.md with /jpspec integration section
+5. Commit and create PR
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+## Implementation Summary (2025-12-03)
+
+### What Was Implemented
+
+Added "Post-Completion: Emit Workflow Event" section to all /jpspec slash commands to enable automatic hook triggering when workflow phases complete.
+
+### Files Updated
+
+**Command Files** (7 files):
+- `.claude/commands/jpspec/assess.md` → emits `workflow.assessed`
+- `.claude/commands/jpspec/specify.md` → emits `spec.created`
+- `.claude/commands/jpspec/research.md` → emits `research.completed`
+- `.claude/commands/jpspec/plan.md` → emits `plan.created`
+- `.claude/commands/jpspec/implement.md` → emits `implement.completed`
+- `.claude/commands/jpspec/validate.md` → emits `validate.completed`
+- `.claude/commands/jpspec/operate.md` → emits `deploy.completed`
+
+**Template Files** (7 files):
+- `templates/commands/jpspec/*.md` - Same changes for new project scaffolding
+
+**Documentation** (1 file):
+- `docs/guides/hooks-quickstart.md` - Added "/jpspec Command Integration" section
+
+### Standard Template Added
+
+Each command now includes:
+```markdown
+## Post-Completion: Emit Workflow Event
+
+After successfully completing this command, emit the workflow event:
+
+specify hooks emit <event-type> \
+  --spec-id "$FEATURE_NAME" \
+  --task-id "$TASK_ID" \
+  -f <artifact-files>
+
+This triggers any configured hooks in `.specify/hooks/hooks.yaml`.
+```
+
+### Event Type Mapping
+
+| Command | Event Type |
+|---------|------------|
+| assess | workflow.assessed |
+| specify | spec.created |
+| research | research.completed |
+| plan | plan.created |
+| implement | implement.completed |
+| validate | validate.completed |
+| operate | deploy.completed |
+<!-- SECTION:NOTES:END -->

--- a/docs/guides/hooks-quickstart.md
+++ b/docs/guides/hooks-quickstart.md
@@ -458,6 +458,90 @@ go vet ./...
 golangci-lint run
 ```
 
+## /jpspec Command Integration
+
+The `/jpspec` workflow commands automatically emit events at the end of each phase. This enables powerful automation pipelines that react to workflow progression.
+
+### Events Emitted by /jpspec Commands
+
+| Command | Event Type | Artifacts Included |
+|---------|------------|-------------------|
+| `/jpspec:assess` | `workflow.assessed` | Assessment report |
+| `/jpspec:specify` | `spec.created` | PRD document |
+| `/jpspec:research` | `research.completed` | Research and validation reports |
+| `/jpspec:plan` | `plan.created` | ADRs, architecture docs |
+| `/jpspec:implement` | `implement.completed` | Source code files |
+| `/jpspec:validate` | `validate.completed` | QA and security reports |
+| `/jpspec:operate` | `deploy.completed` | Workflows, K8s manifests |
+
+### Example: Full Workflow Automation
+
+Configure hooks to automate your entire SDD workflow:
+
+```yaml
+hooks:
+  # After assessment, notify the team
+  - name: assessment-notification
+    events:
+      - type: workflow.assessed
+    script: notify-assessment.sh
+    enabled: true
+
+  # After spec creation, run dependency analysis
+  - name: analyze-dependencies
+    events:
+      - type: spec.created
+    script: analyze-deps.sh
+    enabled: true
+
+  # After plan creation, trigger architecture review
+  - name: arch-review
+    events:
+      - type: plan.created
+    script: request-arch-review.sh
+    enabled: true
+
+  # After implementation, run full test suite
+  - name: run-tests
+    events:
+      - type: implement.completed
+    script: run-tests.sh
+    timeout: 600
+    fail_mode: stop
+    enabled: true
+
+  # After validation, update dashboards
+  - name: update-metrics
+    events:
+      - type: validate.completed
+    script: update-metrics.sh
+    enabled: true
+
+  # After deployment, send release notification
+  - name: release-notification
+    events:
+      - type: deploy.completed
+    script: notify-release.sh
+    enabled: true
+```
+
+### Manual Event Emission
+
+You can manually emit events using the CLI, which is useful for testing or integrating with external tools:
+
+```bash
+# Emit after completing a workflow step manually
+specify hooks emit spec.created \
+  --spec-id user-authentication \
+  --task-id task-123 \
+  -f docs/prd/user-authentication-prd.md
+
+# Dry-run to see what hooks would execute
+specify hooks emit implement.completed \
+  --spec-id user-authentication \
+  --dry-run
+```
+
 ## Next Steps
 
 1. **Enable your first hook** - Start with a simple test hook

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -47,6 +47,9 @@ from typer.core import TyperGroup
 
 # For cross-platform keyboard input
 import readchar
+
+# Hooks module
+from specify_cli.hooks.cli import hooks_app
 import ssl
 import truststore
 import yaml
@@ -4120,8 +4123,6 @@ workflow_app = typer.Typer(
 app.add_typer(workflow_app, name="workflow")
 
 # Hooks app (event emission and hook management)
-from specify_cli.hooks.cli import hooks_app  # noqa: E402
-
 app.add_typer(hooks_app, name="hooks")
 
 

--- a/templates/commands/jpspec/assess.md
+++ b/templates/commands/jpspec/assess.md
@@ -298,3 +298,22 @@ See task-175 for validation mode implementation details.
 - If feature name is ambiguous, ask for clarification
 - If assessment already exists, ask whether to overwrite
 - If override mode is invalid, show valid options
+
+## Post-Completion: Emit Workflow Event
+
+After successfully completing this command, emit the workflow event to trigger any configured hooks:
+
+```bash
+# Emit the workflow.assessed event
+specify hooks emit workflow.assessed \
+  --spec-id "$FEATURE_NAME" \
+  --task-id "$TASK_ID" \
+  -f "docs/assess/${FEATURE_NAME}-assessment.md"
+```
+
+This triggers any configured hooks in `.specify/hooks/hooks.yaml`. Common use cases:
+- Auto-notify team of assessment completion
+- Update project tracking dashboards
+- Trigger downstream automation
+
+**Note**: If the `specify` CLI is not available or hooks are not configured, this step can be skipped without affecting the workflow.

--- a/templates/commands/jpspec/implement.md
+++ b/templates/commands/jpspec/implement.md
@@ -161,3 +161,23 @@ See task-175 for validation mode implementation details.
 - This command is a placeholder for future agent implementation
 - Full engineer and reviewer agent integration will be completed in a future task
 - Coordinates multiple specialist agents for comprehensive implementation
+
+## Post-Completion: Emit Workflow Event
+
+After successfully completing this command, emit the workflow event to trigger any configured hooks:
+
+```bash
+# Emit the implement.completed event
+specify hooks emit implement.completed \
+  --spec-id "$FEATURE_NAME" \
+  --task-id "$TASK_ID" \
+  -f "src/**/*.{ts,tsx,py,go}"
+```
+
+This triggers any configured hooks in `.specify/hooks/hooks.yaml`. Common use cases:
+- Auto-run test suites
+- Trigger code quality analysis
+- Update CI/CD pipelines
+- Notify QA team implementation is ready for validation
+
+**Note**: If the `specify` CLI is not available or hooks are not configured, this step can be skipped without affecting the workflow.

--- a/templates/commands/jpspec/operate.md
+++ b/templates/commands/jpspec/operate.md
@@ -81,3 +81,24 @@ This command executes the operations workflow using two specialized agents:
 - This command is a placeholder for future agent implementation
 - Full SRE and Operations Manager agent integration will be completed in a future task
 - Operations Manager requires explicit human approval for critical operational decisions
+
+## Post-Completion: Emit Workflow Event
+
+After successfully completing this command, emit the workflow event to trigger any configured hooks:
+
+```bash
+# Emit the deploy.completed event
+specify hooks emit deploy.completed \
+  --spec-id "$FEATURE_NAME" \
+  --task-id "$TASK_ID" \
+  -f ".github/workflows/*.yml" \
+  -f "k8s/**/*.yaml"
+```
+
+This triggers any configured hooks in `.specify/hooks/hooks.yaml`. Common use cases:
+- Notify on-call team of deployment
+- Update deployment tracking systems
+- Trigger smoke tests
+- Send release notifications to stakeholders
+
+**Note**: If the `specify` CLI is not available or hooks are not configured, this step can be skipped without affecting the workflow.

--- a/templates/commands/jpspec/plan.md
+++ b/templates/commands/jpspec/plan.md
@@ -149,3 +149,23 @@ After the architecture and platform agents complete their work:
 3. **Only then mark the planning task as Done**
 
 **Architecture without implementation tasks is incomplete design work.**
+
+## Post-Completion: Emit Workflow Event
+
+After successfully completing this command, emit the workflow event to trigger any configured hooks:
+
+```bash
+# Emit the plan.created event
+specify hooks emit plan.created \
+  --spec-id "$FEATURE_NAME" \
+  --task-id "$TASK_ID" \
+  -f "docs/adr/*.md" \
+  -f "docs/plan/${FEATURE_NAME}-plan.md"
+```
+
+This triggers any configured hooks in `.specify/hooks/hooks.yaml`. Common use cases:
+- Auto-notify architecture review board
+- Generate implementation tickets in external systems
+- Trigger security review workflows
+
+**Note**: If the `specify` CLI is not available or hooks are not configured, this step can be skipped without affecting the workflow.

--- a/templates/commands/jpspec/research.md
+++ b/templates/commands/jpspec/research.md
@@ -123,3 +123,22 @@ After the research and business validation agents complete their work:
 **Research without actionable follow-up tasks provides no value. Every research effort must produce implementation direction.**
 
 **Note**: If research concludes with "No-Go" recommendation, create a documentation task to record the decision and rationale for future reference.
+
+## Post-Completion: Emit Workflow Event
+
+After successfully completing this command, emit the workflow event to trigger any configured hooks:
+
+```bash
+# Emit the research.completed event
+specify hooks emit research.completed \
+  --spec-id "$FEATURE_NAME" \
+  --task-id "$TASK_ID" \
+  -f "docs/research/${FEATURE_NAME}-research.md"
+```
+
+This triggers any configured hooks in `.specify/hooks/hooks.yaml`. Common use cases:
+- Auto-notify team of research findings
+- Update competitive analysis dashboards
+- Trigger business case review workflows
+
+**Note**: If the `specify` CLI is not available or hooks are not configured, this step can be skipped without affecting the workflow.

--- a/templates/commands/jpspec/specify.md
+++ b/templates/commands/jpspec/specify.md
@@ -119,3 +119,22 @@ After the PM Planner agent completes its work:
 3. **Only then mark the specification task as Done**
 
 **Failure to create implementation tasks means the specification work is incomplete.**
+
+## Post-Completion: Emit Workflow Event
+
+After successfully completing this command, emit the workflow event to trigger any configured hooks:
+
+```bash
+# Emit the spec.created event
+specify hooks emit spec.created \
+  --spec-id "$FEATURE_NAME" \
+  --task-id "$TASK_ID" \
+  -f "docs/prd/${FEATURE_NAME}.md"
+```
+
+This triggers any configured hooks in `.specify/hooks/hooks.yaml`. Common use cases:
+- Auto-notify stakeholders of new PRD
+- Generate architecture diagrams from spec
+- Trigger dependency analysis
+
+**Note**: If the `specify` CLI is not available or hooks are not configured, this step can be skipped without affecting the workflow.

--- a/templates/commands/jpspec/validate.md
+++ b/templates/commands/jpspec/validate.md
@@ -875,3 +875,24 @@ If a phase fails, fix the issue and re-run the command. The workflow will resume
 - `/jpspec:implement` - Implementation workflow
 - `/jpspec:plan` - Planning workflow
 - `backlog task` - Task management commands
+
+## Post-Completion: Emit Workflow Event
+
+After successfully completing this command (Phase 6 completes with PR creation), emit the workflow event to trigger any configured hooks:
+
+```bash
+# Emit the validate.completed event
+specify hooks emit validate.completed \
+  --spec-id "$FEATURE_NAME" \
+  --task-id "$TASK_ID" \
+  -f "docs/qa/${FEATURE_NAME}-qa-report.md" \
+  -f "docs/security/${FEATURE_NAME}-security-report.md"
+```
+
+This triggers any configured hooks in `.specify/hooks/hooks.yaml`. Common use cases:
+- Notify release management team
+- Update quality dashboards
+- Trigger deployment approval workflows
+- Archive test reports
+
+**Note**: If the `specify` CLI is not available or hooks are not configured, this step can be skipped without affecting the workflow.


### PR DESCRIPTION
## Summary

Completes task-227: Add event emission instructions to /jpspec slash commands

Adds "Post-Completion: Emit Workflow Event" section to all 7 `/jpspec` slash commands, enabling automatic hook triggering when agents complete workflow phases.

## Changes

### Commands Updated

| Command | Event Type |
|---------|------------|
| `/jpspec:assess` | `workflow.assessed` |
| `/jpspec:specify` | `spec.created` |
| `/jpspec:research` | `research.completed` |
| `/jpspec:plan` | `plan.created` |
| `/jpspec:implement` | `implement.completed` |
| `/jpspec:validate` | `validate.completed` |
| `/jpspec:operate` | `deploy.completed` |

### Files Modified

- 7 command files in `.claude/commands/jpspec/`
- 7 template files in `templates/commands/jpspec/`
- `docs/guides/hooks-quickstart.md` - Added "/jpspec Command Integration" section
- Lint and format fixes applied

## Test Plan

- [x] All 153 hook tests pass
- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] DCO sign-off included

🤖 Generated with [Claude Code](https://claude.com/claude-code)