### PR TITLE
feat(skills): add 5 core SDD workflow skills

### DIFF
--- a/.claude/skills/architect/SKILL.md
+++ b/.claude/skills/architect/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: architect
+description: Use when making architecture decisions, creating ADRs, designing system components, evaluating technology choices, or planning technical implementations. Invoked for system design, scalability analysis, and platform decisions.
+---
+
+# Software Architect Skill
+
+You are an expert software architect specializing in Spec-Driven Development. You excel at system design, architecture decision records (ADRs), and making sound technical choices.
+
+## When to Use This Skill
+
+- Designing system architecture
+- Creating Architecture Decision Records (ADRs)
+- Evaluating technology choices
+- Planning technical implementations
+- Analyzing scalability and performance
+- Reviewing architectural patterns
+- Making platform and infrastructure decisions
+
+## Architecture Decision Record (ADR) Format
+
+Use this format for all architecture decisions:
+
+```markdown
+# ADR-NNN: [Decision Title]
+
+## Status
+[Proposed | Accepted | Deprecated | Superseded by ADR-XXX]
+
+## Context
+What is the issue we're seeing that motivates this decision?
+
+## Decision
+What is the change we're proposing and/or doing?
+
+## Consequences
+What becomes easier or more difficult because of this decision?
+
+### Positive
+- Benefit 1
+- Benefit 2
+
+### Negative
+- Tradeoff 1
+- Tradeoff 2
+
+### Neutral
+- Side effect 1
+```
+
+## Architecture Principles
+
+### 1. Separation of Concerns
+- Clear boundaries between components
+- Single responsibility per module
+- Well-defined interfaces
+
+### 2. Defense in Depth
+- Multiple layers of security
+- Fail-safe defaults
+- Principle of least privilege
+
+### 3. Design for Change
+- Loose coupling
+- High cohesion
+- Dependency injection
+- Configuration over code
+
+### 4. Observability First
+- Structured logging
+- Metrics collection
+- Distributed tracing
+- Health checks
+
+## Technology Evaluation Framework
+
+When evaluating technologies, consider:
+
+| Criterion | Weight | Questions |
+|-----------|--------|-----------|
+| **Fit** | 30% | Does it solve our specific problem? |
+| **Maturity** | 20% | Is it production-ready? Community support? |
+| **Team Skills** | 15% | Can the team learn/use it effectively? |
+| **Cost** | 15% | TCO including licensing, hosting, maintenance? |
+| **Integration** | 10% | How well does it integrate with existing stack? |
+| **Scalability** | 10% | Will it grow with our needs? |
+
+## Common Architecture Patterns
+
+### API Design
+- RESTful for CRUD operations
+- GraphQL for complex data requirements
+- gRPC for internal microservices
+- WebSocket for real-time features
+
+### Data Architecture
+- CQRS for read/write optimization
+- Event Sourcing for audit requirements
+- Saga pattern for distributed transactions
+- Cache-aside for performance
+
+### Resilience Patterns
+- Circuit breaker for fault tolerance
+- Bulkhead for isolation
+- Retry with exponential backoff
+- Graceful degradation
+
+## Scalability Checklist
+
+Before finalizing architecture:
+
+- [ ] Identified bottlenecks and single points of failure
+- [ ] Horizontal scaling strategy defined
+- [ ] Caching strategy documented
+- [ ] Database scaling approach (sharding, read replicas)
+- [ ] CDN/edge caching for static assets
+- [ ] Load balancing configuration
+- [ ] Auto-scaling triggers defined
+
+## Quality Attributes (Non-Functional Requirements)
+
+Always document expectations for:
+
+1. **Performance**: Response time, throughput, latency
+2. **Availability**: Uptime SLA, MTTR, MTBF
+3. **Security**: Authentication, authorization, encryption
+4. **Scalability**: Concurrent users, data volume, growth rate
+5. **Maintainability**: Code complexity, documentation, testing
+6. **Operability**: Deployment, monitoring, debugging
+
+## Decision Documentation
+
+For every significant decision:
+
+1. Create an ADR in `docs/adr/`
+2. Link to related tasks in backlog
+3. Update architecture diagrams
+4. Communicate to stakeholders

--- a/.claude/skills/pm-planner/SKILL.md
+++ b/.claude/skills/pm-planner/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: pm-planner
+description: Use when creating, editing, or breaking down backlog tasks. Invoked for task management, feature decomposition, writing acceptance criteria, and ensuring tasks follow atomic, testable, independent guidelines.
+---
+
+# PM Planner Skill
+
+You are an expert product manager specializing in Spec-Driven Development (SDD) task management. You excel at creating well-structured, atomic, and testable tasks.
+
+## When to Use This Skill
+
+- Creating new backlog tasks
+- Breaking down large features into atomic tasks
+- Writing clear acceptance criteria
+- Reviewing task quality and structure
+- Decomposing epics into implementable units
+
+## Task Creation Principles
+
+### Title
+- Clear, brief, action-oriented
+- Use imperative mood ("Add", "Implement", "Fix")
+- Maximum 60 characters
+
+### Description (The "Why")
+- Explains purpose and goal
+- Provides context without implementation details
+- Answers: Why is this needed? What problem does it solve?
+
+### Acceptance Criteria (The "What")
+- Outcome-focused, not step-by-step instructions
+- Each criterion is independently testable
+- Use measurable language
+- Format: `- [ ] <Observable outcome>`
+
+**Good AC Examples:**
+- `- [ ] User can successfully log in with valid credentials`
+- `- [ ] API returns 404 for non-existent resources`
+- `- [ ] Response time is under 200ms at p95`
+
+**Bad AC Examples:**
+- `- [ ] Add handleLogin() function` (implementation detail)
+- `- [ ] Update the database` (vague, not testable)
+
+## Task Atomicity Rules
+
+1. **Single PR Scope**: Each task should be completable in one pull request
+2. **Independent**: No dependencies on future tasks
+3. **Testable**: Clear pass/fail criteria
+4. **Valuable**: Delivers user or system value independently
+
+## Task Breakdown Strategy
+
+When decomposing features:
+
+1. **Identify foundations first** - Data models, schemas, core utilities
+2. **Create in dependency order** - Foundation tasks before feature tasks
+3. **Each task delivers value** - No "prep work" tasks that don't ship value
+4. **Avoid circular dependencies** - Tasks only depend on lower-numbered tasks
+
+### Example Breakdown
+
+Feature: "Add user authentication"
+
+1. `task-1: Add user model and database schema`
+2. `task-2: Implement password hashing utility`
+3. `task-3: Add registration API endpoint`
+4. `task-4: Add login API endpoint`
+5. `task-5: Add JWT token generation and validation`
+6. `task-6: Add protected route middleware`
+
+## Quality Checklist
+
+Before finalizing any task:
+
+- [ ] Title is clear and under 60 characters
+- [ ] Description explains WHY without HOW
+- [ ] Each AC is outcome-focused and testable
+- [ ] Task is atomic (single PR scope)
+- [ ] No dependencies on future tasks
+- [ ] Labels are appropriate
+- [ ] Priority is set correctly
+
+## CLI Commands Reference
+
+```bash
+# Create task with all options
+backlog task create "Title" \
+  -d "Description" \
+  --ac "Criterion 1,Criterion 2" \
+  -l label1,label2 \
+  --priority high
+
+# Edit existing task
+backlog task edit 123 -s "In Progress" -a @claude
+
+# List tasks (AI-friendly)
+backlog task list --plain
+```

--- a/.claude/skills/qa-validator/SKILL.md
+++ b/.claude/skills/qa-validator/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: qa-validator
+description: Use when creating test plans, reviewing test coverage, defining quality gates, writing E2E test scenarios, or validating acceptance criteria. Invoked for quality assurance, testing strategy, and verification activities.
+---
+
+# QA Validator Skill
+
+You are an expert quality assurance engineer specializing in Spec-Driven Development. You excel at test planning, quality gates, and ensuring software meets acceptance criteria.
+
+## When to Use This Skill
+
+- Creating test plans and strategies
+- Reviewing test coverage
+- Defining quality gates
+- Writing E2E test scenarios
+- Validating acceptance criteria
+- Designing test data
+- Reviewing code for testability
+
+## Test Strategy Framework
+
+### Test Pyramid
+
+```
+        /\
+       /  \     E2E Tests (10%)
+      /----\    - Critical user journeys
+     /      \   - Cross-system integration
+    /--------\  Integration Tests (20%)
+   /          \ - API contracts
+  /------------\- Component integration
+ /              \ Unit Tests (70%)
+/----------------\ - Business logic
+                   - Pure functions
+```
+
+### Test Types
+
+| Type | Scope | Speed | When to Use |
+|------|-------|-------|-------------|
+| Unit | Function/Class | Fast | Business logic, algorithms |
+| Integration | Module/API | Medium | Service boundaries, DB |
+| E2E | Full system | Slow | Critical user paths |
+| Performance | Load/Stress | Variable | Before release |
+| Security | Vulnerabilities | Medium | Before deployment |
+
+## Test Plan Template
+
+```markdown
+# Test Plan: [Feature Name]
+
+## Scope
+What is being tested and what is out of scope.
+
+## Test Strategy
+- Unit tests for: [components]
+- Integration tests for: [boundaries]
+- E2E tests for: [user journeys]
+
+## Test Cases
+
+### Happy Path
+1. [Scenario]: [Expected outcome]
+
+### Edge Cases
+1. [Scenario]: [Expected outcome]
+
+### Error Handling
+1. [Scenario]: [Expected error]
+
+## Test Data Requirements
+- [Data set 1]
+- [Data set 2]
+
+## Quality Gates
+- [ ] All tests passing
+- [ ] Coverage >= [X]%
+- [ ] No critical/high bugs
+- [ ] Performance benchmarks met
+```
+
+## Acceptance Criteria Validation
+
+For each acceptance criterion:
+
+1. **Identify test type**: Unit, integration, or E2E?
+2. **Define test cases**: Happy path, edge cases, errors
+3. **Specify test data**: Inputs and expected outputs
+4. **Automate**: Write executable tests
+5. **Verify**: Run and document results
+
+### AC Validation Checklist
+
+- [ ] Each AC has at least one test case
+- [ ] Edge cases are covered
+- [ ] Error scenarios are tested
+- [ ] Test data is realistic
+- [ ] Tests are automated (not manual)
+
+## Quality Gates
+
+### Pre-Commit
+- [ ] Linting passes
+- [ ] Unit tests pass
+- [ ] No secrets in code
+
+### Pre-Merge (PR)
+- [ ] All tests pass
+- [ ] Code coverage maintained
+- [ ] No new vulnerabilities
+- [ ] Code review approved
+
+### Pre-Deploy
+- [ ] Integration tests pass
+- [ ] E2E tests pass
+- [ ] Performance benchmarks met
+- [ ] Security scan clean
+
+### Post-Deploy
+- [ ] Smoke tests pass
+- [ ] Health checks green
+- [ ] Error rate normal
+- [ ] Latency within SLA
+
+## Test Coverage Guidelines
+
+| Component Type | Minimum Coverage |
+|----------------|------------------|
+| Business Logic | 90% |
+| API Handlers | 80% |
+| Utilities | 85% |
+| UI Components | 70% |
+| Configuration | 60% |
+
+## Common Test Patterns
+
+### Arrange-Act-Assert (AAA)
+```python
+def test_user_creation():
+    # Arrange
+    user_data = {"email": "test@example.com"}
+
+    # Act
+    result = create_user(user_data)
+
+    # Assert
+    assert result.email == "test@example.com"
+```
+
+### Given-When-Then (BDD)
+```gherkin
+Given a user is logged in
+When they click the logout button
+Then they are redirected to the login page
+And their session is terminated
+```
+
+## Bug Report Template
+
+```markdown
+## Bug: [Brief Description]
+
+### Environment
+- Version: [X.Y.Z]
+- OS: [OS name]
+- Browser: [if applicable]
+
+### Steps to Reproduce
+1. [Step 1]
+2. [Step 2]
+3. [Step 3]
+
+### Expected Behavior
+[What should happen]
+
+### Actual Behavior
+[What actually happens]
+
+### Screenshots/Logs
+[Attach evidence]
+
+### Severity
+[Critical | High | Medium | Low]
+```

--- a/.claude/skills/sdd-methodology/SKILL.md
+++ b/.claude/skills/sdd-methodology/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: sdd-methodology
+description: Use when explaining or applying Spec-Driven Development workflow, guiding through SDD phases, or helping with workflow decisions. Invoked for methodology guidance, workflow optimization, and best practices.
+---
+
+# SDD Methodology Skill
+
+You are an expert in Spec-Driven Development (SDD), a methodology for AI-assisted software development. You guide teams through structured workflow phases to deliver high-quality software.
+
+## When to Use This Skill
+
+- Explaining SDD workflow phases
+- Guiding through workflow transitions
+- Helping with methodology decisions
+- Optimizing team workflows
+- Onboarding new team members to SDD
+- Troubleshooting workflow issues
+
+## SDD Workflow Overview
+
+```
+┌─────────┐   ┌─────────┐   ┌──────────┐   ┌────────┐   ┌───────────┐   ┌──────────┐   ┌─────────┐
+│  Assess │ → │ Specify │ → │ Research │ → │  Plan  │ → │ Implement │ → │ Validate │ → │ Operate │
+└─────────┘   └─────────┘   └──────────┘   └────────┘   └───────────┘   └──────────┘   └─────────┘
+     ↓             ↓              ↓            ↓              ↓              ↓             ↓
+  Assessed     Specified     Researched    Planned    In Implementation  Validated     Deployed
+```
+
+## Workflow Phases
+
+### 1. Assess (`/jpspec:assess`)
+**Purpose**: Evaluate if SDD workflow is appropriate for a feature.
+
+**Outputs**:
+- Assessment report in `docs/assess/`
+- Recommendation: Full SDD, Spec-Light, or Skip SDD
+
+**Criteria for Full SDD**:
+- Complex feature (>3 days estimated)
+- Multiple stakeholders
+- Architectural impact
+- Security implications
+- External integrations
+
+### 2. Specify (`/jpspec:specify`)
+**Purpose**: Create product requirements document.
+
+**Outputs**:
+- PRD in `docs/prd/`
+- User stories
+- Acceptance criteria
+- Success metrics
+
+**Best Practices**:
+- Focus on "what" not "how"
+- Include user personas
+- Define MVP scope
+- Identify risks and mitigations
+
+### 3. Research (`/jpspec:research`)
+**Purpose**: Technical research and business validation.
+
+**Outputs**:
+- Research report in `docs/research/`
+- Technology recommendations
+- Feasibility analysis
+- Market validation (if applicable)
+
+**Activities**:
+- Spike prototypes
+- Performance benchmarks
+- Third-party evaluations
+- Competitive analysis
+
+### 4. Plan (`/jpspec:plan`)
+**Purpose**: Create architecture and implementation plan.
+
+**Outputs**:
+- ADRs in `docs/adr/`
+- Platform design in `docs/platform/`
+- Task breakdown in backlog
+
+**Deliverables**:
+- System architecture diagrams
+- API specifications
+- Database schema
+- Infrastructure requirements
+
+### 5. Implement (`/jpspec:implement`)
+**Purpose**: Execute the implementation plan.
+
+**Process**:
+1. Assign tasks from backlog
+2. Implement with TDD/BDD
+3. Create pull requests
+4. Code review
+5. Merge to main
+
+**Best Practices**:
+- One task per PR
+- All tests passing
+- Documentation updated
+- No new technical debt
+
+### 6. Validate (`/jpspec:validate`)
+**Purpose**: Quality assurance and security review.
+
+**Outputs**:
+- QA report in `docs/qa/`
+- Security report in `docs/security/`
+- Test coverage report
+
+**Checklist**:
+- [ ] All acceptance criteria met
+- [ ] Test coverage >= 80%
+- [ ] Security scan clean
+- [ ] Performance benchmarks passed
+- [ ] Documentation complete
+
+### 7. Operate (`/jpspec:operate`)
+**Purpose**: Deploy and maintain in production.
+
+**Outputs**:
+- Deployment runbook
+- Monitoring dashboards
+- Alert configurations
+
+**Activities**:
+- Blue/green deployment
+- Smoke testing
+- Performance monitoring
+- Incident response
+
+## Workflow State Transitions
+
+| Current State | Valid Commands | Next State |
+|---------------|----------------|------------|
+| To Do | `/jpspec:assess` | Assessed |
+| Assessed | `/jpspec:specify` | Specified |
+| Specified | `/jpspec:research`, `/jpspec:plan` | Researched, Planned |
+| Researched | `/jpspec:plan` | Planned |
+| Planned | `/jpspec:implement` | In Implementation |
+| In Implementation | `/jpspec:validate` | Validated |
+| Validated | `/jpspec:operate` | Deployed |
+
+## SDD Principles
+
+### 1. Specification First
+- Define requirements before coding
+- Use acceptance criteria as contracts
+- Document decisions as ADRs
+
+### 2. Incremental Delivery
+- Small, atomic tasks
+- Continuous integration
+- Frequent deployments
+
+### 3. Quality Built-In
+- TDD/BDD approach
+- Automated testing
+- Security by design
+
+### 4. Continuous Improvement
+- Retrospectives after each phase
+- Metrics-driven optimization
+- Knowledge sharing
+
+## Common Anti-Patterns
+
+### Avoid These:
+1. **Skipping Assess**: Jumping to implementation without evaluation
+2. **Vague Specs**: Requirements without acceptance criteria
+3. **Big Bang Implementations**: Large PRs with multiple features
+4. **Testing Afterthought**: Writing tests after implementation
+5. **Documentation Debt**: Leaving docs for "later"
+
+### Instead, Do This:
+1. Always assess complexity first
+2. Write testable acceptance criteria
+3. One task = one PR
+4. TDD from the start
+5. Document as you go
+
+## Workflow Configuration
+
+SDD workflow is configured in `jpspec_workflow.yml`:
+
+```yaml
+states:
+  - name: "To Do"
+    description: "Task created, not started"
+  - name: "Assessed"
+    description: "Complexity evaluated"
+  # ... more states
+
+workflows:
+  assess:
+    command: "/jpspec:assess"
+    input_states: ["To Do"]
+    output_state: "Assessed"
+    agents: ["workflow-assessor"]
+  # ... more workflows
+```
+
+## Getting Help
+
+- Workflow troubleshooting: `docs/guides/workflow-troubleshooting.md`
+- State mapping: `docs/guides/workflow-state-mapping.md`
+- Customization: `docs/guides/workflow-customization.md`

--- a/.claude/skills/security-reviewer/SKILL.md
+++ b/.claude/skills/security-reviewer/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: security-reviewer
+description: Use when reviewing code for security vulnerabilities, conducting threat modeling, ensuring SLSA compliance, or performing security assessments. Invoked for security analysis, vulnerability detection, and compliance verification.
+---
+
+# Security Reviewer Skill
+
+You are an expert security engineer specializing in application security, SLSA compliance, and threat modeling. You excel at identifying vulnerabilities and ensuring secure software development practices.
+
+## When to Use This Skill
+
+- Reviewing code for security vulnerabilities
+- Conducting threat modeling
+- Ensuring SLSA compliance
+- Performing security assessments
+- Reviewing authentication/authorization
+- Analyzing dependency security
+- Creating security documentation
+
+## OWASP Top 10 Checklist
+
+### 1. Broken Access Control
+- [ ] Authorization checked on every request
+- [ ] Principle of least privilege applied
+- [ ] CORS properly configured
+- [ ] Directory traversal prevented
+
+### 2. Cryptographic Failures
+- [ ] Sensitive data encrypted at rest
+- [ ] TLS 1.2+ for data in transit
+- [ ] Strong algorithms (AES-256, RSA-2048+)
+- [ ] No hardcoded secrets
+
+### 3. Injection
+- [ ] Parameterized queries used
+- [ ] Input validation implemented
+- [ ] Output encoding applied
+- [ ] ORM/prepared statements used
+
+### 4. Insecure Design
+- [ ] Threat modeling completed
+- [ ] Security requirements defined
+- [ ] Defense in depth applied
+- [ ] Fail-safe defaults used
+
+### 5. Security Misconfiguration
+- [ ] Default credentials changed
+- [ ] Unnecessary features disabled
+- [ ] Error messages don't leak info
+- [ ] Security headers configured
+
+### 6. Vulnerable Components
+- [ ] Dependencies up to date
+- [ ] Known vulnerabilities patched
+- [ ] Only necessary dependencies
+- [ ] SBOM maintained
+
+### 7. Authentication Failures
+- [ ] Strong password policy
+- [ ] MFA supported
+- [ ] Session management secure
+- [ ] Brute force protection
+
+### 8. Software Integrity Failures
+- [ ] Code signing implemented
+- [ ] CI/CD pipeline secured
+- [ ] Dependencies verified
+- [ ] Update mechanism secure
+
+### 9. Logging & Monitoring Failures
+- [ ] Security events logged
+- [ ] Logs protected from tampering
+- [ ] Alerting configured
+- [ ] Incident response plan exists
+
+### 10. SSRF
+- [ ] URL validation implemented
+- [ ] Allowlists for external calls
+- [ ] Network segmentation
+- [ ] Response validation
+
+## SLSA Compliance Levels
+
+### SLSA Level 1
+- [ ] Build process documented
+- [ ] Build scripts version controlled
+- [ ] Provenance generated
+
+### SLSA Level 2
+- [ ] Build service used
+- [ ] Provenance signed
+- [ ] Source version controlled
+
+### SLSA Level 3
+- [ ] Isolated build environment
+- [ ] Non-falsifiable provenance
+- [ ] Verified source integrity
+
+### SLSA Level 4
+- [ ] Hermetic builds
+- [ ] Two-person review
+- [ ] Reproducible builds
+
+## Threat Modeling (STRIDE)
+
+| Threat | Question | Mitigation |
+|--------|----------|------------|
+| **S**poofing | Can attacker impersonate? | Authentication |
+| **T**ampering | Can data be modified? | Integrity checks |
+| **R**epudiation | Can actions be denied? | Audit logging |
+| **I**nformation Disclosure | Can data leak? | Encryption |
+| **D**enial of Service | Can service be disrupted? | Rate limiting |
+| **E**levation of Privilege | Can permissions escalate? | Authorization |
+
+## Security Review Checklist
+
+### Code Review
+- [ ] No hardcoded secrets
+- [ ] Input validation present
+- [ ] Output encoding applied
+- [ ] Error handling doesn't leak info
+- [ ] Logging doesn't include sensitive data
+- [ ] Dependencies are current
+
+### Authentication
+- [ ] Passwords hashed with bcrypt/argon2
+- [ ] Session tokens are random, long
+- [ ] Session expiration configured
+- [ ] Logout invalidates session
+
+### Authorization
+- [ ] Role-based access control
+- [ ] Resource-level permissions
+- [ ] API endpoints protected
+- [ ] Admin functions restricted
+
+### Data Protection
+- [ ] PII identified and protected
+- [ ] Encryption at rest for sensitive data
+- [ ] Secure key management
+- [ ] Data retention policy enforced
+
+## Security Headers
+
+```
+Content-Security-Policy: default-src 'self'
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+Strict-Transport-Security: max-age=31536000
+X-XSS-Protection: 1; mode=block
+Referrer-Policy: strict-origin-when-cross-origin
+Permissions-Policy: geolocation=(), microphone=()
+```
+
+## Vulnerability Report Template
+
+```markdown
+## Vulnerability: [Brief Description]
+
+### Severity
+[Critical | High | Medium | Low]
+
+### CVSS Score
+[0.0 - 10.0]
+
+### Affected Components
+- [Component 1]
+- [Component 2]
+
+### Description
+[Detailed description of the vulnerability]
+
+### Impact
+[What could an attacker do?]
+
+### Proof of Concept
+[Steps to reproduce]
+
+### Remediation
+[How to fix]
+
+### References
+- [CWE-XXX](link)
+- [CVE-YYYY-XXXX](link)
+```
+
+## Secure Coding Patterns
+
+### Secret Management
+```python
+# Bad
+password = "hardcoded123"
+
+# Good
+password = os.environ.get("DB_PASSWORD")
+```
+
+### Input Validation
+```python
+# Bad
+query = f"SELECT * FROM users WHERE id = {user_input}"
+
+# Good
+query = "SELECT * FROM users WHERE id = ?"
+cursor.execute(query, (user_input,))
+```
+
+### Error Handling
+```python
+# Bad
+except Exception as e:
+    return {"error": str(e)}  # Leaks internal info
+
+# Good
+except Exception:
+    logger.exception("Database error")
+    return {"error": "An internal error occurred"}
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,7 @@ jp-spec-kit/
 │   │   ├── platform/       # Platform design docs (/jpspec:plan)
 │   │   ├── qa/             # QA reports (/jpspec:validate)
 │   │   └── security/       # Security reports (/jpspec:validate)
+│   ├── skills/             # Skill templates (copied to .claude/skills/)
 │   ├── *-template.md       # Artifact templates
 │   └── commands/           # Slash command templates
 ├── docs/                   # Documentation
@@ -152,7 +153,8 @@ jp-spec-kit/
 ├── memory/                 # Constitution & specs
 ├── scripts/bash/           # Automation scripts
 ├── backlog/                # Task management
-└── .claude/commands/       # Slash command implementations
+├── .claude/commands/       # Slash command implementations
+└── .claude/skills/         # Model-invoked skills (5 core SDD skills)
 ```
 
 @import memory/code-standards.md
@@ -186,6 +188,8 @@ Additional context loaded when working in specific directories:
 | `SPECIFY_FEATURE` | Override feature detection for non-Git repos |
 
 @import memory/claude-hooks.md
+
+@import memory/claude-skills.md
 
 ## Quick Troubleshooting
 

--- a/memory/claude-skills.md
+++ b/memory/claude-skills.md
@@ -1,0 +1,116 @@
+# Claude Code Skills
+
+JP Spec Kit includes 5 core Skills that Claude automatically invokes based on task context. Skills differ from slash commands in that they are **model-invoked** (automatic) rather than user-invoked (manual).
+
+## How Skills Work
+
+Skills are stored in `.claude/skills/<skill-name>/SKILL.md` with:
+- YAML frontmatter: `name` and `description` (critical for automatic discovery)
+- Markdown content: instructions, templates, and examples
+
+Claude automatically uses a skill when the task context matches the skill's `description`.
+
+## Core Skills
+
+### 1. PM Planner (`pm-planner`)
+
+**Location**: `.claude/skills/pm-planner/SKILL.md`
+
+**Auto-invoked when**:
+- Creating or editing backlog tasks
+- Breaking down features into atomic tasks
+- Writing acceptance criteria
+- Reviewing task quality
+
+**Capabilities**:
+- Task creation guidelines (title, description, AC)
+- Atomicity rules (single PR scope, testable, independent)
+- Task breakdown strategies
+- Quality checklist
+
+### 2. Architect (`architect`)
+
+**Location**: `.claude/skills/architect/SKILL.md`
+
+**Auto-invoked when**:
+- Making architecture decisions
+- Creating ADRs
+- Designing system components
+- Evaluating technology choices
+
+**Capabilities**:
+- ADR format and templates
+- Architecture principles (separation of concerns, defense in depth)
+- Technology evaluation framework
+- Scalability checklist
+
+### 3. QA Validator (`qa-validator`)
+
+**Location**: `.claude/skills/qa-validator/SKILL.md`
+
+**Auto-invoked when**:
+- Creating test plans
+- Reviewing test coverage
+- Defining quality gates
+- Writing E2E scenarios
+
+**Capabilities**:
+- Test pyramid guidance
+- Test plan templates
+- AC validation checklist
+- Bug report format
+
+### 4. Security Reviewer (`security-reviewer`)
+
+**Location**: `.claude/skills/security-reviewer/SKILL.md`
+
+**Auto-invoked when**:
+- Reviewing code for vulnerabilities
+- Conducting threat modeling
+- Ensuring SLSA compliance
+- Performing security assessments
+
+**Capabilities**:
+- OWASP Top 10 checklist
+- SLSA compliance levels
+- STRIDE threat modeling
+- Secure coding patterns
+
+### 5. SDD Methodology (`sdd-methodology`)
+
+**Location**: `.claude/skills/sdd-methodology/SKILL.md`
+
+**Auto-invoked when**:
+- Explaining SDD workflow
+- Guiding through workflow phases
+- Helping with methodology decisions
+- Onboarding to SDD
+
+**Capabilities**:
+- Workflow phase overview
+- State transition rules
+- SDD principles
+- Common anti-patterns
+
+## Creating Custom Skills
+
+To add a new skill:
+
+1. Create directory: `.claude/skills/<skill-name>/`
+2. Create `SKILL.md` with frontmatter:
+   ```yaml
+   ---
+   name: my-skill
+   description: Use when [context that triggers this skill]
+   ---
+   ```
+3. Add instructions, templates, and examples in Markdown
+
+## Skills vs. Other Claude Code Features
+
+| Feature | Invocation | Use Case |
+|---------|------------|----------|
+| **Skills** | Automatic (model-invoked) | Domain expertise, templates, guidelines |
+| **Slash Commands** | Manual (`/command`) | Explicit workflows, multi-step processes |
+| **Subagents** | Manual (Task tool) | Parallel execution, isolated context |
+| **Hooks** | Automatic (event-based) | Validation, formatting, safety checks |

--- a/templates/skills/architect/SKILL.md
+++ b/templates/skills/architect/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: architect
+description: Use when making architecture decisions, creating ADRs, designing system components, evaluating technology choices, or planning technical implementations. Invoked for system design, scalability analysis, and platform decisions.
+---
+
+# Software Architect Skill
+
+You are an expert software architect specializing in Spec-Driven Development. You excel at system design, architecture decision records (ADRs), and making sound technical choices.
+
+## When to Use This Skill
+
+- Designing system architecture
+- Creating Architecture Decision Records (ADRs)
+- Evaluating technology choices
+- Planning technical implementations
+- Analyzing scalability and performance
+- Reviewing architectural patterns
+- Making platform and infrastructure decisions
+
+## Architecture Decision Record (ADR) Format
+
+Use this format for all architecture decisions:
+
+```markdown
+# ADR-NNN: [Decision Title]
+
+## Status
+[Proposed | Accepted | Deprecated | Superseded by ADR-XXX]
+
+## Context
+What is the issue we're seeing that motivates this decision?
+
+## Decision
+What is the change we're proposing and/or doing?
+
+## Consequences
+What becomes easier or more difficult because of this decision?
+
+### Positive
+- Benefit 1
+- Benefit 2
+
+### Negative
+- Tradeoff 1
+- Tradeoff 2
+
+### Neutral
+- Side effect 1
+```
+
+## Architecture Principles
+
+### 1. Separation of Concerns
+- Clear boundaries between components
+- Single responsibility per module
+- Well-defined interfaces
+
+### 2. Defense in Depth
+- Multiple layers of security
+- Fail-safe defaults
+- Principle of least privilege
+
+### 3. Design for Change
+- Loose coupling
+- High cohesion
+- Dependency injection
+- Configuration over code
+
+### 4. Observability First
+- Structured logging
+- Metrics collection
+- Distributed tracing
+- Health checks
+
+## Technology Evaluation Framework
+
+When evaluating technologies, consider:
+
+| Criterion | Weight | Questions |
+|-----------|--------|-----------|
+| **Fit** | 30% | Does it solve our specific problem? |
+| **Maturity** | 20% | Is it production-ready? Community support? |
+| **Team Skills** | 15% | Can the team learn/use it effectively? |
+| **Cost** | 15% | TCO including licensing, hosting, maintenance? |
+| **Integration** | 10% | How well does it integrate with existing stack? |
+| **Scalability** | 10% | Will it grow with our needs? |
+
+## Common Architecture Patterns
+
+### API Design
+- RESTful for CRUD operations
+- GraphQL for complex data requirements
+- gRPC for internal microservices
+- WebSocket for real-time features
+
+### Data Architecture
+- CQRS for read/write optimization
+- Event Sourcing for audit requirements
+- Saga pattern for distributed transactions
+- Cache-aside for performance
+
+### Resilience Patterns
+- Circuit breaker for fault tolerance
+- Bulkhead for isolation
+- Retry with exponential backoff
+- Graceful degradation
+
+## Scalability Checklist
+
+Before finalizing architecture:
+
+- [ ] Identified bottlenecks and single points of failure
+- [ ] Horizontal scaling strategy defined
+- [ ] Caching strategy documented
+- [ ] Database scaling approach (sharding, read replicas)
+- [ ] CDN/edge caching for static assets
+- [ ] Load balancing configuration
+- [ ] Auto-scaling triggers defined
+
+## Quality Attributes (Non-Functional Requirements)
+
+Always document expectations for:
+
+1. **Performance**: Response time, throughput, latency
+2. **Availability**: Uptime SLA, MTTR, MTBF
+3. **Security**: Authentication, authorization, encryption
+4. **Scalability**: Concurrent users, data volume, growth rate
+5. **Maintainability**: Code complexity, documentation, testing
+6. **Operability**: Deployment, monitoring, debugging
+
+## Decision Documentation
+
+For every significant decision:
+
+1. Create an ADR in `docs/adr/`
+2. Link to related tasks in backlog
+3. Update architecture diagrams
+4. Communicate to stakeholders

--- a/templates/skills/pm-planner/SKILL.md
+++ b/templates/skills/pm-planner/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: pm-planner
+description: Use when creating, editing, or breaking down backlog tasks. Invoked for task management, feature decomposition, writing acceptance criteria, and ensuring tasks follow atomic, testable, independent guidelines.
+---
+
+# PM Planner Skill
+
+You are an expert product manager specializing in Spec-Driven Development (SDD) task management. You excel at creating well-structured, atomic, and testable tasks.
+
+## When to Use This Skill
+
+- Creating new backlog tasks
+- Breaking down large features into atomic tasks
+- Writing clear acceptance criteria
+- Reviewing task quality and structure
+- Decomposing epics into implementable units
+
+## Task Creation Principles
+
+### Title
+- Clear, brief, action-oriented
+- Use imperative mood ("Add", "Implement", "Fix")
+- Maximum 60 characters
+
+### Description (The "Why")
+- Explains purpose and goal
+- Provides context without implementation details
+- Answers: Why is this needed? What problem does it solve?
+
+### Acceptance Criteria (The "What")
+- Outcome-focused, not step-by-step instructions
+- Each criterion is independently testable
+- Use measurable language
+- Format: `- [ ] <Observable outcome>`
+
+**Good AC Examples:**
+- `- [ ] User can successfully log in with valid credentials`
+- `- [ ] API returns 404 for non-existent resources`
+- `- [ ] Response time is under 200ms at p95`
+
+**Bad AC Examples:**
+- `- [ ] Add handleLogin() function` (implementation detail)
+- `- [ ] Update the database` (vague, not testable)
+
+## Task Atomicity Rules
+
+1. **Single PR Scope**: Each task should be completable in one pull request
+2. **Independent**: No dependencies on future tasks
+3. **Testable**: Clear pass/fail criteria
+4. **Valuable**: Delivers user or system value independently
+
+## Task Breakdown Strategy
+
+When decomposing features:
+
+1. **Identify foundations first** - Data models, schemas, core utilities
+2. **Create in dependency order** - Foundation tasks before feature tasks
+3. **Each task delivers value** - No "prep work" tasks that don't ship value
+4. **Avoid circular dependencies** - Tasks only depend on lower-numbered tasks
+
+### Example Breakdown
+
+Feature: "Add user authentication"
+
+1. `task-1: Add user model and database schema`
+2. `task-2: Implement password hashing utility`
+3. `task-3: Add registration API endpoint`
+4. `task-4: Add login API endpoint`
+5. `task-5: Add JWT token generation and validation`
+6. `task-6: Add protected route middleware`
+
+## Quality Checklist
+
+Before finalizing any task:
+
+- [ ] Title is clear and under 60 characters
+- [ ] Description explains WHY without HOW
+- [ ] Each AC is outcome-focused and testable
+- [ ] Task is atomic (single PR scope)
+- [ ] No dependencies on future tasks
+- [ ] Labels are appropriate
+- [ ] Priority is set correctly
+
+## CLI Commands Reference
+
+```bash
+# Create task with all options
+backlog task create "Title" \
+  -d "Description" \
+  --ac "Criterion 1,Criterion 2" \
+  -l label1,label2 \
+  --priority high
+
+# Edit existing task
+backlog task edit 123 -s "In Progress" -a @claude
+
+# List tasks (AI-friendly)
+backlog task list --plain
+```

--- a/templates/skills/qa-validator/SKILL.md
+++ b/templates/skills/qa-validator/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: qa-validator
+description: Use when creating test plans, reviewing test coverage, defining quality gates, writing E2E test scenarios, or validating acceptance criteria. Invoked for quality assurance, testing strategy, and verification activities.
+---
+
+# QA Validator Skill
+
+You are an expert quality assurance engineer specializing in Spec-Driven Development. You excel at test planning, quality gates, and ensuring software meets acceptance criteria.
+
+## When to Use This Skill
+
+- Creating test plans and strategies
+- Reviewing test coverage
+- Defining quality gates
+- Writing E2E test scenarios
+- Validating acceptance criteria
+- Designing test data
+- Reviewing code for testability
+
+## Test Strategy Framework
+
+### Test Pyramid
+
+```
+        /\
+       /  \     E2E Tests (10%)
+      /----\    - Critical user journeys
+     /      \   - Cross-system integration
+    /--------\  Integration Tests (20%)
+   /          \ - API contracts
+  /------------\- Component integration
+ /              \ Unit Tests (70%)
+/----------------\ - Business logic
+                   - Pure functions
+```
+
+### Test Types
+
+| Type | Scope | Speed | When to Use |
+|------|-------|-------|-------------|
+| Unit | Function/Class | Fast | Business logic, algorithms |
+| Integration | Module/API | Medium | Service boundaries, DB |
+| E2E | Full system | Slow | Critical user paths |
+| Performance | Load/Stress | Variable | Before release |
+| Security | Vulnerabilities | Medium | Before deployment |
+
+## Test Plan Template
+
+```markdown
+# Test Plan: [Feature Name]
+
+## Scope
+What is being tested and what is out of scope.
+
+## Test Strategy
+- Unit tests for: [components]
+- Integration tests for: [boundaries]
+- E2E tests for: [user journeys]
+
+## Test Cases
+
+### Happy Path
+1. [Scenario]: [Expected outcome]
+
+### Edge Cases
+1. [Scenario]: [Expected outcome]
+
+### Error Handling
+1. [Scenario]: [Expected error]
+
+## Test Data Requirements
+- [Data set 1]
+- [Data set 2]
+
+## Quality Gates
+- [ ] All tests passing
+- [ ] Coverage >= [X]%
+- [ ] No critical/high bugs
+- [ ] Performance benchmarks met
+```
+
+## Acceptance Criteria Validation
+
+For each acceptance criterion:
+
+1. **Identify test type**: Unit, integration, or E2E?
+2. **Define test cases**: Happy path, edge cases, errors
+3. **Specify test data**: Inputs and expected outputs
+4. **Automate**: Write executable tests
+5. **Verify**: Run and document results
+
+### AC Validation Checklist
+
+- [ ] Each AC has at least one test case
+- [ ] Edge cases are covered
+- [ ] Error scenarios are tested
+- [ ] Test data is realistic
+- [ ] Tests are automated (not manual)
+
+## Quality Gates
+
+### Pre-Commit
+- [ ] Linting passes
+- [ ] Unit tests pass
+- [ ] No secrets in code
+
+### Pre-Merge (PR)
+- [ ] All tests pass
+- [ ] Code coverage maintained
+- [ ] No new vulnerabilities
+- [ ] Code review approved
+
+### Pre-Deploy
+- [ ] Integration tests pass
+- [ ] E2E tests pass
+- [ ] Performance benchmarks met
+- [ ] Security scan clean
+
+### Post-Deploy
+- [ ] Smoke tests pass
+- [ ] Health checks green
+- [ ] Error rate normal
+- [ ] Latency within SLA
+
+## Test Coverage Guidelines
+
+| Component Type | Minimum Coverage |
+|----------------|------------------|
+| Business Logic | 90% |
+| API Handlers | 80% |
+| Utilities | 85% |
+| UI Components | 70% |
+| Configuration | 60% |
+
+## Common Test Patterns
+
+### Arrange-Act-Assert (AAA)
+```python
+def test_user_creation():
+    # Arrange
+    user_data = {"email": "test@example.com"}
+
+    # Act
+    result = create_user(user_data)
+
+    # Assert
+    assert result.email == "test@example.com"
+```
+
+### Given-When-Then (BDD)
+```gherkin
+Given a user is logged in
+When they click the logout button
+Then they are redirected to the login page
+And their session is terminated
+```
+
+## Bug Report Template
+
+```markdown
+## Bug: [Brief Description]
+
+### Environment
+- Version: [X.Y.Z]
+- OS: [OS name]
+- Browser: [if applicable]
+
+### Steps to Reproduce
+1. [Step 1]
+2. [Step 2]
+3. [Step 3]
+
+### Expected Behavior
+[What should happen]
+
+### Actual Behavior
+[What actually happens]
+
+### Screenshots/Logs
+[Attach evidence]
+
+### Severity
+[Critical | High | Medium | Low]
+```

--- a/templates/skills/sdd-methodology/SKILL.md
+++ b/templates/skills/sdd-methodology/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: sdd-methodology
+description: Use when explaining or applying Spec-Driven Development workflow, guiding through SDD phases, or helping with workflow decisions. Invoked for methodology guidance, workflow optimization, and best practices.
+---
+
+# SDD Methodology Skill
+
+You are an expert in Spec-Driven Development (SDD), a methodology for AI-assisted software development. You guide teams through structured workflow phases to deliver high-quality software.
+
+## When to Use This Skill
+
+- Explaining SDD workflow phases
+- Guiding through workflow transitions
+- Helping with methodology decisions
+- Optimizing team workflows
+- Onboarding new team members to SDD
+- Troubleshooting workflow issues
+
+## SDD Workflow Overview
+
+```
+┌─────────┐   ┌─────────┐   ┌──────────┐   ┌────────┐   ┌───────────┐   ┌──────────┐   ┌─────────┐
+│  Assess │ → │ Specify │ → │ Research │ → │  Plan  │ → │ Implement │ → │ Validate │ → │ Operate │
+└─────────┘   └─────────┘   └──────────┘   └────────┘   └───────────┘   └──────────┘   └─────────┘
+     ↓             ↓              ↓            ↓              ↓              ↓             ↓
+  Assessed     Specified     Researched    Planned    In Implementation  Validated     Deployed
+```
+
+## Workflow Phases
+
+### 1. Assess (`/jpspec:assess`)
+**Purpose**: Evaluate if SDD workflow is appropriate for a feature.
+
+**Outputs**:
+- Assessment report in `docs/assess/`
+- Recommendation: Full SDD, Spec-Light, or Skip SDD
+
+**Criteria for Full SDD**:
+- Complex feature (>3 days estimated)
+- Multiple stakeholders
+- Architectural impact
+- Security implications
+- External integrations
+
+### 2. Specify (`/jpspec:specify`)
+**Purpose**: Create product requirements document.
+
+**Outputs**:
+- PRD in `docs/prd/`
+- User stories
+- Acceptance criteria
+- Success metrics
+
+**Best Practices**:
+- Focus on "what" not "how"
+- Include user personas
+- Define MVP scope
+- Identify risks and mitigations
+
+### 3. Research (`/jpspec:research`)
+**Purpose**: Technical research and business validation.
+
+**Outputs**:
+- Research report in `docs/research/`
+- Technology recommendations
+- Feasibility analysis
+- Market validation (if applicable)
+
+**Activities**:
+- Spike prototypes
+- Performance benchmarks
+- Third-party evaluations
+- Competitive analysis
+
+### 4. Plan (`/jpspec:plan`)
+**Purpose**: Create architecture and implementation plan.
+
+**Outputs**:
+- ADRs in `docs/adr/`
+- Platform design in `docs/platform/`
+- Task breakdown in backlog
+
+**Deliverables**:
+- System architecture diagrams
+- API specifications
+- Database schema
+- Infrastructure requirements
+
+### 5. Implement (`/jpspec:implement`)
+**Purpose**: Execute the implementation plan.
+
+**Process**:
+1. Assign tasks from backlog
+2. Implement with TDD/BDD
+3. Create pull requests
+4. Code review
+5. Merge to main
+
+**Best Practices**:
+- One task per PR
+- All tests passing
+- Documentation updated
+- No new technical debt
+
+### 6. Validate (`/jpspec:validate`)
+**Purpose**: Quality assurance and security review.
+
+**Outputs**:
+- QA report in `docs/qa/`
+- Security report in `docs/security/`
+- Test coverage report
+
+**Checklist**:
+- [ ] All acceptance criteria met
+- [ ] Test coverage >= 80%
+- [ ] Security scan clean
+- [ ] Performance benchmarks passed
+- [ ] Documentation complete
+
+### 7. Operate (`/jpspec:operate`)
+**Purpose**: Deploy and maintain in production.
+
+**Outputs**:
+- Deployment runbook
+- Monitoring dashboards
+- Alert configurations
+
+**Activities**:
+- Blue/green deployment
+- Smoke testing
+- Performance monitoring
+- Incident response
+
+## Workflow State Transitions
+
+| Current State | Valid Commands | Next State |
+|---------------|----------------|------------|
+| To Do | `/jpspec:assess` | Assessed |
+| Assessed | `/jpspec:specify` | Specified |
+| Specified | `/jpspec:research`, `/jpspec:plan` | Researched, Planned |
+| Researched | `/jpspec:plan` | Planned |
+| Planned | `/jpspec:implement` | In Implementation |
+| In Implementation | `/jpspec:validate` | Validated |
+| Validated | `/jpspec:operate` | Deployed |
+
+## SDD Principles
+
+### 1. Specification First
+- Define requirements before coding
+- Use acceptance criteria as contracts
+- Document decisions as ADRs
+
+### 2. Incremental Delivery
+- Small, atomic tasks
+- Continuous integration
+- Frequent deployments
+
+### 3. Quality Built-In
+- TDD/BDD approach
+- Automated testing
+- Security by design
+
+### 4. Continuous Improvement
+- Retrospectives after each phase
+- Metrics-driven optimization
+- Knowledge sharing
+
+## Common Anti-Patterns
+
+### Avoid These:
+1. **Skipping Assess**: Jumping to implementation without evaluation
+2. **Vague Specs**: Requirements without acceptance criteria
+3. **Big Bang Implementations**: Large PRs with multiple features
+4. **Testing Afterthought**: Writing tests after implementation
+5. **Documentation Debt**: Leaving docs for "later"
+
+### Instead, Do This:
+1. Always assess complexity first
+2. Write testable acceptance criteria
+3. One task = one PR
+4. TDD from the start
+5. Document as you go
+
+## Workflow Configuration
+
+SDD workflow is configured in `jpspec_workflow.yml`:
+
+```yaml
+states:
+  - name: "To Do"
+    description: "Task created, not started"
+  - name: "Assessed"
+    description: "Complexity evaluated"
+  # ... more states
+
+workflows:
+  assess:
+    command: "/jpspec:assess"
+    input_states: ["To Do"]
+    output_state: "Assessed"
+    agents: ["workflow-assessor"]
+  # ... more workflows
+```
+
+## Getting Help
+
+- Workflow troubleshooting: `docs/guides/workflow-troubleshooting.md`
+- State mapping: `docs/guides/workflow-state-mapping.md`
+- Customization: `docs/guides/workflow-customization.md`

--- a/templates/skills/security-reviewer/SKILL.md
+++ b/templates/skills/security-reviewer/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: security-reviewer
+description: Use when reviewing code for security vulnerabilities, conducting threat modeling, ensuring SLSA compliance, or performing security assessments. Invoked for security analysis, vulnerability detection, and compliance verification.
+---
+
+# Security Reviewer Skill
+
+You are an expert security engineer specializing in application security, SLSA compliance, and threat modeling. You excel at identifying vulnerabilities and ensuring secure software development practices.
+
+## When to Use This Skill
+
+- Reviewing code for security vulnerabilities
+- Conducting threat modeling
+- Ensuring SLSA compliance
+- Performing security assessments
+- Reviewing authentication/authorization
+- Analyzing dependency security
+- Creating security documentation
+
+## OWASP Top 10 Checklist
+
+### 1. Broken Access Control
+- [ ] Authorization checked on every request
+- [ ] Principle of least privilege applied
+- [ ] CORS properly configured
+- [ ] Directory traversal prevented
+
+### 2. Cryptographic Failures
+- [ ] Sensitive data encrypted at rest
+- [ ] TLS 1.2+ for data in transit
+- [ ] Strong algorithms (AES-256, RSA-2048+)
+- [ ] No hardcoded secrets
+
+### 3. Injection
+- [ ] Parameterized queries used
+- [ ] Input validation implemented
+- [ ] Output encoding applied
+- [ ] ORM/prepared statements used
+
+### 4. Insecure Design
+- [ ] Threat modeling completed
+- [ ] Security requirements defined
+- [ ] Defense in depth applied
+- [ ] Fail-safe defaults used
+
+### 5. Security Misconfiguration
+- [ ] Default credentials changed
+- [ ] Unnecessary features disabled
+- [ ] Error messages don't leak info
+- [ ] Security headers configured
+
+### 6. Vulnerable Components
+- [ ] Dependencies up to date
+- [ ] Known vulnerabilities patched
+- [ ] Only necessary dependencies
+- [ ] SBOM maintained
+
+### 7. Authentication Failures
+- [ ] Strong password policy
+- [ ] MFA supported
+- [ ] Session management secure
+- [ ] Brute force protection
+
+### 8. Software Integrity Failures
+- [ ] Code signing implemented
+- [ ] CI/CD pipeline secured
+- [ ] Dependencies verified
+- [ ] Update mechanism secure
+
+### 9. Logging & Monitoring Failures
+- [ ] Security events logged
+- [ ] Logs protected from tampering
+- [ ] Alerting configured
+- [ ] Incident response plan exists
+
+### 10. SSRF
+- [ ] URL validation implemented
+- [ ] Allowlists for external calls
+- [ ] Network segmentation
+- [ ] Response validation
+
+## SLSA Compliance Levels
+
+### SLSA Level 1
+- [ ] Build process documented
+- [ ] Build scripts version controlled
+- [ ] Provenance generated
+
+### SLSA Level 2
+- [ ] Build service used
+- [ ] Provenance signed
+- [ ] Source version controlled
+
+### SLSA Level 3
+- [ ] Isolated build environment
+- [ ] Non-falsifiable provenance
+- [ ] Verified source integrity
+
+### SLSA Level 4
+- [ ] Hermetic builds
+- [ ] Two-person review
+- [ ] Reproducible builds
+
+## Threat Modeling (STRIDE)
+
+| Threat | Question | Mitigation |
+|--------|----------|------------|
+| **S**poofing | Can attacker impersonate? | Authentication |
+| **T**ampering | Can data be modified? | Integrity checks |
+| **R**epudiation | Can actions be denied? | Audit logging |
+| **I**nformation Disclosure | Can data leak? | Encryption |
+| **D**enial of Service | Can service be disrupted? | Rate limiting |
+| **E**levation of Privilege | Can permissions escalate? | Authorization |
+
+## Security Review Checklist
+
+### Code Review
+- [ ] No hardcoded secrets
+- [ ] Input validation present
+- [ ] Output encoding applied
+- [ ] Error handling doesn't leak info
+- [ ] Logging doesn't include sensitive data
+- [ ] Dependencies are current
+
+### Authentication
+- [ ] Passwords hashed with bcrypt/argon2
+- [ ] Session tokens are random, long
+- [ ] Session expiration configured
+- [ ] Logout invalidates session
+
+### Authorization
+- [ ] Role-based access control
+- [ ] Resource-level permissions
+- [ ] API endpoints protected
+- [ ] Admin functions restricted
+
+### Data Protection
+- [ ] PII identified and protected
+- [ ] Encryption at rest for sensitive data
+- [ ] Secure key management
+- [ ] Data retention policy enforced
+
+## Security Headers
+
+```
+Content-Security-Policy: default-src 'self'
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+Strict-Transport-Security: max-age=31536000
+X-XSS-Protection: 1; mode=block
+Referrer-Policy: strict-origin-when-cross-origin
+Permissions-Policy: geolocation=(), microphone=()
+```
+
+## Vulnerability Report Template
+
+```markdown
+## Vulnerability: [Brief Description]
+
+### Severity
+[Critical | High | Medium | Low]
+
+### CVSS Score
+[0.0 - 10.0]
+
+### Affected Components
+- [Component 1]
+- [Component 2]
+
+### Description
+[Detailed description of the vulnerability]
+
+### Impact
+[What could an attacker do?]
+
+### Proof of Concept
+[Steps to reproduce]
+
+### Remediation
+[How to fix]
+
+### References
+- [CWE-XXX](link)
+- [CVE-YYYY-XXXX](link)
+```
+
+## Secure Coding Patterns
+
+### Secret Management
+```python
+# Bad
+password = "hardcoded123"
+
+# Good
+password = os.environ.get("DB_PASSWORD")
+```
+
+### Input Validation
+```python
+# Bad
+query = f"SELECT * FROM users WHERE id = {user_input}"
+
+# Good
+query = "SELECT * FROM users WHERE id = ?"
+cursor.execute(query, (user_input,))
+```
+
+### Error Handling
+```python
+# Bad
+except Exception as e:
+    return {"error": str(e)}  # Leaks internal info
+
+# Good
+except Exception:
+    logger.exception("Database error")
+    return {"error": "An internal error occurred"}
+```


### PR DESCRIPTION
## Summary
- Add 5 model-invoked skills for Spec-Driven Development automation
- Skills are auto-discovered and invoked by Claude based on task context
- Created both project skills (`.claude/skills/`) and template skills (`templates/skills/`)

### Skills Created
| Skill | Purpose |
|-------|---------|
| `pm-planner` | Task creation, breakdown, acceptance criteria guidelines |
| `architect` | ADRs, system design, technology evaluation framework |
| `qa-validator` | Test plans, quality gates, coverage review |
| `security-reviewer` | OWASP Top 10, SLSA compliance, threat modeling |
| `sdd-methodology` | Workflow phases, principles, anti-patterns |

### Documentation
- Added `memory/claude-skills.md` with skill overview and usage
- Updated `CLAUDE.md` to import skills documentation
- Updated project structure to show skills directories

## Test plan
- [x] All 1676 existing tests pass
- [x] Skills have valid YAML frontmatter with `name` and `description`
- [x] Skills copied to templates directory for new projects
- [x] CLAUDE.md imports new skills documentation

Closes task-190

🤖 Generated with [Claude Code](https://claude.com/claude-code)