### PR TITLE
feat(security): add permissions.deny rules for sensitive files

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,26 @@
 {
   "description": "Claude Code settings for JP Spec Kit project",
   "projectName": "JP Spec Kit",
+  "permissions": {
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(./secrets/**)",
+      "Read(./**/.env)",
+      "Read(./**/.env.*)",
+      "Write(./CLAUDE.md)",
+      "Write(./memory/constitution.md)",
+      "Write(./uv.lock)",
+      "Write(./package-lock.json)",
+      "Write(./yarn.lock)",
+      "Bash(sudo:*)",
+      "Bash(rm:-rf:*)",
+      "Bash(rm:-fr:*)",
+      "Bash(chmod:777:*)",
+      "Bash(curl:|:*)",
+      "Bash(wget:|:*)"
+    ]
+  },
   "allowedTools": [
     "Read",
     "Write",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,8 @@ Additional context loaded when working in specific directories:
 
 @import memory/claude-hooks.md
 
+@import memory/claude-permissions.md
+
 ## Quick Troubleshooting
 
 ```bash

--- a/memory/claude-permissions.md
+++ b/memory/claude-permissions.md
@@ -1,0 +1,93 @@
+# Claude Code Permissions
+
+JP Spec Kit uses Claude Code's `permissions.deny` feature to prevent accidental exposure of sensitive files and protect critical configuration.
+
+## Denied Operations
+
+The following operations are blocked by `.claude/settings.json`:
+
+### Read Protection (Sensitive Data)
+
+| Pattern | Protects |
+|---------|----------|
+| `Read(./.env)` | Root environment file |
+| `Read(./.env.*)` | All env variants (.env.local, .env.production) |
+| `Read(./secrets/**)` | Secrets directory |
+| `Read(./**/.env)` | Nested .env files |
+| `Read(./**/.env.*)` | Nested env variants |
+
+### Write Protection (Critical Files)
+
+| Pattern | Protects |
+|---------|----------|
+| `Write(./CLAUDE.md)` | Project Claude configuration |
+| `Write(./memory/constitution.md)` | Constitutional principles |
+| `Write(./uv.lock)` | Python dependency lock |
+| `Write(./package-lock.json)` | NPM dependency lock |
+| `Write(./yarn.lock)` | Yarn dependency lock |
+
+### Bash Protection (Dangerous Commands)
+
+| Pattern | Blocks |
+|---------|--------|
+| `Bash(sudo:*)` | All sudo commands |
+| `Bash(rm:-rf:*)` | Recursive force delete |
+| `Bash(rm:-fr:*)` | Force recursive delete |
+| `Bash(chmod:777:*)` | World-writable permissions |
+| `Bash(curl:\|:*)` | Piped curl commands |
+| `Bash(wget:\|:*)` | Piped wget commands |
+
+## Why These Rules?
+
+### Sensitive Data Protection
+- `.env` files often contain API keys, database credentials, and secrets
+- The `secrets/` directory may contain certificates, keys, or tokens
+- Accidental reading could expose these in Claude's context or logs
+
+### Critical File Protection
+- `CLAUDE.md` controls Claude's behavior - modification could alter project configuration
+- `constitution.md` contains project principles that should be changed deliberately
+- Lock files maintain dependency integrity and should be managed by package managers
+
+### Dangerous Command Protection
+- `sudo` can bypass security controls
+- `rm -rf` can delete entire directories irreversibly
+- `chmod 777` creates security vulnerabilities
+- Piped `curl`/`wget` can execute untrusted code
+
+## Bypassing Permissions
+
+If you need to perform a denied operation:
+
+1. **For reads**: Use the file viewer in your IDE or `cat` in a separate terminal
+2. **For writes**: Manually edit the file outside Claude Code
+3. **For bash**: Run the command directly in your terminal
+
+## Customizing Permissions
+
+Edit `.claude/settings.json` to modify rules:
+
+```json
+{
+  "permissions": {
+    "deny": [
+      "Read(./.env)",
+      "Write(./CLAUDE.md)"
+    ]
+  }
+}
+```
+
+### Pattern Syntax
+
+- `Tool(pattern)`: Deny specific tool with glob pattern
+- `*` matches any characters
+- `**` matches nested directories
+- Patterns are relative to project root
+
+## Security Best Practices
+
+1. **Never commit secrets**: Use `.gitignore` for `.env` files
+2. **Review permission changes**: Any modification to deny rules should be reviewed
+3. **Fail-safe defaults**: Err on the side of denying access
+4. **Audit regularly**: Review what operations are being denied


### PR DESCRIPTION
## Summary
- Add `permissions.deny` configuration to `.claude/settings.json`
- Protects sensitive files from accidental exposure
- Blocks dangerous commands that could harm the system

### Permission Rules Added

| Category | Rules |
|----------|-------|
| **Read Protection** | `.env`, `.env.*`, `secrets/**` |
| **Write Protection** | `CLAUDE.md`, `memory/constitution.md`, lock files |
| **Bash Protection** | `sudo`, `rm -rf`, `chmod 777`, piped `curl`/`wget` |

### Documentation
- Added `memory/claude-permissions.md` with full documentation
- Explains each rule and why it's needed
- Provides bypass instructions for legitimate use cases
- Updated `CLAUDE.md` to import permissions documentation

## Test plan
- [x] All 1676 existing tests pass
- [x] settings.json is valid JSON
- [x] Documentation explains all rules clearly
- [x] CLAUDE.md imports new permissions documentation

Closes task-184

🤖 Generated with [Claude Code](https://claude.com/claude-code)