### PR TITLE
feat(hooks): Agent event tracking and auto-emission for /jpspec commands

### DIFF
--- a/.claude/hooks/permission-auto-approve.py
+++ b/.claude/hooks/permission-auto-approve.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: Auto-approve safe read operations.
+
+This hook automatically approves Read operations in safe directories
+to reduce friction for common documentation and task management operations.
+
+Approved Directories:
+- docs/           - Documentation files
+- backlog/        - Task management files
+- templates/      - Template files
+- .specify/       - JP Spec Kit configuration
+
+Also approves:
+- Bash commands using the 'backlog' CLI tool
+
+All other operations require normal approval flow.
+"""
+
+import json
+import re
+import sys
+
+# Directories where Read is always safe
+SAFE_READ_DIRECTORIES = [
+    "docs/",
+    "backlog/",
+    "templates/",
+    ".specify/",
+    ".github/prompts/",  # GitHub prompts for slash commands
+    "memory/",  # Memory/constitution files
+]
+
+# Bash command patterns that are safe to auto-approve
+SAFE_BASH_PATTERNS = [
+    r"^backlog\s+",  # Any backlog CLI command
+    r"^specify\s+hooks\s+(list|audit|validate)",  # Read-only hooks commands
+    r"^git\s+status",  # Git status is read-only
+    r"^git\s+log\b",  # Git log is read-only
+    r"^git\s+diff\b",  # Git diff is read-only
+    r"^git\s+branch\s+--?(list|show)",  # Git branch listing
+]
+
+
+def allow(reason: str = "") -> None:
+    """Output allow decision and exit."""
+    result = {"decision": "allow"}
+    if reason:
+        result["reason"] = reason
+    print(json.dumps(result))
+    sys.exit(0)
+
+
+def pass_through(reason: str = "") -> None:
+    """Let the default permission flow handle this."""
+    result = {"decision": "pass"}
+    if reason:
+        result["reason"] = reason
+    print(json.dumps(result))
+    sys.exit(0)
+
+
+def is_safe_read_path(file_path: str) -> bool:
+    """Check if the file path is in a safe directory for reading."""
+    # Normalize path - remove leading ./ but keep leading . for hidden dirs
+    normalized = file_path
+    if normalized.startswith("./"):
+        normalized = normalized[2:]
+    normalized = normalized.lstrip("/")
+
+    for safe_dir in SAFE_READ_DIRECTORIES:
+        if normalized.startswith(safe_dir):
+            return True
+
+    return False
+
+
+def is_safe_bash_command(command: str) -> bool:
+    """Check if the bash command is safe to auto-approve."""
+    # Trim and normalize command
+    cmd = command.strip()
+
+    for pattern in SAFE_BASH_PATTERNS:
+        if re.match(pattern, cmd, re.IGNORECASE):
+            return True
+
+    return False
+
+
+def main():
+    """Main entry point for the hook."""
+    # Read JSON input from stdin
+    try:
+        input_data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        pass_through("Invalid JSON input")
+        return
+
+    # Get tool name and input
+    tool_name = input_data.get("tool_name", "")
+    tool_input = input_data.get("tool_input", {})
+
+    # Handle Read tool
+    if tool_name == "Read":
+        file_path = tool_input.get("file_path", "")
+        if is_safe_read_path(file_path):
+            allow(f"Auto-approved Read in safe directory: {file_path}")
+            return
+
+    # Handle Bash tool
+    if tool_name == "Bash":
+        command = tool_input.get("command", "")
+        if is_safe_bash_command(command):
+            allow(f"Auto-approved safe command: {command}")
+            return
+
+    # Handle Glob tool in safe directories
+    if tool_name == "Glob":
+        path = tool_input.get("path", "")
+        if path and is_safe_read_path(path):
+            allow(f"Auto-approved Glob in safe directory: {path}")
+            return
+
+    # Handle Grep tool in safe directories
+    if tool_name == "Grep":
+        path = tool_input.get("path", "")
+        if path and is_safe_read_path(path):
+            allow(f"Auto-approved Grep in safe directory: {path}")
+            return
+
+    # Let everything else go through normal flow
+    pass_through("Not a safe operation, using normal approval")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/post-slash-command-emit.py
+++ b/.claude/hooks/post-slash-command-emit.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: Auto-emit jp-spec-kit events when /jpspec commands complete.
+
+This hook intercepts SlashCommand tool completions and emits corresponding
+jp-spec-kit events to trigger user-configured hooks in .specify/hooks/.
+
+Event Mapping:
+    /jpspec:assess    → workflow.assessed
+    /jpspec:specify   → spec.created
+    /jpspec:research  → research.completed
+    /jpspec:plan      → plan.created
+    /jpspec:implement → implement.completed
+    /jpspec:validate  → validate.completed
+    /jpspec:operate   → deploy.completed
+
+The hook operates in a fail-open mode - errors are logged but don't block workflow.
+"""
+
+import json
+import re
+import subprocess
+import sys
+
+# Event type mapping for /jpspec commands
+COMMAND_EVENT_MAP = {
+    "/jpspec:assess": "workflow.assessed",
+    "/jpspec:specify": "spec.created",
+    "/jpspec:research": "research.completed",
+    "/jpspec:plan": "plan.created",
+    "/jpspec:implement": "implement.completed",
+    "/jpspec:validate": "validate.completed",
+    "/jpspec:operate": "deploy.completed",
+}
+
+
+def allow(reason: str, context: str | None = None) -> None:
+    """Output allow decision and exit."""
+    result = {"decision": "allow", "reason": reason}
+    if context:
+        result["additionalContext"] = context
+    print(json.dumps(result))
+    sys.exit(0)
+
+
+def extract_feature_id(text: str, is_command: bool = False) -> str | None:
+    """Extract feature/spec ID from command arguments or output.
+
+    Args:
+        text: Text to search for feature ID
+        is_command: If True, only match explicit flags (not "Feature:" patterns)
+
+    Looks for patterns like:
+    - --spec-id feature-name
+    - spec: feature-name (output only)
+    - feature: feature-name (output only)
+    - Feature: feature-name (output only)
+    """
+    # Always check explicit flag first
+    flag_match = re.search(r"--spec-id\s+([a-zA-Z0-9_-]+)", text)
+    if flag_match:
+        return flag_match.group(1)
+
+    # Only check output patterns if not parsing a command
+    if not is_command:
+        patterns = [
+            r"spec:\s*([a-zA-Z0-9_-]+)",
+            r"[Ff]eature:\s*([a-zA-Z0-9_-]+)",
+        ]
+        for pattern in patterns:
+            match = re.search(pattern, text)
+            if match:
+                return match.group(1)
+
+    return None
+
+
+def extract_task_id(text: str) -> str | None:
+    """Extract task ID from command arguments or output.
+
+    Looks for patterns like:
+    - task-123
+    - --task-id task-123
+    """
+    patterns = [
+        r"--task-id\s+(task-\d+)",
+        r"\btask-(\d+)\b",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, text)
+        if match:
+            if match.group(0).startswith("--task-id"):
+                return match.group(1)
+            return f"task-{match.group(1)}"
+    return None
+
+
+def emit_event(
+    event_type: str, feature_id: str | None, task_id: str | None
+) -> tuple[bool, str]:
+    """Call specify hooks emit to trigger user-configured hooks.
+
+    Returns:
+        Tuple of (success, message)
+    """
+    cmd = ["specify", "hooks", "emit", event_type]
+
+    if feature_id:
+        cmd.extend(["--spec-id", feature_id])
+    if task_id:
+        cmd.extend(["--task-id", task_id])
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+
+        if result.returncode == 0:
+            return True, f"Emitted {event_type} event"
+        else:
+            return False, f"Failed to emit event: {result.stderr}"
+
+    except subprocess.TimeoutExpired:
+        return False, "Event emission timed out"
+    except FileNotFoundError:
+        return False, "specify CLI not found"
+    except Exception as e:
+        return False, f"Unexpected error: {e}"
+
+
+def main():
+    """Main entry point for the hook."""
+    # Read JSON input from stdin
+    try:
+        input_data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        allow("Invalid JSON input")
+        return
+
+    # Get tool name
+    tool_name = input_data.get("tool_name", "")
+
+    # Only process SlashCommand tool
+    if tool_name != "SlashCommand":
+        allow("Not a SlashCommand tool")
+        return
+
+    # Get command from tool_input
+    tool_input = input_data.get("tool_input", {})
+    command = tool_input.get("command", "")
+
+    # Check if this is a /jpspec command
+    jpspec_command = None
+    for cmd_prefix in COMMAND_EVENT_MAP:
+        if command.startswith(cmd_prefix):
+            jpspec_command = cmd_prefix
+            break
+
+    if not jpspec_command:
+        allow("Not a /jpspec command")
+        return
+
+    # Get event type
+    event_type = COMMAND_EVENT_MAP[jpspec_command]
+
+    # Extract feature and task IDs from command arguments (with is_command=True)
+    feature_id = extract_feature_id(command, is_command=True)
+    task_id = extract_task_id(command)
+
+    # Also try to extract from tool output if available (is_command=False)
+    tool_output = input_data.get("tool_output", "")
+    if not feature_id:
+        feature_id = extract_feature_id(tool_output, is_command=False)
+    if not task_id:
+        task_id = extract_task_id(tool_output)
+
+    # Emit the event
+    success, message = emit_event(event_type, feature_id, task_id)
+
+    # Always allow (fail-open) but report results
+    context_parts = [f"Command: {jpspec_command}", f"Event: {event_type}"]
+    if feature_id:
+        context_parts.append(f"Feature: {feature_id}")
+    if task_id:
+        context_parts.append(f"Task: {task_id}")
+    context_parts.append(f"Emission: {'Success' if success else 'Failed'}")
+    if not success:
+        context_parts.append(f"Details: {message}")
+
+    allow(message, "\n".join(context_parts))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/test-permission-auto-approve.py
+++ b/.claude/hooks/test-permission-auto-approve.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Tests for permission-auto-approve.py hook.
+
+Tests the auto-approval functionality for safe read operations.
+"""
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+HOOK_SCRIPT = Path(__file__).parent / "permission-auto-approve.py"
+
+
+def run_hook(input_data: dict) -> tuple[int, dict]:
+    """Run the hook with given input data.
+
+    Returns:
+        Tuple of (exit_code, parsed_output_json)
+    """
+    result = subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input=json.dumps(input_data),
+        capture_output=True,
+        text=True,
+    )
+
+    try:
+        output = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        output = {"raw": result.stdout, "stderr": result.stderr}
+
+    return result.returncode, output
+
+
+class TestPermissionAutoApprove(unittest.TestCase):
+    """Test the auto-approve hook."""
+
+    # --- Read tool tests ---
+
+    def test_read_docs_approved(self):
+        """Read in docs/ should be auto-approved."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": "docs/guides/hooks-quickstart.md"},
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output["decision"], "allow")
+        self.assertIn("safe directory", output.get("reason", ""))
+
+    def test_read_backlog_approved(self):
+        """Read in backlog/ should be auto-approved."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": "backlog/tasks/task-123.md"},
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output["decision"], "allow")
+
+    def test_read_templates_approved(self):
+        """Read in templates/ should be auto-approved."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": "templates/spec-template.md"},
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output["decision"], "allow")
+
+    def test_read_specify_approved(self):
+        """Read in .specify/ should be auto-approved."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": ".specify/hooks/hooks.yaml"},
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output["decision"], "allow")
+
+    def test_read_src_passes(self):
+        """Read in src/ should use normal approval flow."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": "src/main.py"},
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output["decision"], "pass")
+
+    def test_read_root_passes(self):
+        """Read at root should use normal approval flow."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": "pyproject.toml"},
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output["decision"], "pass")
+
+    # --- Bash tool tests ---
+
+    def test_backlog_command_approved(self):
+        """backlog CLI commands should be auto-approved."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "backlog task list --plain"},
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output["decision"], "allow")
+        self.assertIn("safe command", output.get("reason", ""))
+
+    def test_backlog_task_edit_approved(self):
+        """backlog task edit should be auto-approved."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "backlog task edit 123 -s Done"},
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output["decision"], "allow")
+
+    def test_git_status_approved(self):
+        """git status should be auto-approved."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "git status"},
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output["decision"], "allow")
+
+    def test_git_log_approved(self):
+        """git log should be auto-approved."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "git log --oneline -10"},
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output["decision"], "allow")
+
+    def test_git_diff_approved(self):
+        """git diff should be auto-approved."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "git diff HEAD~1"},
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output["decision"], "allow")
+
+    def test_dangerous_bash_passes(self):
+        """Dangerous bash commands should use normal approval."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "rm -rf /"},
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output["decision"], "pass")
+
+    def test_git_push_passes(self):
+        """git push should use normal approval."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "git push origin main"},
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output["decision"], "pass")
+
+    # --- Glob/Grep tool tests ---
+
+    def test_glob_docs_approved(self):
+        """Glob in docs/ should be auto-approved."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "Glob",
+                "tool_input": {"path": "docs/", "pattern": "**/*.md"},
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output["decision"], "allow")
+
+    def test_grep_backlog_approved(self):
+        """Grep in backlog/ should be auto-approved."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "Grep",
+                "tool_input": {"path": "backlog/tasks/", "pattern": "task-"},
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output["decision"], "allow")
+
+    # --- Other tools ---
+
+    def test_write_passes(self):
+        """Write tool should use normal approval."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "Write",
+                "tool_input": {"file_path": "docs/test.md", "content": "test"},
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output["decision"], "pass")
+
+    def test_edit_passes(self):
+        """Edit tool should use normal approval."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "Edit",
+                "tool_input": {"file_path": "docs/test.md"},
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output["decision"], "pass")
+
+    def test_invalid_json_passes(self):
+        """Invalid JSON should pass through."""
+        result = subprocess.run(
+            [sys.executable, str(HOOK_SCRIPT)],
+            input="not valid json",
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        output = json.loads(result.stdout)
+        self.assertEqual(output["decision"], "pass")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.claude/hooks/test-post-slash-command-emit.py
+++ b/.claude/hooks/test-post-slash-command-emit.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Tests for post-slash-command-emit.py hook.
+
+Tests the auto-emit functionality for /jpspec slash commands.
+"""
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+HOOK_SCRIPT = Path(__file__).parent / "post-slash-command-emit.py"
+
+
+def run_hook(input_data: dict) -> tuple[int, dict]:
+    """Run the hook with given input data.
+
+    Returns:
+        Tuple of (exit_code, parsed_output_json)
+    """
+    result = subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input=json.dumps(input_data),
+        capture_output=True,
+        text=True,
+    )
+
+    try:
+        output = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        output = {"raw": result.stdout, "stderr": result.stderr}
+
+    return result.returncode, output
+
+
+class TestPostSlashCommandEmit(unittest.TestCase):
+    """Test the auto-emit hook."""
+
+    def test_non_slash_command_tool_allows(self):
+        """Non-SlashCommand tools should be allowed without emission."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "ls -la"},
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output["decision"], "allow")
+        self.assertEqual(output["reason"], "Not a SlashCommand tool")
+
+    def test_non_jpspec_command_allows(self):
+        """Non-jpspec slash commands should be allowed without emission."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "SlashCommand",
+                "tool_input": {"command": "/commit fix: update readme"},
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output["decision"], "allow")
+        self.assertEqual(output["reason"], "Not a /jpspec command")
+
+    def test_jpspec_assess_detected(self):
+        """Test /jpspec:assess is detected and maps to workflow.assessed."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "SlashCommand",
+                "tool_input": {"command": "/jpspec:assess my-feature"},
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output["decision"], "allow")
+        self.assertIn("workflow.assessed", output.get("additionalContext", ""))
+
+    def test_jpspec_specify_detected(self):
+        """Test /jpspec:specify is detected and maps to spec.created."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "SlashCommand",
+                "tool_input": {
+                    "command": "/jpspec:specify auth-feature --spec-id auth"
+                },
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output["decision"], "allow")
+        self.assertIn("spec.created", output.get("additionalContext", ""))
+        self.assertIn("Feature: auth", output.get("additionalContext", ""))
+
+    def test_jpspec_implement_detected(self):
+        """Test /jpspec:implement is detected and maps to implement.completed."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "SlashCommand",
+                "tool_input": {"command": "/jpspec:implement task-229"},
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output["decision"], "allow")
+        self.assertIn("implement.completed", output.get("additionalContext", ""))
+        self.assertIn("Task: task-229", output.get("additionalContext", ""))
+
+    def test_jpspec_validate_detected(self):
+        """Test /jpspec:validate is detected and maps to validate.completed."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "SlashCommand",
+                "tool_input": {"command": "/jpspec:validate"},
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output["decision"], "allow")
+        self.assertIn("validate.completed", output.get("additionalContext", ""))
+
+    def test_jpspec_operate_detected(self):
+        """Test /jpspec:operate is detected and maps to deploy.completed."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "SlashCommand",
+                "tool_input": {"command": "/jpspec:operate production"},
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output["decision"], "allow")
+        self.assertIn("deploy.completed", output.get("additionalContext", ""))
+
+    def test_extract_task_id_from_command(self):
+        """Test task ID extraction from command."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "SlashCommand",
+                "tool_input": {"command": "/jpspec:implement --task-id task-123"},
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("Task: task-123", output.get("additionalContext", ""))
+
+    def test_extract_feature_from_output(self):
+        """Test feature extraction from tool output."""
+        exit_code, output = run_hook(
+            {
+                "tool_name": "SlashCommand",
+                "tool_input": {"command": "/jpspec:specify"},
+                "tool_output": "Feature: user-authentication\nCreating specification...",
+            }
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn(
+            "Feature: user-authentication", output.get("additionalContext", "")
+        )
+
+    def test_invalid_json_allows(self):
+        """Invalid JSON input should allow (fail-open)."""
+        result = subprocess.run(
+            [sys.executable, str(HOOK_SCRIPT)],
+            input="not valid json",
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        output = json.loads(result.stdout)
+        self.assertEqual(output["decision"], "allow")
+
+    def test_all_jpspec_commands_mapped(self):
+        """Verify all /jpspec commands have event mappings."""
+        commands = [
+            ("/jpspec:assess", "workflow.assessed"),
+            ("/jpspec:specify", "spec.created"),
+            ("/jpspec:research", "research.completed"),
+            ("/jpspec:plan", "plan.created"),
+            ("/jpspec:implement", "implement.completed"),
+            ("/jpspec:validate", "validate.completed"),
+            ("/jpspec:operate", "deploy.completed"),
+        ]
+
+        for command, expected_event in commands:
+            with self.subTest(command=command):
+                exit_code, output = run_hook(
+                    {
+                        "tool_name": "SlashCommand",
+                        "tool_input": {"command": command},
+                    }
+                )
+
+                self.assertEqual(exit_code, 0)
+                self.assertIn(
+                    expected_event,
+                    output.get("additionalContext", ""),
+                    f"Expected {expected_event} for {command}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,6 +32,16 @@
     ],
     "PreToolUse": [
       {
+        "matcher": "Read|Glob|Grep|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python .claude/hooks/permission-auto-approve.py",
+            "timeout": 3
+          }
+        ]
+      },
+      {
         "matcher": "Edit|Write",
         "hooks": [
           {
@@ -65,6 +75,16 @@
             "type": "command",
             "command": "bash .claude/hooks/post-tool-use-lint-python.sh",
             "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "SlashCommand",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python .claude/hooks/post-slash-command-emit.py",
+            "timeout": 35
           }
         ]
       }

--- a/docs/examples/hooks/aggregate-progress.sh
+++ b/docs/examples/hooks/aggregate-progress.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# aggregate-progress.sh - Aggregate agent progress to a central summary file
+#
+# This hook aggregates agent.* events to track multi-machine progress.
+# Place in .specify/hooks/aggregate-progress.sh
+#
+# Configuration in hooks.yaml:
+#   - name: aggregate-progress
+#     events:
+#       - pattern: "agent.*"
+#     script: aggregate-progress.sh
+#     enabled: true
+#
+set -e
+
+# Parse event data from HOOK_EVENT environment variable
+EVENT_TYPE=$(echo "$HOOK_EVENT" | jq -r '.event_type')
+AGENT_ID=$(echo "$HOOK_EVENT" | jq -r '.context.agent_id // "unknown"')
+MACHINE=$(echo "$HOOK_EVENT" | jq -r '.context.machine // "unknown"')
+TASK_ID=$(echo "$HOOK_EVENT" | jq -r '.context.task_id // "none"')
+PROGRESS=$(echo "$HOOK_EVENT" | jq -r '.context.progress_percent // "n/a"')
+MESSAGE=$(echo "$HOOK_EVENT" | jq -r '.context.status_message // ""')
+FEATURE=$(echo "$HOOK_EVENT" | jq -r '.feature // "unknown"')
+TIMESTAMP=$(echo "$HOOK_EVENT" | jq -r '.timestamp')
+
+# Determine project root from event
+PROJECT_ROOT=$(echo "$HOOK_EVENT" | jq -r '.project_root')
+SUMMARY_FILE="$PROJECT_ROOT/.specify/hooks/progress-summary.log"
+
+# Create summary directory if needed
+mkdir -p "$(dirname "$SUMMARY_FILE")"
+
+# Format progress string
+if [ "$PROGRESS" != "n/a" ]; then
+    PROGRESS_STR="${PROGRESS}%"
+else
+    PROGRESS_STR="-"
+fi
+
+# Format log entry
+LOG_ENTRY="[$TIMESTAMP] $MACHINE: $EVENT_TYPE | agent=$AGENT_ID | task=$TASK_ID | feature=$FEATURE | progress=$PROGRESS_STR"
+if [ -n "$MESSAGE" ]; then
+    LOG_ENTRY="$LOG_ENTRY | $MESSAGE"
+fi
+
+# Append to progress summary
+echo "$LOG_ENTRY" >> "$SUMMARY_FILE"
+
+# Keep only last 100 entries to prevent unbounded growth
+if [ -f "$SUMMARY_FILE" ]; then
+    tail -100 "$SUMMARY_FILE" > "$SUMMARY_FILE.tmp" && mv "$SUMMARY_FILE.tmp" "$SUMMARY_FILE"
+fi
+
+# Optional: Print to stdout for debugging
+echo "Logged: $EVENT_TYPE from $MACHINE"

--- a/templates/commands/jpspec/assess.md
+++ b/templates/commands/jpspec/assess.md
@@ -282,3 +282,18 @@ Before completing:
 - [ ] Recommendation is clear and justified
 - [ ] Next steps are specific and actionable
 - [ ] Override instructions are provided
+
+## Post-Completion: Emit Workflow Event
+
+After successfully completing this command (assessment report generated), emit the workflow event:
+
+```bash
+specify hooks emit workflow.assessed \
+  --spec-id "$FEATURE_NAME" \
+  --task-id "$TASK_ID" \
+  -f docs/assess/<feature>-assessment.md
+```
+
+Replace `$FEATURE_NAME` with the feature being assessed and `$TASK_ID` with the backlog task ID if available.
+
+This triggers any configured hooks in `.specify/hooks/hooks.yaml` (e.g., notifications, workflow tracking).

--- a/templates/commands/jpspec/implement.md
+++ b/templates/commands/jpspec/implement.md
@@ -715,3 +715,18 @@ gh pr create --title "feat: description" --body "..."
 - Integration documentation
 - Deployment-ready artifacts
 - **All pre-PR validation checks passing**
+
+## Post-Completion: Emit Workflow Event
+
+After successfully completing this command (implementation done, reviews passed, pre-PR validation complete), emit the workflow event:
+
+```bash
+specify hooks emit implement.completed \
+  --spec-id "$FEATURE_ID" \
+  --task-id "$TASK_ID" \
+  -f src/<feature>/
+```
+
+Replace `$FEATURE_ID` with the feature name/identifier and `$TASK_ID` with the backlog task ID if available.
+
+This triggers any configured hooks in `.specify/hooks/hooks.yaml` (e.g., running tests, quality gates, notifications).

--- a/templates/commands/jpspec/operate.md
+++ b/templates/commands/jpspec/operate.md
@@ -416,3 +416,19 @@ Deliver comprehensive operational package with:
 - SLI/SLO definitions and monitoring
 - Security scanning integration
 - DR and backup procedures
+
+## Post-Completion: Emit Workflow Event
+
+After successfully completing this command (deployment complete, operational readiness achieved), emit the workflow event:
+
+```bash
+specify hooks emit deploy.completed \
+  --spec-id "$FEATURE_ID" \
+  --task-id "$TASK_ID" \
+  -f .github/workflows/<feature>.yml \
+  -f k8s/<feature>/
+```
+
+Replace `$FEATURE_ID` with the feature name/identifier and `$TASK_ID` with the backlog task ID if available.
+
+This triggers any configured hooks in `.specify/hooks/hooks.yaml` (e.g., notifications, monitoring alerts, post-deployment validation).

--- a/templates/commands/jpspec/plan.md
+++ b/templates/commands/jpspec/plan.md
@@ -388,3 +388,19 @@ After both agents complete:
    echo "✓ Workflow state updated to: Planned"
    echo "  Next step: /jpspec:implement"
    ```
+
+## Post-Completion: Emit Workflow Event
+
+After successfully completing this command (architecture and platform designs created), emit the workflow event:
+
+```bash
+specify hooks emit plan.created \
+  --spec-id "$FEATURE_ID" \
+  --task-id "$TASK_ID" \
+  -f docs/adr/<feature>-architecture.md \
+  -f docs/platform/<feature>-platform.md
+```
+
+Replace `$FEATURE_ID` with the feature name/identifier and `$TASK_ID` with the backlog task ID if available.
+
+This triggers any configured hooks in `.specify/hooks/hooks.yaml` (e.g., notifications, quality gates).

--- a/templates/commands/jpspec/research.md
+++ b/templates/commands/jpspec/research.md
@@ -386,3 +386,19 @@ After the research and business validation agents complete their work:
 **Research without actionable follow-up tasks provides no value. Every research effort must produce implementation direction.**
 
 **Note**: If research concludes with "No-Go" recommendation, create a documentation task to record the decision and rationale for future reference.
+
+## Post-Completion: Emit Workflow Event
+
+After successfully completing this command (research and validation reports generated), emit the workflow event:
+
+```bash
+specify hooks emit research.completed \
+  --spec-id "$FEATURE_ID" \
+  --task-id "$TASK_ID" \
+  -f docs/research/<feature>-research.md \
+  -f docs/research/<feature>-validation.md
+```
+
+Replace `$FEATURE_ID` with the feature name/identifier and `$TASK_ID` with the backlog task ID if available.
+
+This triggers any configured hooks in `.specify/hooks/hooks.yaml` (e.g., notifications, quality gates).

--- a/templates/commands/jpspec/specify.md
+++ b/templates/commands/jpspec/specify.md
@@ -263,3 +263,18 @@ backlog task list --plain | grep -i "<feature-keyword>"
 ```
 
 **Failure to create implementation tasks means the specification work is incomplete.**
+
+## Post-Completion: Emit Workflow Event
+
+After successfully completing this command (PRD created and tasks defined), emit the workflow event:
+
+```bash
+specify hooks emit spec.created \
+  --spec-id "$FEATURE_ID" \
+  --task-id "$TASK_ID" \
+  -f docs/prd/<feature>-spec.md
+```
+
+Replace `$FEATURE_ID` with the feature name/identifier and `$TASK_ID` with the backlog task ID if available.
+
+This triggers any configured hooks in `.specify/hooks/hooks.yaml` (e.g., notifications, quality gates).

--- a/templates/commands/jpspec/validate.md
+++ b/templates/commands/jpspec/validate.md
@@ -926,3 +926,19 @@ If a phase fails, fix the issue and re-run the command. The workflow will resume
 - `/jpspec:implement` - Implementation workflow
 - `/jpspec:plan` - Planning workflow
 - `backlog task` - Task management commands
+
+## Post-Completion: Emit Workflow Event
+
+After successfully completing this command (all validation phases passed, PR created), emit the workflow event:
+
+```bash
+specify hooks emit validate.completed \
+  --spec-id "$FEATURE_ID" \
+  --task-id "$TASK_ID" \
+  -f docs/qa/<feature>-qa-report.md \
+  -f docs/security/<feature>-security-report.md
+```
+
+Replace `$FEATURE_ID` with the feature name/identifier and `$TASK_ID` with the backlog task ID if available.
+
+This triggers any configured hooks in `.specify/hooks/hooks.yaml` (e.g., notifications, deployment triggers).


### PR DESCRIPTION
## Summary

- Add multi-machine agent observability with `agent.started`, `agent.progress`, `agent.blocked`, `agent.completed`, `agent.error`, and `agent.handoff` event types
- Create PostToolUse hook to auto-emit workflow events when `/jpspec` commands complete
- Create PreToolUse hook for auto-approving safe read operations in docs/, backlog/, templates/, .specify/
- Add post-completion event emission instructions to all 7 `/jpspec` slash commands

## Completed Tasks

| Task | Description |
|------|-------------|
| task-189 | Stop Hook for Backlog Task Quality Gate |
| task-193 | PermissionRequest Hook for Auto-Approvals |
| task-203 | Integrate Event Emission into /jpspec Commands |
| task-227 | Add event emission instructions to slash commands |
| task-228 | Create hook to auto-emit events on /jpspec completion |
| task-229 | Agent progress tracking via event emission |

## Changes

### Agent Events (`src/specify_cli/hooks/events.py`)
- Added `agent.*` event types to `EventType` enum
- Added factory functions: `create_agent_started_event()`, `create_agent_progress_event()`, `create_agent_completed_event()`, `create_agent_handoff_event()`
- Auto-detects machine hostname for multi-machine tracking

### CLI (`src/specify_cli/hooks/cli.py`)
- Added `--progress` flag for progress percentage (0-100)
- Added `--message` flag for status messages
- Added `--agent-id` flag for agent identification

### Claude Code Hooks
- **post-slash-command-emit.py**: PostToolUse hook that maps /jpspec commands to events and auto-emits
- **permission-auto-approve.py**: PreToolUse hook for auto-approving safe read operations

### Slash Commands
- Added Post-Completion sections to all `/jpspec` commands with event emission instructions

### Documentation
- Updated `docs/guides/hooks-quickstart.md` with agent events section
- Added `docs/examples/hooks/aggregate-progress.sh` example

## Test plan

- [x] All 1687 tests pass (`pytest tests/`)
- [x] Hook tests pass (29 tests across both hook test files)
- [x] Linting clean (`ruff check . && ruff format --check .`)
- [x] Agent event factory functions tested
- [x] CLI flag validation tested
- [x] Hook JSON input/output tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)