### PR TITLE
docs: add jpspec + backlog.md integration documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,8 +119,30 @@ You can customize the workflow by editing `jpspec_workflow.yml`:
 
 See [Workflow Customization Guide](docs/guides/workflow-customization.md) for details.
 
+### /jpspec + Backlog.md Integration
+
+Every `/jpspec` command integrates with backlog.md:
+
+**Design commands create tasks**:
+```bash
+# /jpspec:specify creates implementation tasks with ACs
+backlog task create "Implement feature X" --ac "AC 1" --ac "AC 2" -l backend
+```
+
+**Implementation commands consume tasks**:
+```bash
+# /jpspec:implement discovers and works from existing tasks
+backlog task edit task-42 -s "In Progress" -a @backend-engineer
+backlog task edit task-42 --check-ac 1  # Check ACs progressively
+```
+
+**Key rule**: Never run `/jpspec:implement` without first running `/jpspec:specify` to create tasks.
+
+See [JP Spec + Backlog.md Integration Guide](docs/guides/jpspec-backlog-workflow.md) for complete details.
+
 ### Workflow Documentation
 
+- [JP Spec + Backlog.md Integration](docs/guides/jpspec-backlog-workflow.md) - Complete integration guide
 - [Workflow State Mapping](docs/guides/workflow-state-mapping.md) - State and command mapping
 - [Workflow Customization Guide](docs/guides/workflow-customization.md) - How to modify workflows
 - [Workflow Architecture](docs/guides/workflow-architecture.md) - Overall design

--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ specify init my-project --ai claude,copilot,cursor-agent
 ### Task Management
 - **[Backlog Quick Start](docs/guides/backlog-quickstart.md)** - Get started in 5 minutes
 - **[Backlog User Guide](docs/guides/backlog-user-guide.md)** - Complete task management guide
+- **[JP Spec + Backlog Integration](docs/guides/jpspec-backlog-workflow.md)** - How /jpspec commands integrate with backlog.md
 
 ### Guides
 - **[Problem Sizing Assessment](docs/guides/problem-sizing-assessment.md)** - When to use SDD

--- a/docs/guides/backlog-user-guide.md
+++ b/docs/guides/backlog-user-guide.md
@@ -964,6 +964,73 @@ backlog board --filter US1  # Instead of viewing all tasks
 
 ---
 
+## /jpspec Command Integration
+
+Backlog.md integrates seamlessly with the `/jpspec` workflow commands. Each command creates, discovers, or updates tasks in your backlog.
+
+### Quick Reference
+
+| Command | Backlog Action | Task State Change |
+|---------|---------------|-------------------|
+| `/jpspec:assess` | Labels with complexity | To Do → Assessed |
+| `/jpspec:specify` | Creates implementation tasks | Assessed → Specified |
+| `/jpspec:research` | Creates research + follow-up tasks | Specified → Researched |
+| `/jpspec:plan` | Creates architecture/infra tasks | Researched → Planned |
+| `/jpspec:implement` | Assigns and tracks existing tasks | Planned → In Implementation |
+| `/jpspec:validate` | Validates task completion | In Implementation → Validated |
+| `/jpspec:operate` | Creates operational tasks | Validated → Deployed |
+
+### How Commands Use Backlog
+
+**Design commands** (specify, research, plan) create tasks:
+
+```bash
+# /jpspec:specify creates tasks with acceptance criteria
+backlog task create "Implement user login" \
+  --ac "POST /auth/login returns JWT" \
+  --ac "Invalid credentials return 401" \
+  -l backend,US1
+```
+
+**Implementation commands** (implement, validate, operate) work from tasks:
+
+```bash
+# /jpspec:implement discovers and assigns tasks
+backlog search "authentication" --plain
+backlog task edit task-42 -s "In Progress" -a @backend-engineer
+backlog task edit task-42 --check-ac 1  # Mark AC complete
+```
+
+### Task Format Requirements
+
+For full `/jpspec` compatibility, tasks should include:
+
+1. **Status field** - Valid workflow state (To Do, Specified, Planned, etc.)
+2. **Acceptance criteria** - Numbered checkboxes for tracking
+3. **Labels** - User story references (US1, US2) and categories
+
+```markdown
+---
+id: task-042
+status: To Do
+labels: [backend, US1]
+---
+
+## Acceptance Criteria
+- [ ] #1 First criterion
+- [ ] #2 Second criterion
+```
+
+### Learn More
+
+See **[JP Spec + Backlog.md Integration Guide](jpspec-backlog-workflow.md)** for:
+- Complete workflow state transitions
+- Task format specifications
+- Command integration details
+- Troubleshooting guide
+
+---
+
 **Status**: This integration is in active development. Some features (like automatic task generation) are coming soon.
 
 **Feedback**: Your input helps shape this integration. Please share your experiences and suggestions!

--- a/docs/guides/jpspec-backlog-workflow.md
+++ b/docs/guides/jpspec-backlog-workflow.md
@@ -1,0 +1,599 @@
+# JP Spec + Backlog.md Integration Guide
+
+Complete guide to using `/jpspec` commands with backlog.md task management for end-to-end spec-driven development.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [How It Works](#how-it-works)
+- [Task Format for JPSpec Compatibility](#task-format-for-jpspec-compatibility)
+- [Workflow State Transitions](#workflow-state-transitions)
+- [Command Integration Reference](#command-integration-reference)
+- [Best Practices](#best-practices)
+- [Troubleshooting](#troubleshooting)
+
+## Overview
+
+The `/jpspec` workflow system and backlog.md are deeply integrated to provide:
+
+1. **State-Driven Commands**: Each `/jpspec` command validates task state before execution
+2. **Automatic Task Discovery**: Commands search backlog for relevant tasks
+3. **Progressive Task Creation**: Design commands create tasks; implementation commands consume them
+4. **Acceptance Criteria Tracking**: Engineers check ACs as work progresses
+5. **Full Traceability**: Requirements → Tasks → Implementation → Validation
+
+### The Integration Flow
+
+```
+/jpspec:assess    →  Evaluate complexity (To Do → Assessed)
+       ↓
+/jpspec:specify   →  Create PRD + tasks (Assessed → Specified)
+       ↓
+/jpspec:research  →  Market validation (Specified → Researched)
+       ↓
+/jpspec:plan      →  Architecture design (Researched → Planned)
+       ↓
+/jpspec:implement →  Code development (Planned → In Implementation)
+       ↓
+/jpspec:validate  →  QA + security (In Implementation → Validated)
+       ↓
+/jpspec:operate   →  Deploy to production (Validated → Deployed)
+```
+
+## How It Works
+
+### Design Commands Create Tasks
+
+**Design commands** (`/jpspec:specify`, `/jpspec:research`, `/jpspec:plan`) create new tasks:
+
+```bash
+# /jpspec:specify creates implementation tasks
+backlog task create "Implement user authentication" \
+  -d "Core auth implementation per PRD section 4" \
+  --ac "Implement OAuth2 flow" \
+  --ac "Add JWT token validation" \
+  --ac "Write unit tests" \
+  -l backend,auth \
+  --priority high
+
+# /jpspec:plan creates architecture tasks
+backlog task create "ADR: Authentication approach" \
+  -d "Document OAuth2 vs SAML decision" \
+  --ac "Document context and options" \
+  --ac "Record decision and consequences" \
+  -l architecture,adr \
+  --priority high
+```
+
+### Implementation Commands Consume Tasks
+
+**Implementation commands** (`/jpspec:implement`, `/jpspec:validate`, `/jpspec:operate`) work from existing tasks:
+
+```bash
+# Step 0: Discover existing tasks
+backlog task list -s "To Do" --plain
+backlog search "authentication" --plain
+
+# Engineer workflow
+backlog task edit task-42 -s "In Progress" -a @backend-engineer
+# ... implement feature ...
+backlog task edit task-42 --check-ac 1  # Mark AC complete
+backlog task edit task-42 --check-ac 2
+backlog task edit task-42 -s Done       # Only after ALL ACs checked
+```
+
+### State Validation
+
+Before executing, each `/jpspec` command validates task state:
+
+```bash
+# This will ERROR if task is in wrong state
+/jpspec:implement  # Requires task in "Planned" state
+
+# Error message:
+# Cannot run /jpspec:implement
+#   Current state: "To Do"
+#   Required states: Planned
+# Suggestions:
+#   - Run /jpspec:plan first
+```
+
+## Task Format for JPSpec Compatibility
+
+### Required Fields
+
+Tasks must include these fields for full `/jpspec` integration:
+
+```markdown
+---
+id: task-042
+title: Implement user authentication
+status: To Do
+priority: High
+labels: [backend, auth, US1]
+assignee: []
+---
+
+## Description
+
+Implement user authentication system with OAuth2 support.
+
+## Acceptance Criteria
+
+- [ ] #1 Implement OAuth2 flow with Google provider
+- [ ] #2 Add JWT token generation and validation
+- [ ] #3 Write unit tests with 90% coverage
+- [ ] #4 Add integration tests for auth flow
+```
+
+### Status Values
+
+Use these exact status values for workflow compatibility:
+
+| Status | Description | Used By |
+|--------|-------------|---------|
+| `To Do` | Created, not started | Initial state |
+| `Assessed` | Complexity evaluated | After `/jpspec:assess` |
+| `Specified` | PRD complete | After `/jpspec:specify` |
+| `Researched` | Research validated | After `/jpspec:research` |
+| `Planned` | Architecture designed | After `/jpspec:plan` |
+| `In Progress` | Engineer working | During `/jpspec:implement` |
+| `In Implementation` | Active coding | `/jpspec:implement` phase |
+| `Validated` | QA + security passed | After `/jpspec:validate` |
+| `Deployed` | In production | After `/jpspec:operate` |
+| `Done` | All work complete | Final state |
+
+### Labels for Traceability
+
+Use labels to connect tasks to requirements:
+
+```yaml
+labels:
+  # User story reference
+  - US1      # Links to User Story 1 in PRD
+  - US2      # Links to User Story 2
+
+  # Task type
+  - backend
+  - frontend
+  - architecture
+  - infrastructure
+
+  # Phase
+  - setup
+  - foundational
+  - implementation
+  - polish
+
+  # Custom
+  - blocking
+  - parallelizable
+```
+
+### Acceptance Criteria Format
+
+Write ACs in numbered checkbox format:
+
+```markdown
+## Acceptance Criteria
+
+- [ ] #1 Users can register with email and password
+- [ ] #2 Users can login with valid credentials
+- [ ] #3 Invalid credentials return 401 error
+- [ ] #4 Sessions expire after 15 minutes of inactivity
+```
+
+**Rules**:
+- Minimum 2 ACs per task
+- Each AC should be independently verifiable
+- Use action verbs (implement, create, add, fix)
+- Include measurable outcomes where possible
+
+## Workflow State Transitions
+
+### Valid Transitions
+
+```
+To Do ────────────────────────────────────────────────┐
+   │                                                   │
+   ↓ /jpspec:assess                                    │
+Assessed                                               │
+   │                                                   │
+   ↓ /jpspec:specify                                   │
+Specified ─────────────────────┐                      │
+   │                           │                       │
+   ↓ /jpspec:research          │ (skip research)       │
+Researched                     │                       │
+   │                           │                       │
+   └───────────┬───────────────┘                       │
+               ↓ /jpspec:plan                          │
+           Planned                                     │
+               │                                       │
+               ↓ /jpspec:implement                     │
+        In Implementation                              │
+               │                                       │
+               ↓ /jpspec:validate                      │
+           Validated                                   │
+               │                                       │
+               ↓ /jpspec:operate                       │
+           Deployed                                    │
+               │                                       │
+               ↓ Release Manager verification          │
+             Done ←────────────────────────────────────┘
+                    (simple tasks can go direct)
+```
+
+### Skipping Phases
+
+Some phases can be skipped based on complexity:
+
+```bash
+# Simple tasks (8-12 complexity score)
+To Do → Done  # Skip all /jpspec commands
+
+# Medium tasks (13-20 complexity score)
+To Do → Specified → Planned → In Implementation → Done
+
+# Complex tasks (21-32 complexity score)
+To Do → Assessed → Specified → Researched → Planned →
+  In Implementation → Validated → Deployed → Done
+```
+
+## Command Integration Reference
+
+### /jpspec:assess
+
+**State Transition**: `To Do` → `Assessed`
+
+**Backlog Operations**:
+```bash
+# Before: Task in To Do
+backlog task list -s "To Do" --plain
+
+# After: Task moved to Assessed with complexity labels
+backlog task edit task-42 -s "Assessed" -l complexity-complex
+```
+
+### /jpspec:specify
+
+**State Transition**: `Assessed` → `Specified`
+
+**Backlog Operations**:
+```bash
+# Creates implementation tasks
+backlog task create "T001: Implement login endpoint" \
+  --ac "POST /auth/login returns JWT" \
+  --ac "Invalid credentials return 401" \
+  -l backend,US1
+
+# Updates feature task
+backlog task edit task-42 -s "Specified"
+```
+
+### /jpspec:research
+
+**State Transition**: `Specified` → `Researched`
+
+**Backlog Operations**:
+```bash
+# Creates research spike tasks
+backlog task create "Research: OAuth providers comparison" \
+  --ac "Compare Google, GitHub, Microsoft OAuth" \
+  --ac "Document security considerations" \
+  -l research
+
+# Creates follow-up implementation tasks
+backlog task create "Implement OAuth with recommended provider" \
+  --dep task-research-42
+```
+
+### /jpspec:plan
+
+**State Transition**: `Specified|Researched` → `Planned`
+
+**Backlog Operations**:
+```bash
+# Creates architecture tasks
+backlog task create "ADR: JWT vs session tokens" \
+  --ac "Document decision rationale" \
+  -l architecture,adr
+
+# Creates infrastructure tasks
+backlog task create "Setup CI/CD for auth service" \
+  --ac "Configure build pipeline" \
+  --ac "Add security scanning" \
+  -l infrastructure,cicd
+```
+
+### /jpspec:implement
+
+**State Transition**: `Planned` → `In Implementation`
+
+**Backlog Operations**:
+```bash
+# Step 0: Discover tasks
+backlog search "authentication" --plain
+backlog task list -l backend --plain
+
+# Engineer workflow
+backlog task edit task-42 -s "In Progress" -a @backend-engineer
+backlog task edit task-42 --plan $'1. Create auth endpoints\n2. Add JWT logic\n3. Write tests'
+backlog task edit task-42 --check-ac 1
+backlog task edit task-42 --check-ac 2
+backlog task edit task-42 --notes $'Implemented with RS256 signing'
+
+# Code reviewer validation
+backlog task edit task-42 --uncheck-ac 2  # If AC not satisfied
+backlog task edit task-42 --append-notes 'Review: Missing token expiration'
+```
+
+### /jpspec:validate
+
+**State Transition**: `In Implementation` → `Validated`
+
+**Backlog Operations**:
+```bash
+# QA validation
+backlog task edit task-42 --check-ac 3  # Tests passing
+backlog task edit task-42 --append-notes 'QA: All tests pass, 95% coverage'
+
+# Security validation
+backlog task edit task-42 --append-notes 'Security: No vulnerabilities found'
+
+# Release Manager verification
+backlog task 42 --plain  # Verify all ACs checked
+backlog task edit task-42 -s "Validated"
+```
+
+### /jpspec:operate
+
+**State Transition**: `Validated` → `Deployed`
+
+**Backlog Operations**:
+```bash
+# Creates operational tasks
+backlog task create "Runbook: Auth service high latency" \
+  --ac "Document triage steps" \
+  --ac "Add rollback procedure" \
+  -l operations,runbook
+
+# Marks feature as deployed
+backlog task edit task-42 -s "Deployed"
+```
+
+## Best Practices
+
+### 1. Always Start with Assessment
+
+```bash
+# Determine appropriate workflow depth
+/jpspec:assess <feature description>
+
+# Use result to choose path:
+# Simple (8-12) → Implement directly
+# Medium (13-20) → Spec-light mode
+# Complex (21-32) → Full workflow
+```
+
+### 2. Verify Tasks Before Implementation
+
+```bash
+# WRONG: Jump straight to implement
+/jpspec:implement User authentication  # ERROR: No tasks found
+
+# RIGHT: Verify tasks exist
+backlog task list --plain | grep -i "auth"
+backlog search "authentication" --plain
+
+# If no tasks, create them first
+/jpspec:specify User authentication
+```
+
+### 3. Check ACs Progressively
+
+```bash
+# DON'T: Check all ACs at once at the end
+backlog task edit task-42 --check-ac 1 --check-ac 2 --check-ac 3
+
+# DO: Check as you complete each
+# After implementing OAuth flow:
+backlog task edit task-42 --check-ac 1
+
+# After implementing JWT:
+backlog task edit task-42 --check-ac 2
+
+# After writing tests:
+backlog task edit task-42 --check-ac 3
+```
+
+### 4. Add Implementation Notes
+
+```bash
+# Always document what was done
+backlog task edit task-42 --notes $'Implementation summary:
+
+- Used RS256 for JWT signing (more secure than HS256)
+- Token expiration set to 15 minutes
+- Refresh token rotation implemented per RFC 6749
+- Added rate limiting (100 req/min per user)
+
+Files changed:
+- src/auth/jwt.ts
+- src/auth/oauth.ts
+- tests/auth/'
+```
+
+### 5. Code Reviewers Validate ACs
+
+```bash
+# Reviewer checks each AC
+backlog task 42 --plain
+
+# If AC marked complete but code doesn't satisfy:
+backlog task edit task-42 --uncheck-ac 2
+backlog task edit task-42 --append-notes 'Review: AC #2 missing token refresh logic'
+```
+
+### 6. Release Manager Verifies Definition of Done
+
+Before marking any task as `Done`:
+- [ ] All acceptance criteria checked (`[x]`)
+- [ ] Implementation notes present
+- [ ] Code review completed
+- [ ] Tests passing
+- [ ] No blocking issues
+
+```bash
+# Verify before marking Done
+backlog task 42 --plain
+
+# Only then mark complete
+backlog task edit task-42 -s Done
+```
+
+## Troubleshooting
+
+### "No backlog tasks found" Error
+
+**Problem**: `/jpspec:implement` can't find tasks to work on.
+
+**Cause**: No tasks created yet or wrong search terms.
+
+**Solution**:
+```bash
+# 1. Check if tasks exist
+backlog task list --plain
+
+# 2. Search with different terms
+backlog search "auth" --plain
+backlog search "login" --plain
+
+# 3. If no tasks, create them first
+/jpspec:specify <feature description>
+
+# 4. Verify tasks were created
+backlog task list --plain | grep -i "<keyword>"
+```
+
+### "Cannot run /jpspec:X - wrong state" Error
+
+**Problem**: Task not in expected state for command.
+
+**Cause**: Running commands out of order.
+
+**Solution**:
+```bash
+# Check current state
+backlog task 42 --plain
+
+# Follow workflow order:
+# To Do → Assessed → Specified → Researched → Planned → ...
+
+# If stuck in wrong state, manually fix:
+backlog task edit task-42 -s "Planned"  # Requires appropriate AC completion
+```
+
+### Tasks Not Transitioning States
+
+**Problem**: Commands complete but task status doesn't change.
+
+**Cause**: Agent didn't call backlog CLI or CLI call failed.
+
+**Solution**:
+```bash
+# 1. Check task status
+backlog task 42 --plain
+
+# 2. Manually update if needed
+backlog task edit task-42 -s "Specified"
+
+# 3. Verify agent context includes backlog CLI instructions
+# Check .claude/commands/jpspec/*.md files
+```
+
+### Acceptance Criteria Not Checking
+
+**Problem**: ACs remain unchecked despite work completion.
+
+**Cause**: Engineer forgot to check ACs or CLI command failed.
+
+**Solution**:
+```bash
+# Manually check ACs
+backlog task edit task-42 --check-ac 1
+backlog task edit task-42 --check-ac 2
+
+# Verify
+backlog task 42 --plain
+# Should show [x] for checked ACs
+```
+
+### Code Reviewer Can't Uncheck ACs
+
+**Problem**: Need to uncheck AC that shouldn't be marked complete.
+
+**Solution**:
+```bash
+# Uncheck specific AC
+backlog task edit task-42 --uncheck-ac 2
+
+# Add note explaining why
+backlog task edit task-42 --append-notes 'Unchecked AC #2: Missing error handling'
+```
+
+### Dependency Chain Issues
+
+**Problem**: Tasks can't start because dependencies not complete.
+
+**Diagnosis**:
+```bash
+# View task with dependencies
+backlog task 42 --plain
+
+# Check dependency status
+backlog task <dep-id> --plain
+```
+
+**Solution**:
+```bash
+# Option 1: Complete blocking task first
+backlog task edit <dep-id> -s "In Progress"
+# ... complete work ...
+backlog task edit <dep-id> -s Done
+
+# Option 2: Remove dependency if not needed
+# Edit task file directly to remove from dependencies list
+```
+
+### MCP Connection Issues
+
+**Problem**: Claude Code can't manage tasks via MCP.
+
+**Solution**:
+```bash
+# 1. Verify MCP server configured
+claude mcp list
+
+# 2. Re-add if missing
+claude mcp add backlog --scope user -- backlog mcp start
+
+# 3. Restart Claude Code
+
+# 4. Test connection
+# Ask Claude: "List all backlog tasks"
+```
+
+---
+
+## Related Documentation
+
+- **[JP Spec Workflow Guide](jpspec-workflow-guide.md)** - Complete workflow documentation
+- **[Backlog User Guide](backlog-user-guide.md)** - Backlog.md standalone usage
+- **[Backlog Quick Start](backlog-quickstart.md)** - Get started in 5 minutes
+- **[Workflow State Mapping](workflow-state-mapping.md)** - State transition details
+- **[Workflow Troubleshooting](workflow-troubleshooting.md)** - More troubleshooting tips
+
+---
+
+**Last Updated**: 2025-12-03
+**Version**: 1.0


### PR DESCRIPTION
## Summary

- Create comprehensive integration guide for /jpspec commands with backlog.md
- Update existing docs with cross-references to new guide
- Document task format requirements for workflow compatibility
- Add troubleshooting section for common integration issues

## Changes

| File | Change |
|------|--------|
| `docs/guides/jpspec-backlog-workflow.md` | NEW: Complete integration guide (600+ lines) |
| `CLAUDE.md` | Add /jpspec + Backlog.md Integration section |
| `docs/guides/backlog-user-guide.md` | Add /jpspec Command Integration section |
| `README.md` | Add link to integration guide |

## Acceptance Criteria Coverage

| AC | Description | Status |
|----|-------------|--------|
| AC #1 | Update CLAUDE.md with workflow section | Done |
| AC #2 | Update backlog-user-guide.md with jpspec integration | Done |
| AC #3 | Create jpspec-backlog-workflow.md guide | Done |
| AC #4 | Document required task format | Done |
| AC #5 | Add troubleshooting section | Done |
| AC #6 | Update README.md Quick Reference | Done |

## Test plan

- [x] All 1676 existing tests pass
- [x] New documentation renders correctly in markdown preview
- [x] Links between docs are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)