### PR TITLE
docs(security): add documentation and test suite

### DIFF
--- a/docs/guides/security-cicd-integration.md
+++ b/docs/guides/security-cicd-integration.md
@@ -1,0 +1,779 @@
+# CI/CD Security Integration Guide
+
+Complete examples for integrating `/jpspec:security` into your CI/CD pipelines.
+
+## Overview
+
+Security scanning should be integrated at multiple stages:
+
+1. **Pre-commit** - Fast checks before code is committed
+2. **Pull Request** - Full scan with AI triage on PR
+3. **Main Branch** - Comprehensive audit with reporting
+4. **Scheduled** - Regular scans for new vulnerabilities
+
+## GitHub Actions
+
+### Basic Security Scan
+
+```yaml
+# .github/workflows/security.yml
+name: Security Scan
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly Monday 6 AM
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  security-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install specify-cli semgrep
+
+      - name: Run security scan
+        run: |
+          specify security scan \
+            --format sarif \
+            --output results.sarif \
+            --fail-on high
+        continue-on-error: true
+
+      - name: Upload SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+
+      - name: Check for critical findings
+        run: |
+          specify security scan --fail-on critical
+```
+
+### Full Security Pipeline
+
+```yaml
+# .github/workflows/security-full.yml
+name: Full Security Pipeline
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  scan:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    outputs:
+      findings-count: ${{ steps.scan.outputs.findings }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install tools
+        run: pip install specify-cli semgrep
+
+      - name: Run scan
+        id: scan
+        run: |
+          specify security scan --format json --output scan-results.json
+          FINDINGS=$(jq '.findings | length' scan-results.json)
+          echo "findings=$FINDINGS" >> $GITHUB_OUTPUT
+
+      - name: Upload scan results
+        uses: actions/upload-artifact@v4
+        with:
+          name: scan-results
+          path: scan-results.json
+
+  triage:
+    name: AI Triage
+    runs-on: ubuntu-latest
+    needs: scan
+    if: needs.scan.outputs.findings-count > 0
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install tools
+        run: pip install specify-cli
+
+      - name: Download scan results
+        uses: actions/download-artifact@v4
+        with:
+          name: scan-results
+
+      - name: Run AI triage
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          specify security triage scan-results.json \
+            --format json \
+            --output triage-results.json
+
+      - name: Upload triage results
+        uses: actions/upload-artifact@v4
+        with:
+          name: triage-results
+          path: triage-results.json
+
+  report:
+    name: Generate Report
+    runs-on: ubuntu-latest
+    needs: [scan, triage]
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install tools
+        run: pip install specify-cli
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+
+      - name: Generate audit report
+        run: |
+          specify security audit scan-results/scan-results.json \
+            --format markdown \
+            --output security-report.md \
+            --owasp
+
+      - name: Generate SARIF
+        run: |
+          specify security audit scan-results/scan-results.json \
+            --format sarif \
+            --output results.sarif
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const report = fs.readFileSync('security-report.md', 'utf8');
+            const summary = report.split('\n').slice(0, 50).join('\n');
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## Security Scan Results\n\n${summary}\n\n<details><summary>Full Report</summary>\n\n${report}\n\n</details>`
+            });
+```
+
+### Incremental Scan (PR Only)
+
+```yaml
+# .github/workflows/security-incremental.yml
+name: Incremental Security Scan
+
+on:
+  pull_request:
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed
+        run: |
+          echo "files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | tr '\n' ' ')" >> $GITHUB_OUTPUT
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install tools
+        run: pip install specify-cli semgrep
+
+      - name: Scan changed files
+        if: steps.changed.outputs.files != ''
+        run: |
+          specify security scan ${{ steps.changed.outputs.files }} \
+            --fail-on high
+```
+
+## GitLab CI
+
+### Basic Configuration
+
+```yaml
+# .gitlab-ci.yml
+stages:
+  - test
+  - security
+  - report
+
+variables:
+  PIP_CACHE_DIR: "$CI_PROJECT_DIR/.pip-cache"
+
+.security-base:
+  image: python:3.11
+  before_script:
+    - pip install specify-cli semgrep
+  cache:
+    paths:
+      - .pip-cache/
+
+security-scan:
+  extends: .security-base
+  stage: security
+  script:
+    - specify security scan --format json --output gl-sast-report.json
+  artifacts:
+    reports:
+      sast: gl-sast-report.json
+    paths:
+      - gl-sast-report.json
+    expire_in: 1 week
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+security-triage:
+  extends: .security-base
+  stage: security
+  needs: [security-scan]
+  script:
+    - specify security triage gl-sast-report.json --format json --output triage-report.json
+  artifacts:
+    paths:
+      - triage-report.json
+    expire_in: 1 week
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  when: manual
+
+security-report:
+  extends: .security-base
+  stage: report
+  needs: [security-scan]
+  script:
+    - specify security audit gl-sast-report.json --format markdown --output security-report.md
+    - specify security audit gl-sast-report.json --format html --output security-report.html
+  artifacts:
+    paths:
+      - security-report.md
+      - security-report.html
+    expire_in: 1 month
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+security-gate:
+  extends: .security-base
+  stage: security
+  needs: [security-scan]
+  script:
+    - specify security scan --fail-on critical
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+```
+
+### GitLab Security Dashboard Integration
+
+```yaml
+# .gitlab-ci.yml
+include:
+  - template: Security/SAST.gitlab-ci.yml
+
+sast:
+  variables:
+    SAST_EXCLUDED_ANALYZERS: ""
+
+jpspec-security:
+  stage: test
+  image: python:3.11
+  script:
+    - pip install specify-cli semgrep
+    - specify security scan --format json --output gl-sast-report.json
+  artifacts:
+    reports:
+      sast: gl-sast-report.json
+```
+
+## Jenkins
+
+### Jenkinsfile
+
+```groovy
+// Jenkinsfile
+pipeline {
+    agent {
+        docker {
+            image 'python:3.11'
+        }
+    }
+
+    environment {
+        ANTHROPIC_API_KEY = credentials('anthropic-api-key')
+    }
+
+    stages {
+        stage('Setup') {
+            steps {
+                sh 'pip install specify-cli semgrep'
+            }
+        }
+
+        stage('Security Scan') {
+            steps {
+                sh '''
+                    specify security scan \
+                        --format json \
+                        --output scan-results.json
+                '''
+            }
+            post {
+                always {
+                    archiveArtifacts artifacts: 'scan-results.json'
+                }
+            }
+        }
+
+        stage('AI Triage') {
+            when {
+                expression {
+                    def results = readJSON file: 'scan-results.json'
+                    return results.findings.size() > 0
+                }
+            }
+            steps {
+                sh '''
+                    specify security triage scan-results.json \
+                        --format json \
+                        --output triage-results.json
+                '''
+            }
+            post {
+                always {
+                    archiveArtifacts artifacts: 'triage-results.json'
+                }
+            }
+        }
+
+        stage('Generate Report') {
+            steps {
+                sh '''
+                    specify security audit scan-results.json \
+                        --format html \
+                        --output security-report.html \
+                        --owasp
+                '''
+            }
+            post {
+                always {
+                    publishHTML(target: [
+                        allowMissing: false,
+                        alwaysLinkToLastBuild: true,
+                        keepAll: true,
+                        reportDir: '.',
+                        reportFiles: 'security-report.html',
+                        reportName: 'Security Report'
+                    ])
+                }
+            }
+        }
+
+        stage('Security Gate') {
+            steps {
+                sh 'specify security scan --fail-on high'
+            }
+        }
+    }
+
+    post {
+        failure {
+            emailext(
+                subject: "Security Scan Failed: ${env.JOB_NAME} #${env.BUILD_NUMBER}",
+                body: "Security vulnerabilities found. See: ${env.BUILD_URL}",
+                recipientProviders: [developers()]
+            )
+        }
+    }
+}
+```
+
+### Jenkins Declarative with Matrix
+
+```groovy
+// Jenkinsfile with matrix builds
+pipeline {
+    agent none
+
+    stages {
+        stage('Security Matrix') {
+            matrix {
+                axes {
+                    axis {
+                        name 'SCANNER'
+                        values 'semgrep', 'bandit'
+                    }
+                }
+                agent {
+                    docker { image 'python:3.11' }
+                }
+                stages {
+                    stage('Scan') {
+                        steps {
+                            sh """
+                                pip install specify-cli ${SCANNER}
+                                specify security scan \
+                                    --scanner ${SCANNER} \
+                                    --format json \
+                                    --output ${SCANNER}-results.json
+                            """
+                        }
+                        post {
+                            always {
+                                archiveArtifacts artifacts: "${SCANNER}-results.json"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+## Azure DevOps
+
+### Azure Pipelines
+
+```yaml
+# azure-pipelines.yml
+trigger:
+  - main
+  - develop
+
+pr:
+  - main
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+  pythonVersion: '3.11'
+
+stages:
+  - stage: Security
+    displayName: 'Security Scanning'
+    jobs:
+      - job: Scan
+        displayName: 'Security Scan'
+        steps:
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: '$(pythonVersion)'
+
+          - script: |
+              pip install specify-cli semgrep
+            displayName: 'Install tools'
+
+          - script: |
+              specify security scan \
+                --format json \
+                --output $(Build.ArtifactStagingDirectory)/scan-results.json
+            displayName: 'Run security scan'
+
+          - task: PublishBuildArtifacts@1
+            inputs:
+              pathToPublish: '$(Build.ArtifactStagingDirectory)/scan-results.json'
+              artifactName: 'SecurityResults'
+
+          - script: |
+              specify security scan --fail-on high
+            displayName: 'Security gate'
+            continueOnError: true
+
+      - job: Report
+        displayName: 'Generate Report'
+        dependsOn: Scan
+        steps:
+          - task: DownloadBuildArtifacts@0
+            inputs:
+              artifactName: 'SecurityResults'
+
+          - script: |
+              pip install specify-cli
+              specify security audit \
+                $(System.ArtifactsDirectory)/SecurityResults/scan-results.json \
+                --format html \
+                --output $(Build.ArtifactStagingDirectory)/security-report.html
+            displayName: 'Generate HTML report'
+
+          - task: PublishBuildArtifacts@1
+            inputs:
+              pathToPublish: '$(Build.ArtifactStagingDirectory)/security-report.html'
+              artifactName: 'SecurityReport'
+```
+
+## CircleCI
+
+### CircleCI Configuration
+
+```yaml
+# .circleci/config.yml
+version: 2.1
+
+orbs:
+  python: circleci/python@2.1
+
+executors:
+  security-executor:
+    docker:
+      - image: cimg/python:3.11
+
+jobs:
+  security-scan:
+    executor: security-executor
+    steps:
+      - checkout
+      - python/install-packages:
+          pkg-manager: pip
+          packages: specify-cli semgrep
+      - run:
+          name: Run security scan
+          command: |
+            specify security scan \
+              --format json \
+              --output scan-results.json
+      - store_artifacts:
+          path: scan-results.json
+      - persist_to_workspace:
+          root: .
+          paths:
+            - scan-results.json
+
+  security-triage:
+    executor: security-executor
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - python/install-packages:
+          pkg-manager: pip
+          packages: specify-cli
+      - run:
+          name: AI triage
+          command: |
+            specify security triage scan-results.json \
+              --format json \
+              --output triage-results.json
+      - store_artifacts:
+          path: triage-results.json
+
+  security-report:
+    executor: security-executor
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - python/install-packages:
+          pkg-manager: pip
+          packages: specify-cli
+      - run:
+          name: Generate report
+          command: |
+            specify security audit scan-results.json \
+              --format html \
+              --output security-report.html
+      - store_artifacts:
+          path: security-report.html
+
+  security-gate:
+    executor: security-executor
+    steps:
+      - checkout
+      - python/install-packages:
+          pkg-manager: pip
+          packages: specify-cli semgrep
+      - run:
+          name: Security gate
+          command: specify security scan --fail-on critical
+
+workflows:
+  security:
+    jobs:
+      - security-scan
+      - security-triage:
+          requires:
+            - security-scan
+      - security-report:
+          requires:
+            - security-scan
+      - security-gate:
+          requires:
+            - security-scan
+```
+
+## Pre-commit Integration
+
+### Basic Pre-commit Hook
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: local
+    hooks:
+      - id: jpspec-security
+        name: Security Scan
+        entry: specify security scan --quick --fail-on critical
+        language: python
+        additional_dependencies: [specify-cli, semgrep]
+        pass_filenames: false
+        stages: [commit]
+```
+
+### Advanced Pre-commit with Multiple Hooks
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: local
+    hooks:
+      - id: jpspec-security-python
+        name: Security Scan (Python)
+        entry: specify security scan --scanner semgrep --quick --fail-on high
+        language: python
+        additional_dependencies: [specify-cli, semgrep]
+        types: [python]
+        pass_filenames: false
+
+      - id: jpspec-security-bandit
+        name: Bandit Security Check
+        entry: bandit -r
+        language: python
+        additional_dependencies: [bandit]
+        types: [python]
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: detect-private-key
+      - id: detect-aws-credentials
+```
+
+## Best Practices
+
+### 1. Fail Fast, Report Always
+
+```yaml
+# Always upload results, even on failure
+- name: Upload SARIF
+  uses: github/codeql-action/upload-sarif@v3
+  if: always()
+  with:
+    sarif_file: results.sarif
+```
+
+### 2. Cache Scanner Tools
+
+```yaml
+- name: Cache scanner tools
+  uses: actions/cache@v4
+  with:
+    path: ~/.local/share/specify/tools
+    key: security-tools-${{ runner.os }}
+```
+
+### 3. Use Secrets Properly
+
+```yaml
+env:
+  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+```
+
+### 4. Incremental Scans for PRs
+
+```yaml
+- name: Scan changed files only
+  run: |
+    git diff --name-only ${{ github.event.before }} ${{ github.sha }} | \
+    xargs specify security scan
+```
+
+### 5. Scheduled Full Scans
+
+```yaml
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly
+```
+
+## Troubleshooting
+
+### Scanner Not Found in CI
+
+```yaml
+- name: Install scanner
+  run: |
+    pip install semgrep
+    which semgrep  # Verify installation
+```
+
+### Permission Denied for SARIF Upload
+
+Ensure workflow has correct permissions:
+
+```yaml
+permissions:
+  security-events: write
+```
+
+### Timeouts on Large Codebases
+
+```yaml
+- name: Run scan with timeout
+  timeout-minutes: 30
+  run: specify security scan --timeout 1800
+```
+
+## Related Documentation
+
+- [Security Quickstart](./security-quickstart.md)
+- [Command Reference](../reference/jpspec-security-commands.md)
+- [Custom Rules](./security-custom-rules.md)

--- a/docs/guides/security-custom-rules.md
+++ b/docs/guides/security-custom-rules.md
@@ -1,0 +1,462 @@
+# Custom Security Rules Guide
+
+This guide explains how to create custom security rules for `/jpspec:security` scanning.
+
+## Overview
+
+Custom rules allow you to:
+- Detect organization-specific vulnerability patterns
+- Enforce internal coding standards
+- Add checks for proprietary frameworks
+- Reduce false positives with context-aware rules
+
+## Rule Formats
+
+### Semgrep Rules (Recommended)
+
+Semgrep rules are YAML-based pattern matching rules.
+
+**Location**: `.specify/security/rules/` or `.semgrep/`
+
+**Example**: Detect hardcoded AWS keys
+
+```yaml
+# .specify/security/rules/aws-keys.yml
+rules:
+  - id: hardcoded-aws-access-key
+    pattern: AKIA[A-Z0-9]{16}
+    message: "Hardcoded AWS access key detected"
+    severity: ERROR
+    languages:
+      - generic
+    metadata:
+      cwe: "CWE-798"
+      owasp: "A07:2021"
+      category: security
+
+  - id: hardcoded-aws-secret-key
+    pattern-regex: "['\"][A-Za-z0-9/+=]{40}['\"]"
+    message: "Possible hardcoded AWS secret key"
+    severity: WARNING
+    languages:
+      - generic
+    metadata:
+      cwe: "CWE-798"
+```
+
+### Bandit Rules (Python)
+
+Bandit plugins are Python modules that extend the scanner.
+
+**Location**: `.specify/security/bandit/`
+
+**Example**: Detect unsafe deserialization
+
+```python
+# .specify/security/bandit/unsafe_yaml.py
+import bandit
+from bandit.core import issue
+from bandit.core import test_properties as test
+
+@test.checks('Call')
+@test.test_id('B506')
+def unsafe_yaml_load(context):
+    """Detect yaml.load without SafeLoader."""
+    if context.call_function_name_qual == 'yaml.load':
+        if not context.check_call_arg_value('Loader', 'SafeLoader'):
+            return bandit.Issue(
+                severity=bandit.HIGH,
+                confidence=bandit.HIGH,
+                text="yaml.load() called without SafeLoader",
+                cwe=issue.Cwe.DESERIALIZATION_OF_UNTRUSTED_DATA
+            )
+```
+
+## Creating Semgrep Rules
+
+### Basic Pattern Matching
+
+```yaml
+rules:
+  - id: my-rule-id
+    pattern: dangerous_function($ARG)
+    message: "Avoid using dangerous_function"
+    severity: WARNING
+    languages:
+      - python
+```
+
+### Pattern Operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `pattern` | Exact match | `eval($X)` |
+| `pattern-regex` | Regex match | `password\s*=\s*['\"]` |
+| `pattern-either` | OR patterns | Multiple patterns |
+| `pattern-not` | Exclude pattern | Filter false positives |
+| `pattern-inside` | Context match | Match within function |
+| `pattern-not-inside` | Exclude context | Exclude safe contexts |
+
+### Example: Complex Rule
+
+```yaml
+rules:
+  - id: flask-sql-injection
+    patterns:
+      - pattern-either:
+          - pattern: cursor.execute($QUERY)
+          - pattern: db.execute($QUERY)
+      - pattern-not:
+          - pattern: cursor.execute("...", $PARAMS)
+      - metavariable-pattern:
+          metavariable: $QUERY
+          patterns:
+            - pattern-either:
+                - pattern: $X + $Y
+                - pattern: f"..."
+                - pattern: "...".format(...)
+    message: |
+      SQL query constructed with string concatenation or formatting.
+      Use parameterized queries instead.
+    severity: ERROR
+    languages:
+      - python
+    metadata:
+      cwe: "CWE-89"
+      owasp: "A03:2021"
+      remediation: |
+        Use parameterized queries:
+        ```python
+        cursor.execute("SELECT * FROM users WHERE id = ?", (user_id,))
+        ```
+```
+
+### Metavariables
+
+Metavariables capture code elements for analysis:
+
+| Metavariable | Description |
+|--------------|-------------|
+| `$X` | Any expression |
+| `$...X` | Multiple expressions |
+| `$_` | Any single item (ignore) |
+
+```yaml
+rules:
+  - id: insecure-random
+    pattern: random.random()
+    message: "Use secrets module for security-sensitive randomness"
+    severity: WARNING
+    languages:
+      - python
+    fix: secrets.token_hex(16)
+```
+
+## Rule Configuration
+
+### Enable Custom Rules
+
+```yaml
+# .specify/security.yml
+scanners:
+  semgrep:
+    enabled: true
+    config:
+      - auto  # OWASP ruleset
+      - .specify/security/rules/  # Custom rules
+    exclude_rules:
+      - generic.secrets.security.detected-generic-api-key
+```
+
+### Rule Priority
+
+Rules are applied in order:
+1. Built-in rules (auto)
+2. Custom rules (.specify/security/rules/)
+3. Exclusions applied last
+
+## Testing Custom Rules
+
+### Using Semgrep CLI
+
+```bash
+# Test rule against file
+semgrep --config .specify/security/rules/my-rule.yml src/
+
+# Test with verbose output
+semgrep --config .specify/security/rules/my-rule.yml src/ --verbose
+
+# Validate rule syntax
+semgrep --validate --config .specify/security/rules/my-rule.yml
+```
+
+### Creating Test Cases
+
+```yaml
+# .specify/security/rules/my-rule.yml
+rules:
+  - id: unsafe-eval
+    pattern: eval($X)
+    message: "Avoid eval()"
+    severity: ERROR
+    languages:
+      - python
+
+# Test file: .specify/security/rules/my-rule.test.py
+# ruleid: unsafe-eval
+eval(user_input)
+
+# ok: unsafe-eval
+ast.literal_eval(safe_input)
+```
+
+Run tests:
+
+```bash
+semgrep --test .specify/security/rules/
+```
+
+## Common Rule Patterns
+
+### 1. Detect Dangerous Functions
+
+```yaml
+rules:
+  - id: dangerous-exec
+    pattern-either:
+      - pattern: exec($X)
+      - pattern: eval($X)
+      - pattern: compile($X, ...)
+    message: "Dangerous code execution function"
+    severity: ERROR
+    languages:
+      - python
+```
+
+### 2. Detect Insecure Configuration
+
+```yaml
+rules:
+  - id: flask-debug-true
+    pattern: app.run(..., debug=True, ...)
+    message: "Flask debug mode enabled in production"
+    severity: ERROR
+    languages:
+      - python
+    paths:
+      exclude:
+        - "**/test_*.py"
+        - "**/tests/**"
+```
+
+### 3. Detect Missing Security Headers
+
+```yaml
+rules:
+  - id: missing-csrf-protection
+    patterns:
+      - pattern: |
+          @app.route(...)
+          def $FUNC(...):
+            ...
+      - pattern-not-inside: |
+          @csrf.exempt
+          ...
+      - pattern-not-inside: |
+          csrf_token()
+          ...
+    message: "Route handler may be missing CSRF protection"
+    severity: WARNING
+    languages:
+      - python
+```
+
+### 4. Detect Hardcoded Credentials
+
+```yaml
+rules:
+  - id: hardcoded-password
+    patterns:
+      - pattern-either:
+          - pattern: password = "..."
+          - pattern: PASSWORD = "..."
+          - pattern: secret = "..."
+      - pattern-not: password = ""
+      - pattern-not: password = os.environ[...]
+    message: "Hardcoded password detected"
+    severity: ERROR
+    languages:
+      - python
+```
+
+### 5. Detect SQL Injection (Framework-Specific)
+
+```yaml
+rules:
+  - id: django-raw-sql-injection
+    patterns:
+      - pattern-either:
+          - pattern: Model.objects.raw($QUERY)
+          - pattern: connection.cursor().execute($QUERY)
+      - metavariable-pattern:
+          metavariable: $QUERY
+          pattern-either:
+            - pattern: $X + $Y
+            - pattern: f"..."
+            - pattern: "...".format(...)
+    message: "Django raw SQL with string interpolation"
+    severity: ERROR
+    languages:
+      - python
+```
+
+## Integrating with jpspec
+
+### Custom Rule Workflow
+
+1. **Create rule file**:
+   ```bash
+   mkdir -p .specify/security/rules
+   vim .specify/security/rules/company-rules.yml
+   ```
+
+2. **Test locally**:
+   ```bash
+   specify security scan --config .specify/security/rules/
+   ```
+
+3. **Add to configuration**:
+   ```yaml
+   # .specify/security.yml
+   scanners:
+     semgrep:
+       config:
+         - auto
+         - .specify/security/rules/
+   ```
+
+4. **Commit and use**:
+   ```bash
+   git add .specify/security/rules/
+   git commit -m "Add custom security rules"
+   specify security scan
+   ```
+
+## Rule Metadata
+
+Include metadata for better reporting:
+
+```yaml
+rules:
+  - id: my-rule
+    metadata:
+      # OWASP mapping
+      owasp: "A03:2021"
+
+      # CWE identifier
+      cwe: "CWE-89"
+
+      # Category for grouping
+      category: security
+
+      # Confidence level
+      confidence: HIGH
+
+      # Technology tags
+      technology:
+        - flask
+        - python
+
+      # Remediation guidance
+      remediation: |
+        Use parameterized queries instead of string concatenation.
+
+      # References
+      references:
+        - https://owasp.org/Top10/A03_2021-Injection/
+```
+
+## Best Practices
+
+### 1. Start Specific
+
+Begin with specific patterns, then generalize:
+
+```yaml
+# Too broad - many false positives
+pattern: $X + $Y
+
+# Better - scoped to SQL context
+patterns:
+  - pattern: cursor.execute($X + $Y)
+```
+
+### 2. Use Pattern-Not for False Positives
+
+```yaml
+patterns:
+  - pattern: yaml.load($X)
+  - pattern-not: yaml.load($X, Loader=yaml.SafeLoader)
+```
+
+### 3. Include Fix Suggestions
+
+```yaml
+rules:
+  - id: md5-usage
+    pattern: hashlib.md5($X)
+    message: "MD5 is cryptographically weak"
+    fix: hashlib.sha256($X)
+```
+
+### 4. Test Thoroughly
+
+- Create positive test cases (should match)
+- Create negative test cases (should not match)
+- Test on real codebase before deploying
+
+### 5. Document Rules
+
+```yaml
+rules:
+  - id: company-specific-rule
+    message: |
+      ## Issue
+      Description of the security issue.
+
+      ## Impact
+      What could happen if exploited.
+
+      ## Remediation
+      How to fix it.
+```
+
+## Troubleshooting
+
+### Rule Not Matching
+
+```bash
+# Debug with verbose output
+semgrep --verbose --config rule.yml file.py
+
+# Check pattern syntax
+semgrep --validate --config rule.yml
+```
+
+### Too Many False Positives
+
+1. Add `pattern-not` clauses
+2. Use `paths.exclude` for test files
+3. Add `pattern-inside` for context
+
+### Performance Issues
+
+1. Use specific file types in `languages`
+2. Avoid overly broad regex patterns
+3. Use `paths.include` to limit scope
+
+## Related Documentation
+
+- [Security Quickstart](./security-quickstart.md)
+- [Command Reference](../reference/jpspec-security-commands.md)
+- [Semgrep Rule Syntax](https://semgrep.dev/docs/writing-rules/rule-syntax/)

--- a/docs/guides/security-quickstart.md
+++ b/docs/guides/security-quickstart.md
@@ -1,0 +1,295 @@
+# Security Quickstart Guide
+
+This guide helps you integrate security scanning into your development workflow using `/jpspec:security` commands.
+
+## Prerequisites
+
+- Python 3.11+
+- JP Spec Kit installed (`pip install specify-cli`)
+- At least one security scanner (Semgrep recommended)
+
+### Installing Semgrep
+
+```bash
+# Via pip (recommended)
+pip install semgrep
+
+# Via Homebrew (macOS/Linux)
+brew install semgrep
+
+# Verify installation
+semgrep --version
+```
+
+## Quick Start
+
+### 1. Run Your First Scan
+
+```bash
+# Scan current directory
+specify security scan
+
+# Scan specific path
+specify security scan ./src
+
+# Output as JSON for CI/CD
+specify security scan --format json --output results.json
+```
+
+### 2. Triage Findings with AI
+
+```bash
+# AI-powered triage to classify true/false positives
+specify security triage results.json
+
+# Interactive mode for manual confirmation
+specify security triage results.json --interactive
+```
+
+### 3. Generate Fix Suggestions
+
+```bash
+# Generate fix patches for findings
+specify security fix results.json
+
+# Auto-apply patches (use with caution)
+specify security fix results.json --apply
+```
+
+### 4. Generate Audit Report
+
+```bash
+# Generate compliance-ready report
+specify security audit results.json --format markdown
+
+# Generate SARIF for GitHub Code Scanning
+specify security audit results.json --format sarif --output results.sarif
+```
+
+## CLI Command Summary
+
+| Command | Description |
+|---------|-------------|
+| `specify security scan [PATH]` | Run security scanners on codebase |
+| `specify security triage RESULTS` | AI-powered finding classification |
+| `specify security fix RESULTS` | Generate remediation patches |
+| `specify security audit RESULTS` | Generate compliance reports |
+| `specify security status` | Show scan status and configuration |
+
+## Slash Commands
+
+Use these within Claude Code sessions:
+
+| Command | Description |
+|---------|-------------|
+| `/jpspec:security scan` | Interactive security scan |
+| `/jpspec:security triage` | AI triage with explanations |
+| `/jpspec:security fix` | Generate and review fixes |
+| `/jpspec:security audit` | Generate security report |
+
+## Configuration
+
+Create `.specify/security.yml` in your project root:
+
+```yaml
+# Security scanning configuration
+version: "1.0"
+
+# Scanner configuration
+scanners:
+  semgrep:
+    enabled: true
+    config: auto  # Use "auto" for OWASP rules
+    severity_threshold: warning
+
+  bandit:
+    enabled: false
+    severity_threshold: medium
+
+# Fail threshold for CI/CD
+fail_on:
+  severity: high  # critical, high, medium, low
+  confidence: high
+
+# Exclusions
+exclusions:
+  paths:
+    - "**/tests/**"
+    - "**/node_modules/**"
+    - "**/.venv/**"
+  patterns:
+    - "*.test.py"
+    - "*.spec.ts"
+
+# Triage configuration
+triage:
+  auto_dismiss_info: true
+  require_review_for: critical
+
+# Reporting
+reporting:
+  formats:
+    - markdown
+    - sarif
+  owasp_mapping: true
+  include_remediation: true
+```
+
+## CI/CD Integration
+
+### GitHub Actions
+
+```yaml
+name: Security Scan
+on: [push, pull_request]
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          pip install specify-cli semgrep
+
+      - name: Run security scan
+        run: specify security scan --format sarif --output results.sarif
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+```
+
+### GitLab CI
+
+```yaml
+security-scan:
+  stage: security
+  image: python:3.11
+  script:
+    - pip install specify-cli semgrep
+    - specify security scan --format json --output gl-sast-report.json
+  artifacts:
+    reports:
+      sast: gl-sast-report.json
+```
+
+## Common Workflows
+
+### Workflow 1: Quick Security Check
+
+```bash
+# Fast scan with default settings
+specify security scan --quick
+
+# View summary
+specify security status
+```
+
+### Workflow 2: Pre-Commit Hook
+
+Add to `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: jpspec-security
+        name: Security Scan
+        entry: specify security scan --fail-on high
+        language: python
+        pass_filenames: false
+```
+
+### Workflow 3: Full Security Audit
+
+```bash
+# Comprehensive scan
+specify security scan --all-scanners
+
+# AI triage
+specify security triage results.json --interactive
+
+# Generate fixes
+specify security fix results.json
+
+# Generate audit report
+specify security audit results.json --format markdown --compliance soc2
+```
+
+## Severity Levels
+
+| Level | Description | Example |
+|-------|-------------|---------|
+| **Critical** | Immediate exploitation risk | SQL injection, RCE |
+| **High** | Significant security impact | XSS, path traversal |
+| **Medium** | Moderate risk with mitigations | Information disclosure |
+| **Low** | Minor issues or hardening | Missing security headers |
+| **Info** | Best practices, no risk | Code quality suggestions |
+
+## OWASP Top 10 Mapping
+
+Findings are automatically mapped to OWASP Top 10 2021:
+
+| Category | CWEs | Example |
+|----------|------|---------|
+| A01 Broken Access Control | CWE-22, CWE-284 | Path traversal |
+| A02 Cryptographic Failures | CWE-327, CWE-328 | Weak encryption |
+| A03 Injection | CWE-79, CWE-89 | SQL injection, XSS |
+| A04 Insecure Design | CWE-209, CWE-256 | Design flaws |
+| A05 Security Misconfiguration | CWE-16, CWE-611 | XML external entities |
+| A06 Vulnerable Components | CWE-829, CWE-1035 | Known vulnerabilities |
+| A07 Auth Failures | CWE-287, CWE-384 | Broken authentication |
+| A08 Data Integrity Failures | CWE-502, CWE-829 | Deserialization |
+| A09 Logging Failures | CWE-117, CWE-223 | Log injection |
+| A10 SSRF | CWE-918 | Server-side request forgery |
+
+## Troubleshooting
+
+### Scanner Not Found
+
+```bash
+# Check if scanner is installed
+which semgrep
+
+# Install if missing
+pip install semgrep
+```
+
+### Permission Denied
+
+```bash
+# Ensure scanner is executable
+chmod +x $(which semgrep)
+```
+
+### High False Positive Rate
+
+1. Use conservative rulesets: `--config auto`
+2. Enable AI triage: `specify security triage results.json`
+3. Add exclusions for test files
+4. Tune sensitivity in `.specify/security.yml`
+
+### Memory Issues on Large Codebases
+
+```bash
+# Scan incrementally
+specify security scan --incremental
+
+# Limit parallel jobs
+specify security scan --jobs 2
+```
+
+## Next Steps
+
+- [Command Reference](../reference/jpspec-security-commands.md) - Full CLI documentation
+- [CI/CD Integration](./security-cicd-integration.md) - Detailed pipeline setup
+- [Custom Rules](./security-custom-rules.md) - Writing custom security rules
+- [Threat Model](../reference/security-threat-model.md) - Security limitations

--- a/docs/reference/jpspec-security-commands.md
+++ b/docs/reference/jpspec-security-commands.md
@@ -1,0 +1,462 @@
+# Security Commands Reference
+
+Complete reference for `/jpspec:security` slash commands and `specify security` CLI commands.
+
+## Command Overview
+
+```
+specify security <command> [options]
+```
+
+### Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `scan` | Run security scanners on codebase |
+| `triage` | AI-powered finding classification |
+| `fix` | Generate remediation patches |
+| `audit` | Generate compliance reports |
+| `status` | Show configuration and scan status |
+| `init` | Initialize security configuration |
+
+---
+
+## `specify security scan`
+
+Run security scanners and generate findings.
+
+### Usage
+
+```bash
+specify security scan [PATH] [OPTIONS]
+```
+
+### Arguments
+
+| Argument | Description | Default |
+|----------|-------------|---------|
+| `PATH` | Directory or file to scan | `.` (current directory) |
+
+### Options
+
+| Option | Short | Description | Default |
+|--------|-------|-------------|---------|
+| `--scanner` | `-s` | Specific scanner to use | All enabled |
+| `--config` | `-c` | Scanner configuration | `auto` |
+| `--format` | `-f` | Output format (json, sarif, markdown) | `json` |
+| `--output` | `-o` | Output file path | stdout |
+| `--severity` | | Minimum severity to report | `info` |
+| `--fail-on` | | Fail if findings >= severity | None |
+| `--incremental` | | Only scan changed files | `false` |
+| `--quick` | `-q` | Fast scan with reduced rules | `false` |
+| `--jobs` | `-j` | Parallel scanner jobs | Auto |
+| `--timeout` | `-t` | Scan timeout in seconds | 300 |
+| `--verbose` | `-v` | Verbose output | `false` |
+
+### Examples
+
+```bash
+# Basic scan
+specify security scan
+
+# Scan specific directory with JSON output
+specify security scan ./src --format json --output results.json
+
+# Use only Semgrep
+specify security scan --scanner semgrep
+
+# Fail CI on high severity findings
+specify security scan --fail-on high
+
+# Quick scan for pre-commit
+specify security scan --quick --fail-on critical
+
+# SARIF output for GitHub
+specify security scan --format sarif --output results.sarif
+```
+
+### Exit Codes
+
+| Code | Description |
+|------|-------------|
+| 0 | Success, no findings above threshold |
+| 1 | Findings found above `--fail-on` threshold |
+| 2 | Scanner execution error |
+| 3 | Configuration error |
+
+---
+
+## `specify security triage`
+
+AI-powered classification of security findings.
+
+### Usage
+
+```bash
+specify security triage RESULTS [OPTIONS]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `RESULTS` | Path to scan results JSON file |
+
+### Options
+
+| Option | Short | Description | Default |
+|--------|-------|-------------|---------|
+| `--interactive` | `-i` | Interactive confirmation mode | `false` |
+| `--model` | `-m` | AI model to use | `claude-sonnet-4-20250514` |
+| `--output` | `-o` | Output file for triage results | stdout |
+| `--format` | `-f` | Output format (json, markdown) | `json` |
+| `--auto-dismiss` | | Auto-dismiss info severity | `false` |
+| `--confidence-threshold` | | Minimum AI confidence | 0.7 |
+| `--explain` | `-e` | Include detailed explanations | `true` |
+| `--verbose` | `-v` | Verbose output | `false` |
+
+### Classifications
+
+| Classification | Code | Description |
+|----------------|------|-------------|
+| True Positive | `TP` | Confirmed vulnerability |
+| False Positive | `FP` | Not a real vulnerability |
+| Needs Investigation | `NI` | Requires manual review |
+
+### Examples
+
+```bash
+# Basic triage
+specify security triage results.json
+
+# Interactive mode with explanations
+specify security triage results.json --interactive --explain
+
+# Auto-dismiss informational findings
+specify security triage results.json --auto-dismiss
+
+# Output triage report
+specify security triage results.json --format markdown --output triage.md
+```
+
+### Output Format
+
+```json
+{
+  "findings": [
+    {
+      "id": "SEMGREP-001",
+      "classification": "TP",
+      "confidence": 0.95,
+      "risk_score": 8.5,
+      "explanation": {
+        "summary": "SQL injection vulnerability",
+        "impact": "Attackers can execute arbitrary SQL",
+        "exploitability": "High - user input directly concatenated",
+        "recommendation": "Use parameterized queries"
+      }
+    }
+  ],
+  "summary": {
+    "total": 10,
+    "true_positives": 6,
+    "false_positives": 3,
+    "needs_investigation": 1
+  }
+}
+```
+
+---
+
+## `specify security fix`
+
+Generate remediation patches for security findings.
+
+### Usage
+
+```bash
+specify security fix RESULTS [OPTIONS]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `RESULTS` | Path to triage results JSON file |
+
+### Options
+
+| Option | Short | Description | Default |
+|--------|-------|-------------|---------|
+| `--apply` | `-a` | Apply patches automatically | `false` |
+| `--dry-run` | | Preview changes without applying | `true` |
+| `--output` | `-o` | Output directory for patches | `./patches` |
+| `--format` | `-f` | Patch format (unified, git) | `unified` |
+| `--validate` | | Validate syntax after patch | `true` |
+| `--test` | | Run tests after applying | `false` |
+| `--backup` | | Create backup before patching | `true` |
+| `--verbose` | `-v` | Verbose output | `false` |
+
+### Examples
+
+```bash
+# Generate patches (dry-run)
+specify security fix triage.json
+
+# Preview specific fixes
+specify security fix triage.json --dry-run
+
+# Apply patches with backup
+specify security fix triage.json --apply --backup
+
+# Apply and run tests
+specify security fix triage.json --apply --test
+
+# Output patches to directory
+specify security fix triage.json --output ./security-patches
+```
+
+### Patch Output
+
+```diff
+--- a/src/db.py
++++ b/src/db.py
+@@ -42,1 +42,1 @@
+-    query = "SELECT * FROM users WHERE id = " + user_id
++    query = "SELECT * FROM users WHERE id = ?"
++    cursor.execute(query, (user_id,))
+```
+
+---
+
+## `specify security audit`
+
+Generate compliance-ready security audit reports.
+
+### Usage
+
+```bash
+specify security audit RESULTS [OPTIONS]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `RESULTS` | Path to scan or triage results |
+
+### Options
+
+| Option | Short | Description | Default |
+|--------|-------|-------------|---------|
+| `--format` | `-f` | Report format (markdown, html, sarif, json) | `markdown` |
+| `--output` | `-o` | Output file path | stdout |
+| `--compliance` | `-c` | Compliance framework (soc2, iso27001, hipaa) | None |
+| `--owasp` | | Include OWASP Top 10 mapping | `true` |
+| `--executive` | | Include executive summary | `true` |
+| `--technical` | | Include technical details | `true` |
+| `--remediation` | | Include remediation guidance | `true` |
+| `--trend` | | Include historical trend | `false` |
+| `--verbose` | `-v` | Verbose output | `false` |
+
+### Examples
+
+```bash
+# Basic markdown report
+specify security audit results.json
+
+# SARIF for GitHub Code Scanning
+specify security audit results.json --format sarif --output results.sarif
+
+# SOC2 compliance report
+specify security audit results.json --compliance soc2 --format html
+
+# Executive summary only
+specify security audit results.json --executive --no-technical
+```
+
+### Report Sections
+
+1. **Executive Summary** - High-level security posture
+2. **Finding Summary** - Counts by severity and category
+3. **OWASP Top 10 Mapping** - Compliance view
+4. **Detailed Findings** - Technical vulnerability details
+5. **Remediation Plan** - Prioritized fix recommendations
+6. **Appendix** - Scanner configuration and metadata
+
+---
+
+## `specify security status`
+
+Display current security configuration and scan status.
+
+### Usage
+
+```bash
+specify security status [OPTIONS]
+```
+
+### Options
+
+| Option | Short | Description | Default |
+|--------|-------|-------------|---------|
+| `--check-tools` | | Verify scanner installation | `true` |
+| `--config` | | Show current configuration | `true` |
+| `--format` | `-f` | Output format (text, json) | `text` |
+
+### Examples
+
+```bash
+# Check status
+specify security status
+
+# JSON output for scripting
+specify security status --format json
+```
+
+### Output
+
+```
+Security Status
+===============
+
+Configuration: .specify/security.yml (found)
+
+Scanners:
+  [✓] semgrep 1.50.0 (installed)
+  [✗] codeql (not installed)
+  [✗] bandit (not installed)
+
+Last Scan:
+  Date: 2025-12-03 14:30:00
+  Findings: 12 (3 critical, 5 high, 4 medium)
+  Duration: 45s
+
+Configuration:
+  Fail on: high
+  OWASP mapping: enabled
+  Auto-triage: disabled
+```
+
+---
+
+## `specify security init`
+
+Initialize security configuration for a project.
+
+### Usage
+
+```bash
+specify security init [OPTIONS]
+```
+
+### Options
+
+| Option | Short | Description | Default |
+|--------|-------|-------------|---------|
+| `--template` | `-t` | Configuration template (minimal, standard, strict) | `standard` |
+| `--force` | `-f` | Overwrite existing configuration | `false` |
+| `--scanners` | `-s` | Scanners to configure | `semgrep` |
+
+### Examples
+
+```bash
+# Initialize with standard template
+specify security init
+
+# Strict security configuration
+specify security init --template strict
+
+# Minimal configuration
+specify security init --template minimal --scanners semgrep
+```
+
+---
+
+## Slash Commands
+
+### `/jpspec:security scan`
+
+Interactive security scanning within Claude Code sessions.
+
+```
+/jpspec:security scan
+```
+
+**Behavior:**
+1. Detects available scanners
+2. Prompts for scan scope (all files, changed files, specific path)
+3. Runs scan with progress display
+4. Shows findings summary
+5. Offers to proceed with triage
+
+### `/jpspec:security triage`
+
+AI-powered finding triage with explanations.
+
+```
+/jpspec:security triage
+```
+
+**Behavior:**
+1. Loads latest scan results
+2. Classifies each finding (TP/FP/NI)
+3. Provides plain-English explanations
+4. Calculates risk scores
+5. Prioritizes remediation order
+
+### `/jpspec:security fix`
+
+Generate and apply security fixes.
+
+```
+/jpspec:security fix
+```
+
+**Behavior:**
+1. Loads triage results
+2. Generates fix patches for true positives
+3. Shows diff preview
+4. Prompts for confirmation
+5. Applies patches with backup
+
+### `/jpspec:security audit`
+
+Generate security audit report.
+
+```
+/jpspec:security audit
+```
+
+**Behavior:**
+1. Aggregates scan and triage results
+2. Maps to OWASP Top 10
+3. Calculates security posture score
+4. Generates markdown report
+5. Creates SARIF for GitHub integration
+
+---
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `SPECIFY_SECURITY_CONFIG` | Path to configuration file | `.specify/security.yml` |
+| `SPECIFY_SECURITY_SCANNER` | Default scanner | `semgrep` |
+| `SPECIFY_SECURITY_OUTPUT` | Default output directory | `./security-reports` |
+| `SEMGREP_APP_TOKEN` | Semgrep App token | None |
+| `GITHUB_TOKEN` | GitHub token for SARIF upload | None |
+
+---
+
+## Configuration File
+
+See [Security Configuration Reference](./security-configuration.md) for complete `.specify/security.yml` schema.
+
+## Related Documentation
+
+- [Security Quickstart](../guides/security-quickstart.md) - Getting started guide
+- [CI/CD Integration](../guides/security-cicd-integration.md) - Pipeline setup
+- [Custom Rules](../guides/security-custom-rules.md) - Writing custom rules
+- [Threat Model](./security-threat-model.md) - Security limitations
+- [Privacy Policy](./security-privacy-policy.md) - AI data handling

--- a/docs/reference/security-privacy-policy.md
+++ b/docs/reference/security-privacy-policy.md
@@ -1,0 +1,272 @@
+# Security Scanning Privacy Policy
+
+This document describes how `/jpspec:security` handles your code and data, particularly when using AI-powered features.
+
+## Data Collection Overview
+
+| Feature | Data Sent | Destination | Purpose |
+|---------|-----------|-------------|---------|
+| **Scan** | None | Local only | Scanner runs locally |
+| **Triage** | Code snippets | AI API (Anthropic) | Classification |
+| **Fix** | Code + context | AI API (Anthropic) | Patch generation |
+| **Audit** | None | Local only | Report generation |
+| **SARIF Upload** | Findings only | GitHub | Code Scanning |
+
+## AI Feature Data Handling
+
+### What Data is Sent to AI APIs
+
+When using AI-powered triage or fix generation:
+
+**Sent to AI API:**
+- Code snippet from finding location (typically 10-50 lines)
+- File path (relative to project root)
+- Finding metadata (severity, CWE, description)
+- Scanner-provided context
+
+**NOT Sent to AI API:**
+- Full source files
+- Git history or commit messages
+- Environment variables or secrets
+- Other files in your repository
+- Your API keys or credentials
+
+### Example AI Request
+
+```json
+{
+  "finding": {
+    "id": "SEMGREP-001",
+    "severity": "high",
+    "title": "SQL Injection",
+    "cwe": "CWE-89",
+    "file": "src/db.py",
+    "line": 42,
+    "code_snippet": "query = \"SELECT * FROM users WHERE id = \" + user_id"
+  },
+  "context": {
+    "language": "python",
+    "framework_hints": ["flask"]
+  }
+}
+```
+
+### AI Provider Information
+
+**Default Provider**: Anthropic (Claude)
+
+| Aspect | Details |
+|--------|---------|
+| Provider | Anthropic |
+| Data Retention | See [Anthropic's Privacy Policy](https://www.anthropic.com/privacy) |
+| Training Use | See Anthropic's terms for API usage |
+| Encryption | TLS 1.2+ in transit |
+| Location | US-based servers |
+
+**Alternative Providers**: Future versions may support additional providers. Check configuration options.
+
+## Local-Only Operation
+
+### Running Without AI
+
+To run security scanning without any external API calls:
+
+```bash
+# Scan only (no AI)
+specify security scan --format json --output results.json
+
+# Manual triage (no AI)
+# Review results.json directly
+
+# Report without AI analysis
+specify security audit results.json --no-ai-explanation
+```
+
+### Configuration for Air-Gapped Environments
+
+```yaml
+# .specify/security.yml
+triage:
+  ai_enabled: false  # Disable AI triage
+
+fixes:
+  ai_enabled: false  # Disable AI fix generation
+
+reporting:
+  include_ai_explanation: false
+```
+
+## Scanner Data Handling
+
+### Semgrep
+
+| Aspect | Details |
+|--------|---------|
+| Data Sent | None (local execution) |
+| Rule Download | From Semgrep Registry (HTTPS) |
+| Telemetry | Opt-out via `SEMGREP_SEND_METRICS=off` |
+
+### CodeQL
+
+| Aspect | Details |
+|--------|---------|
+| Data Sent | None (local analysis) |
+| Database | Local CodeQL database |
+| Telemetry | See GitHub's telemetry policy |
+
+### Bandit
+
+| Aspect | Details |
+|--------|---------|
+| Data Sent | None (fully local) |
+| Telemetry | None |
+
+## SARIF Upload to GitHub
+
+When uploading SARIF results to GitHub Code Scanning:
+
+**Data Included in SARIF:**
+- Finding locations (file, line numbers)
+- Rule IDs and descriptions
+- Severity levels
+- CWE identifiers
+
+**NOT Included:**
+- Source code content
+- AI triage explanations
+- Fix suggestions
+
+### Controlling SARIF Content
+
+```bash
+# Minimal SARIF (findings only)
+specify security audit results.json --format sarif --sarif-minimal
+
+# Full SARIF (with descriptions)
+specify security audit results.json --format sarif
+```
+
+## Data Storage
+
+### Local Files Created
+
+| File | Location | Contents | Sensitive? |
+|------|----------|----------|------------|
+| Scan results | `./security-results.json` | Finding details | Low |
+| Triage results | `./triage-results.json` | AI classifications | Low |
+| Patches | `./patches/*.patch` | Code fixes | Medium |
+| Reports | `./security-report.md` | Aggregated findings | Low |
+
+### Cleaning Up
+
+```bash
+# Remove all generated files
+rm -f security-results.json triage-results.json
+rm -rf ./patches
+rm -f security-report.*
+```
+
+## Compliance Considerations
+
+### SOC2
+
+- AI triage sends code snippets externally
+- Document in your data flow diagrams
+- Consider disabling AI for SOC2-scoped code
+
+### HIPAA
+
+- Do not scan PHI-containing code with AI enabled
+- Use local-only mode for healthcare applications
+- Review Anthropic's BAA status
+
+### GDPR
+
+- Code snippets may contain PII
+- Anthropic processes data in US
+- Ensure appropriate data processing agreements
+
+### PCI-DSS
+
+- Cardholder data should not be in source code
+- AI triage is low risk if code is properly written
+- Document external data flows
+
+## Opting Out
+
+### Disable All External Communication
+
+```yaml
+# .specify/security.yml
+privacy:
+  offline_mode: true  # No external API calls
+  disable_telemetry: true
+  disable_rule_updates: true
+```
+
+### Environment Variables
+
+```bash
+# Disable AI features
+export SPECIFY_AI_ENABLED=false
+
+# Disable Semgrep telemetry
+export SEMGREP_SEND_METRICS=off
+
+# Disable CodeQL telemetry
+export CODEQL_DISABLE_TELEMETRY=true
+```
+
+## Security of API Keys
+
+### Anthropic API Key
+
+**Required for**: AI triage, AI fix generation
+
+**Storage Options:**
+1. Environment variable: `ANTHROPIC_API_KEY`
+2. Configuration file: `.specify/credentials.yml` (gitignored)
+3. CI/CD secrets
+
+**Best Practices:**
+- Never commit API keys to version control
+- Use environment variables in CI/CD
+- Rotate keys periodically
+- Use least-privilege API key scopes
+
+### GitHub Token
+
+**Required for**: SARIF upload to GitHub Code Scanning
+
+**Storage Options:**
+1. Environment variable: `GITHUB_TOKEN`
+2. `gh` CLI authentication
+
+## Data Retention
+
+| System | Retention | User Control |
+|--------|-----------|--------------|
+| Local files | Until deleted | Full control |
+| AI API | Per provider policy | Request deletion |
+| GitHub SARIF | Per repo settings | Delete via API |
+
+## Contact
+
+For privacy concerns or data deletion requests:
+- Open an issue on GitHub
+- Contact the maintainers
+
+## Updates
+
+This privacy policy may be updated. Check for the latest version:
+- In documentation: `docs/reference/security-privacy-policy.md`
+- On GitHub releases
+
+**Last Updated**: 2025-12-03
+**Version**: 1.0
+
+## Related Documentation
+
+- [Threat Model](./security-threat-model.md) - Security boundaries
+- [Command Reference](./jpspec-security-commands.md) - CLI options
+- [Configuration](./security-configuration.md) - Privacy settings

--- a/docs/reference/security-threat-model.md
+++ b/docs/reference/security-threat-model.md
@@ -1,0 +1,247 @@
+# Security Threat Model and Limitations
+
+This document describes the threat model, security boundaries, and known limitations of the `/jpspec:security` scanning system.
+
+## Scope
+
+### What `/jpspec:security` Protects Against
+
+| Category | Coverage | Tools |
+|----------|----------|-------|
+| **SAST vulnerabilities** | High | Semgrep, CodeQL, Bandit |
+| **OWASP Top 10** | High | All scanners |
+| **Hardcoded secrets** | High | Semgrep, custom rules |
+| **Dependency vulnerabilities** | Medium | Trivy (containers) |
+| **Configuration issues** | Medium | Custom rules |
+
+### What `/jpspec:security` Does NOT Protect Against
+
+| Category | Reason | Mitigation |
+|----------|--------|------------|
+| **Runtime vulnerabilities** | Static analysis only | Use DAST tools (Playwright, ZAP) |
+| **Business logic flaws** | Requires domain knowledge | Manual code review |
+| **Social engineering** | Non-code attack | Security training |
+| **Infrastructure attacks** | Out of scope | Cloud security tools |
+| **Zero-day exploits** | Unknown patterns | Keep rules updated |
+| **Compiled binaries** | Source code analysis only | Binary analysis tools |
+
+## Trust Boundaries
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    TRUSTED BOUNDARY                          │
+│  ┌─────────────────────────────────────────────────────────┐│
+│  │  Local System                                           ││
+│  │  - Source code (user's codebase)                       ││
+│  │  - Scanner tools (Semgrep, Bandit)                     ││
+│  │  - Configuration files (.specify/security.yml)         ││
+│  │  - Scan results (local JSON files)                     ││
+│  └─────────────────────────────────────────────────────────┘│
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                  SEMI-TRUSTED BOUNDARY                       │
+│  - AI API (Anthropic Claude) for triage                     │
+│  - Semgrep Registry (rule downloads)                        │
+│  - GitHub API (SARIF upload)                                │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    UNTRUSTED BOUNDARY                        │
+│  - Third-party dependencies (scanned code)                  │
+│  - External rule repositories                               │
+│  - User-provided custom rules                               │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Threat Analysis
+
+### T1: Malicious Code Injection via Scan Results
+
+**Threat**: Attacker crafts code that causes scanner to execute malicious commands.
+
+**Likelihood**: Low
+**Impact**: High
+
+**Mitigations**:
+- Scanners execute in subprocess with limited permissions
+- Scan results are JSON/SARIF data only, not executed
+- No shell interpolation of finding content
+
+**Residual Risk**: Minimal - scanner tools themselves could be compromised
+
+### T2: AI Prompt Injection via Code Comments
+
+**Threat**: Attacker embeds prompt injection in code comments that influences AI triage decisions.
+
+**Likelihood**: Medium
+**Impact**: Medium (finding misclassified)
+
+**Mitigations**:
+- Code snippets are clearly delineated in prompts
+- AI is instructed to analyze code structure, not follow instructions in code
+- Human review required for critical findings
+
+**Residual Risk**: AI may occasionally be influenced by cleverly crafted comments
+
+### T3: False Negative from AI Triage
+
+**Threat**: AI incorrectly classifies a true vulnerability as false positive.
+
+**Likelihood**: Medium
+**Impact**: High (vulnerability missed)
+
+**Mitigations**:
+- Conservative default: err toward true positive
+- Confidence scores displayed for all classifications
+- Interactive mode allows human override
+- Critical/high severity findings require manual confirmation
+
+**Residual Risk**: Some false negatives will occur; recommend periodic manual review
+
+### T4: Sensitive Code Sent to AI API
+
+**Threat**: Proprietary code snippets sent to external AI service.
+
+**Likelihood**: High (by design for AI triage)
+**Impact**: Varies (depends on code sensitivity)
+
+**Mitigations**:
+- Only relevant code snippets sent, not entire files
+- Configurable: disable AI triage for sensitive projects
+- See [Privacy Policy](./security-privacy-policy.md) for data handling
+
+**Residual Risk**: Code snippets are shared with AI provider
+
+### T5: Scanner Tool Supply Chain Attack
+
+**Threat**: Compromised scanner tool (Semgrep, Bandit) delivers malicious code.
+
+**Likelihood**: Low
+**Impact**: Critical
+
+**Mitigations**:
+- Install tools from official sources only
+- Verify tool checksums when possible
+- Pin tool versions in CI/CD
+- SLSA compliance for tool installation
+
+**Residual Risk**: Supply chain attacks on scanner tools
+
+### T6: Rule Manipulation
+
+**Threat**: Attacker modifies custom rules to hide vulnerabilities.
+
+**Likelihood**: Low
+**Impact**: High
+
+**Mitigations**:
+- Custom rules stored in version control
+- Rule changes visible in code review
+- Use official rulesets as baseline
+
+**Residual Risk**: Insider threat with commit access
+
+### T7: Denial of Service via Scan
+
+**Threat**: Malicious code causes scanner to hang or consume excessive resources.
+
+**Likelihood**: Medium
+**Impact**: Low (availability only)
+
+**Mitigations**:
+- Scan timeout configurable (default 5 minutes)
+- Resource limits in CI/CD
+- Incremental scans for large codebases
+
+**Residual Risk**: Pathological inputs may slow scanning
+
+## Known Limitations
+
+### Static Analysis Limitations
+
+1. **No runtime context**: Cannot detect issues that only manifest at runtime
+2. **Limited data flow**: Complex data flows may not be tracked accurately
+3. **Framework-specific**: Some frameworks require specialized rules
+4. **Language support**: Not all languages equally supported
+
+### AI Triage Limitations
+
+1. **Accuracy**: Target 85%, meaning ~15% may be incorrect
+2. **Novel vulnerabilities**: AI trained on known patterns
+3. **Context understanding**: May miss business logic implications
+4. **Consistency**: Same input may produce different outputs
+
+### Fix Generation Limitations
+
+1. **Syntax only**: Validates syntax, not semantic correctness
+2. **Test coverage**: Generated fixes may not have tests
+3. **Breaking changes**: Fixes may change API behavior
+4. **Complex fixes**: Multi-file changes may be incomplete
+
+### Coverage Gaps
+
+| Scanner | Languages | Strengths | Weaknesses |
+|---------|-----------|-----------|------------|
+| Semgrep | Python, JS, Go, Java, Ruby | Pattern matching, speed | Limited data flow |
+| CodeQL | Python, JS, Go, Java, C++ | Data flow, queries | Complex setup, slow |
+| Bandit | Python only | Fast, security-focused | Python only |
+| Trivy | Containers, IaC | Dependency scanning | Not SAST |
+
+## Security Recommendations
+
+### For High-Security Projects
+
+1. **Enable manual review** for all critical/high findings
+2. **Disable AI triage** if code confidentiality is critical
+3. **Use multiple scanners** for defense in depth
+4. **Pin scanner versions** to avoid supply chain attacks
+5. **Review custom rules** in pull requests
+
+### For CI/CD Integration
+
+1. **Fail on critical only** to avoid alert fatigue
+2. **Use incremental scans** in PRs for speed
+3. **Full scans on main** for comprehensive coverage
+4. **Store results** for trend analysis
+
+### For Development Teams
+
+1. **Review AI classifications** don't blindly trust
+2. **Test generated fixes** before merging
+3. **Update rules regularly** for new vulnerability patterns
+4. **Report false positives** to improve accuracy
+
+## Incident Response
+
+### If a Vulnerability is Missed
+
+1. Document the finding details
+2. Identify why scanner/AI missed it
+3. Create custom rule if pattern is detectable
+4. Consider additional scanners
+
+### If Sensitive Code is Exposed
+
+1. Review AI API data retention policy
+2. Rotate any secrets in exposed code
+3. Consider disabling AI triage
+4. Contact security team
+
+## Security Updates
+
+This threat model is reviewed and updated:
+- Quarterly for routine updates
+- Immediately when new threats are identified
+- When major features are added
+
+**Last Updated**: 2025-12-03
+**Version**: 1.0
+
+## Related Documentation
+
+- [Privacy Policy](./security-privacy-policy.md) - AI data handling
+- [Command Reference](./jpspec-security-commands.md) - CLI options
+- [CI/CD Integration](../guides/security-cicd-integration.md) - Pipeline security

--- a/tests/security/__init__.py
+++ b/tests/security/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for security scanning module."""

--- a/tests/security/adapters/__init__.py
+++ b/tests/security/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for security scanner adapters."""

--- a/tests/security/adapters/test_semgrep.py
+++ b/tests/security/adapters/test_semgrep.py
@@ -1,0 +1,499 @@
+"""Tests for Semgrep scanner adapter.
+
+Tests cover:
+- Availability checking
+- Scan execution with mocked Semgrep output
+- Finding conversion to UFFormat
+- Severity mapping
+- CWE extraction
+- Error handling
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from specify_cli.security.adapters.semgrep import SemgrepAdapter
+from specify_cli.security.models import Confidence, Severity
+
+
+# Sample Semgrep JSON output for testing
+SAMPLE_SEMGREP_OUTPUT = {
+    "results": [
+        {
+            "check_id": "python.lang.security.audit.dangerous-exec-use.dangerous-exec-use",
+            "path": "src/app.py",
+            "start": {"line": 42, "col": 5},
+            "end": {"line": 42, "col": 25},
+            "extra": {
+                "severity": "ERROR",
+                "message": "Detected string concatenation in SQL query. This could be vulnerable to SQL injection.",
+                "lines": 'query = "SELECT * FROM users WHERE id = " + user_id',
+                "metadata": {
+                    "cwe": ["CWE-89"],
+                    "owasp": ["A03:2021"],
+                    "references": ["https://owasp.org/Top10/A03_2021-Injection/"],
+                    "remediation": "Use parameterized queries instead of string concatenation.",
+                },
+            },
+        },
+        {
+            "check_id": "python.lang.security.audit.hardcoded-password",
+            "path": "src/config.py",
+            "start": {"line": 10, "col": 1},
+            "end": {"line": 10, "col": 30},
+            "extra": {
+                "severity": "WARNING",
+                "message": "Hardcoded password detected",
+                "lines": 'PASSWORD = "secretpass123"',
+                "metadata": {
+                    "cwe": "CWE-798",
+                    "references": ["https://cwe.mitre.org/data/definitions/798.html"],
+                },
+            },
+        },
+        {
+            "check_id": "python.lang.best-practice.logging-format",
+            "path": "src/utils.py",
+            "start": {"line": 100, "col": 1},
+            "end": {"line": 100, "col": 50},
+            "extra": {
+                "severity": "INFO",
+                "message": "Use lazy % formatting in logging functions",
+                "lines": 'logging.info("User %s logged in" % username)',
+                "metadata": {},
+            },
+        },
+    ],
+    "errors": [],
+    "version": "1.50.0",
+}
+
+
+EMPTY_SEMGREP_OUTPUT = {"results": [], "errors": [], "version": "1.50.0"}
+
+
+class TestSemgrepAdapterAvailability:
+    """Tests for Semgrep availability checking."""
+
+    def test_name_property(self):
+        """Test adapter name is 'semgrep'."""
+        adapter = SemgrepAdapter()
+        assert adapter.name == "semgrep"
+
+    @patch("specify_cli.security.adapters.semgrep.ToolDiscovery")
+    def test_is_available_true(self, mock_discovery_class):
+        """Test is_available returns True when Semgrep is installed."""
+        mock_discovery = MagicMock()
+        mock_discovery.is_available.return_value = True
+        mock_discovery_class.return_value = mock_discovery
+
+        adapter = SemgrepAdapter()
+        assert adapter.is_available() is True
+        mock_discovery.is_available.assert_called_with("semgrep")
+
+    @patch("specify_cli.security.adapters.semgrep.ToolDiscovery")
+    def test_is_available_false(self, mock_discovery_class):
+        """Test is_available returns False when Semgrep is not installed."""
+        mock_discovery = MagicMock()
+        mock_discovery.is_available.return_value = False
+        mock_discovery_class.return_value = mock_discovery
+
+        adapter = SemgrepAdapter()
+        assert adapter.is_available() is False
+
+    @patch("specify_cli.security.adapters.semgrep.subprocess.run")
+    @patch("specify_cli.security.adapters.semgrep.ToolDiscovery")
+    def test_version_property(self, mock_discovery_class, mock_run):
+        """Test version property returns Semgrep version."""
+        mock_discovery = MagicMock()
+        mock_discovery.is_available.return_value = True
+        mock_discovery.find_tool.return_value = Path("/usr/bin/semgrep")
+        mock_discovery_class.return_value = mock_discovery
+
+        mock_run.return_value = Mock(stdout="1.50.0\n", returncode=0)
+
+        adapter = SemgrepAdapter()
+        assert adapter.version == "1.50.0"
+
+    @patch("specify_cli.security.adapters.semgrep.ToolDiscovery")
+    def test_version_not_available_raises(self, mock_discovery_class):
+        """Test version raises when Semgrep not available."""
+        mock_discovery = MagicMock()
+        mock_discovery.is_available.return_value = False
+        mock_discovery_class.return_value = mock_discovery
+
+        adapter = SemgrepAdapter()
+        with pytest.raises(RuntimeError, match="not available"):
+            _ = adapter.version
+
+    def test_get_install_instructions(self):
+        """Test install instructions are provided."""
+        adapter = SemgrepAdapter()
+        instructions = adapter.get_install_instructions()
+
+        assert "pip install semgrep" in instructions
+        assert "brew install semgrep" in instructions
+
+
+class TestSemgrepAdapterScanning:
+    """Tests for Semgrep scanning functionality."""
+
+    @pytest.fixture
+    def mock_adapter(self):
+        """Create adapter with mocked discovery."""
+        with patch("specify_cli.security.adapters.semgrep.ToolDiscovery") as mock_class:
+            mock_discovery = MagicMock()
+            mock_discovery.is_available.return_value = True
+            mock_discovery.find_tool.return_value = Path("/usr/bin/semgrep")
+            mock_class.return_value = mock_discovery
+
+            adapter = SemgrepAdapter()
+            yield adapter
+
+    @pytest.fixture
+    def temp_dir(self, tmp_path):
+        """Create temporary directory with test file."""
+        test_file = tmp_path / "test.py"
+        test_file.write_text("print('hello')")
+        return tmp_path
+
+    @patch("specify_cli.security.adapters.semgrep.subprocess.run")
+    def test_scan_basic(self, mock_run, mock_adapter, temp_dir):
+        """Test basic scan execution and result parsing."""
+        mock_run.return_value = Mock(
+            stdout=json.dumps(SAMPLE_SEMGREP_OUTPUT),
+            stderr="",
+            returncode=1,  # 1 means findings
+        )
+
+        findings = mock_adapter.scan(temp_dir)
+
+        assert len(findings) == 3
+        assert findings[0].scanner == "semgrep"
+        mock_run.assert_called_once()
+
+    @patch("specify_cli.security.adapters.semgrep.subprocess.run")
+    def test_scan_no_findings(self, mock_run, mock_adapter, temp_dir):
+        """Test scan with no findings returns empty list."""
+        mock_run.return_value = Mock(
+            stdout=json.dumps(EMPTY_SEMGREP_OUTPUT),
+            stderr="",
+            returncode=0,
+        )
+
+        findings = mock_adapter.scan(temp_dir)
+
+        assert len(findings) == 0
+
+    @patch("specify_cli.security.adapters.semgrep.subprocess.run")
+    def test_scan_converts_to_unified_format(self, mock_run, mock_adapter, temp_dir):
+        """Test findings are converted to UFFormat correctly."""
+        mock_run.return_value = Mock(
+            stdout=json.dumps(SAMPLE_SEMGREP_OUTPUT),
+            stderr="",
+            returncode=1,
+        )
+
+        findings = mock_adapter.scan(temp_dir)
+
+        # Check first finding (SQL injection)
+        sql_finding = findings[0]
+        assert sql_finding.id.startswith("SEMGREP-")
+        assert sql_finding.severity == Severity.HIGH  # ERROR maps to HIGH
+        assert sql_finding.cwe_id == "CWE-89"
+        assert sql_finding.location.file == Path("src/app.py")
+        assert sql_finding.location.line_start == 42
+        assert sql_finding.confidence == Confidence.HIGH
+        assert "parameterized" in (sql_finding.remediation or "").lower()
+
+    @patch("specify_cli.security.adapters.semgrep.subprocess.run")
+    def test_scan_target_not_exists(self, mock_run, mock_adapter):
+        """Test scan with nonexistent target raises error."""
+        with pytest.raises(ValueError, match="does not exist"):
+            mock_adapter.scan(Path("/nonexistent/path"))
+
+    @patch("specify_cli.security.adapters.semgrep.ToolDiscovery")
+    def test_scan_not_available_raises(self, mock_discovery_class, tmp_path):
+        """Test scan raises when Semgrep not available."""
+        mock_discovery = MagicMock()
+        mock_discovery.is_available.return_value = False
+        mock_discovery_class.return_value = mock_discovery
+
+        test_file = tmp_path / "test.py"
+        test_file.write_text("print('hello')")
+
+        adapter = SemgrepAdapter()
+        with pytest.raises(RuntimeError, match="not available"):
+            adapter.scan(tmp_path)
+
+    @patch("specify_cli.security.adapters.semgrep.subprocess.run")
+    def test_scan_error_exit_code(self, mock_run, mock_adapter, temp_dir):
+        """Test scan handles error exit codes."""
+        mock_run.return_value = Mock(
+            stdout="",
+            stderr="Error: invalid config",
+            returncode=2,
+        )
+
+        with pytest.raises(RuntimeError, match="scan failed"):
+            mock_adapter.scan(temp_dir)
+
+    @patch("specify_cli.security.adapters.semgrep.subprocess.run")
+    def test_scan_timeout(self, mock_run, mock_adapter, temp_dir):
+        """Test scan handles timeout."""
+        import subprocess
+
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="semgrep", timeout=600)
+
+        with pytest.raises(RuntimeError, match="timed out"):
+            mock_adapter.scan(temp_dir)
+
+    @patch("specify_cli.security.adapters.semgrep.subprocess.run")
+    def test_scan_invalid_json(self, mock_run, mock_adapter, temp_dir):
+        """Test scan handles invalid JSON output."""
+        mock_run.return_value = Mock(
+            stdout="not valid json",
+            stderr="",
+            returncode=0,
+        )
+
+        with pytest.raises(RuntimeError, match="parse.*output"):
+            mock_adapter.scan(temp_dir)
+
+    @patch("specify_cli.security.adapters.semgrep.subprocess.run")
+    def test_scan_with_config(self, mock_run, mock_adapter, temp_dir):
+        """Test scan passes configuration options."""
+        mock_run.return_value = Mock(
+            stdout=json.dumps(EMPTY_SEMGREP_OUTPUT),
+            stderr="",
+            returncode=0,
+        )
+
+        config = {
+            "rules": ["p/security-audit", "p/owasp-top-ten"],
+            "exclude": ["tests/", "*.test.py"],
+            "timeout": 300,
+        }
+        mock_adapter.scan(temp_dir, config=config)
+
+        call_args = mock_run.call_args
+        cmd = call_args[0][0]
+
+        # Check rules
+        assert "--config" in cmd
+        config_idx = cmd.index("--config")
+        assert "p/security-audit,p/owasp-top-ten" in cmd[config_idx + 1]
+
+        # Check excludes
+        exclude_indices = [i for i, arg in enumerate(cmd) if arg == "--exclude"]
+        assert len(exclude_indices) == 2
+
+        # Check timeout passed to subprocess
+        assert call_args[1]["timeout"] == 300
+
+
+class TestSeverityMapping:
+    """Tests for Semgrep severity to UFFormat mapping."""
+
+    @pytest.fixture
+    def adapter(self):
+        with patch("specify_cli.security.adapters.semgrep.ToolDiscovery") as mock_class:
+            mock_discovery = MagicMock()
+            mock_discovery.is_available.return_value = True
+            mock_class.return_value = mock_discovery
+            yield SemgrepAdapter()
+
+    def test_error_maps_to_high(self, adapter):
+        """Test Semgrep ERROR maps to UFFormat HIGH."""
+        assert adapter._map_severity("ERROR") == Severity.HIGH
+
+    def test_warning_maps_to_medium(self, adapter):
+        """Test Semgrep WARNING maps to UFFormat MEDIUM."""
+        assert adapter._map_severity("WARNING") == Severity.MEDIUM
+
+    def test_info_maps_to_low(self, adapter):
+        """Test Semgrep INFO maps to UFFormat LOW."""
+        assert adapter._map_severity("INFO") == Severity.LOW
+
+    def test_unknown_maps_to_info(self, adapter):
+        """Test unknown severity maps to INFO."""
+        assert adapter._map_severity("UNKNOWN") == Severity.INFO
+        assert adapter._map_severity("") == Severity.INFO
+
+    def test_case_insensitive(self, adapter):
+        """Test severity mapping is case insensitive."""
+        assert adapter._map_severity("error") == Severity.HIGH
+        assert adapter._map_severity("Error") == Severity.HIGH
+        assert adapter._map_severity("WARNING") == Severity.MEDIUM
+
+
+class TestCWEExtraction:
+    """Tests for CWE extraction from Semgrep metadata."""
+
+    @pytest.fixture
+    def adapter(self):
+        with patch("specify_cli.security.adapters.semgrep.ToolDiscovery") as mock_class:
+            mock_discovery = MagicMock()
+            mock_class.return_value = mock_discovery
+            yield SemgrepAdapter()
+
+    def test_cwe_from_list(self, adapter):
+        """Test CWE extraction from list."""
+        finding = {
+            "extra": {
+                "metadata": {
+                    "cwe": ["CWE-89", "CWE-90"],
+                }
+            }
+        }
+        assert adapter._extract_cwe(finding) == "CWE-89"
+
+    def test_cwe_from_string(self, adapter):
+        """Test CWE extraction from string."""
+        finding = {
+            "extra": {
+                "metadata": {
+                    "cwe": "CWE-79",
+                }
+            }
+        }
+        assert adapter._extract_cwe(finding) == "CWE-79"
+
+    def test_cwe_from_integer(self, adapter):
+        """Test CWE extraction from integer."""
+        finding = {
+            "extra": {
+                "metadata": {
+                    "cwe": 89,
+                }
+            }
+        }
+        assert adapter._extract_cwe(finding) == "CWE-89"
+
+    def test_cwe_from_list_of_integers(self, adapter):
+        """Test CWE extraction from list of integers."""
+        finding = {
+            "extra": {
+                "metadata": {
+                    "cwe": [89, 90],
+                }
+            }
+        }
+        assert adapter._extract_cwe(finding) == "CWE-89"
+
+    def test_cwe_missing(self, adapter):
+        """Test CWE extraction when missing."""
+        finding = {"extra": {"metadata": {}}}
+        assert adapter._extract_cwe(finding) is None
+
+        finding = {"extra": {}}
+        assert adapter._extract_cwe(finding) is None
+
+    def test_cwe_empty_list(self, adapter):
+        """Test CWE extraction from empty list."""
+        finding = {"extra": {"metadata": {"cwe": []}}}
+        assert adapter._extract_cwe(finding) is None
+
+
+class TestReferenceExtraction:
+    """Tests for reference URL extraction."""
+
+    @pytest.fixture
+    def adapter(self):
+        with patch("specify_cli.security.adapters.semgrep.ToolDiscovery") as mock_class:
+            mock_discovery = MagicMock()
+            mock_class.return_value = mock_discovery
+            yield SemgrepAdapter()
+
+    def test_references_from_list(self, adapter):
+        """Test reference extraction from list."""
+        metadata = {
+            "references": [
+                "https://owasp.org/Top10/",
+                "https://cwe.mitre.org/",
+            ]
+        }
+        refs = adapter._extract_references(metadata)
+        assert len(refs) == 2
+        assert "https://owasp.org/Top10/" in refs
+
+    def test_reference_from_string(self, adapter):
+        """Test reference extraction from single string."""
+        metadata = {"reference": "https://example.com"}
+        refs = adapter._extract_references(metadata)
+        assert refs == ["https://example.com"]
+
+    def test_source_reference(self, adapter):
+        """Test extraction of 'source' field."""
+        metadata = {"source": "https://semgrep.dev/r/rule-id"}
+        refs = adapter._extract_references(metadata)
+        assert "https://semgrep.dev/r/rule-id" in refs
+
+    def test_no_references(self, adapter):
+        """Test empty references when none present."""
+        metadata = {}
+        refs = adapter._extract_references(metadata)
+        assert refs == []
+
+    def test_multiple_reference_fields(self, adapter):
+        """Test combining multiple reference fields."""
+        metadata = {
+            "references": ["https://ref1.com"],
+            "source": "https://ref2.com",
+        }
+        refs = adapter._extract_references(metadata)
+        assert len(refs) == 2
+
+
+class TestFindingConversion:
+    """Integration tests for full finding conversion."""
+
+    @pytest.fixture
+    def adapter(self):
+        with patch("specify_cli.security.adapters.semgrep.ToolDiscovery") as mock_class:
+            mock_discovery = MagicMock()
+            mock_class.return_value = mock_discovery
+            yield SemgrepAdapter()
+
+    def test_full_finding_conversion(self, adapter):
+        """Test complete finding conversion with all fields."""
+        semgrep_finding = SAMPLE_SEMGREP_OUTPUT["results"][0]
+        finding = adapter._to_finding(semgrep_finding)
+
+        assert finding.id.startswith("SEMGREP-")
+        assert finding.scanner == "semgrep"
+        assert finding.severity == Severity.HIGH
+        assert finding.title == semgrep_finding["check_id"]
+        assert "SQL" in finding.description
+        assert finding.location.file == Path("src/app.py")
+        assert finding.location.line_start == 42
+        assert finding.location.column_start == 5
+        assert finding.cwe_id == "CWE-89"
+        assert finding.confidence == Confidence.HIGH
+        assert finding.remediation is not None
+        assert len(finding.references) > 0
+        assert finding.raw_data == semgrep_finding
+
+    def test_minimal_finding_conversion(self, adapter):
+        """Test finding conversion with minimal metadata."""
+        semgrep_finding = {
+            "check_id": "test.rule",
+            "path": "test.py",
+            "start": {"line": 1},
+            "end": {"line": 1},
+            "extra": {
+                "severity": "INFO",
+                "message": "Test message",
+                "metadata": {},
+            },
+        }
+        finding = adapter._to_finding(semgrep_finding)
+
+        assert finding.id == "SEMGREP-test.rule"
+        assert finding.severity == Severity.LOW
+        assert finding.cwe_id is None
+        assert finding.remediation is None
+        assert finding.references == []

--- a/tests/security/test_models.py
+++ b/tests/security/test_models.py
@@ -1,0 +1,465 @@
+"""Tests for security models - Unified Finding Format (UFFormat).
+
+Tests cover:
+- Severity and Confidence enums
+- Location dataclass
+- Finding dataclass with fingerprinting and merging
+- Serialization (to_dict, from_dict, to_sarif)
+"""
+
+from pathlib import Path
+
+import pytest
+
+from specify_cli.security.models import Confidence, Finding, Location, Severity
+
+
+class TestSeverity:
+    """Tests for Severity enum."""
+
+    def test_severity_values(self):
+        """Test severity enum values are correct."""
+        assert Severity.CRITICAL.value == "critical"
+        assert Severity.HIGH.value == "high"
+        assert Severity.MEDIUM.value == "medium"
+        assert Severity.LOW.value == "low"
+        assert Severity.INFO.value == "info"
+
+    def test_severity_from_string(self):
+        """Test creating severity from string value."""
+        assert Severity("critical") == Severity.CRITICAL
+        assert Severity("high") == Severity.HIGH
+        assert Severity("medium") == Severity.MEDIUM
+        assert Severity("low") == Severity.LOW
+        assert Severity("info") == Severity.INFO
+
+    def test_severity_invalid_value(self):
+        """Test invalid severity raises error."""
+        with pytest.raises(ValueError):
+            Severity("invalid")
+
+
+class TestConfidence:
+    """Tests for Confidence enum."""
+
+    def test_confidence_values(self):
+        """Test confidence enum values are correct."""
+        assert Confidence.HIGH.value == "high"
+        assert Confidence.MEDIUM.value == "medium"
+        assert Confidence.LOW.value == "low"
+
+    def test_confidence_from_string(self):
+        """Test creating confidence from string value."""
+        assert Confidence("high") == Confidence.HIGH
+        assert Confidence("medium") == Confidence.MEDIUM
+        assert Confidence("low") == Confidence.LOW
+
+
+class TestLocation:
+    """Tests for Location dataclass."""
+
+    @pytest.fixture
+    def sample_location(self):
+        """Create a sample location for testing."""
+        return Location(
+            file=Path("src/app.py"),
+            line_start=42,
+            line_end=45,
+            column_start=8,
+            column_end=50,
+            code_snippet='query = "SELECT * FROM users WHERE id = " + user_id',
+            context_snippet="def get_user(user_id):\n    ...",
+        )
+
+    def test_location_creation(self, sample_location):
+        """Test basic location creation."""
+        assert sample_location.file == Path("src/app.py")
+        assert sample_location.line_start == 42
+        assert sample_location.line_end == 45
+        assert sample_location.column_start == 8
+        assert sample_location.column_end == 50
+
+    def test_location_minimal(self):
+        """Test location with minimal required fields."""
+        loc = Location(file=Path("test.py"), line_start=1, line_end=1)
+        assert loc.file == Path("test.py")
+        assert loc.column_start is None
+        assert loc.code_snippet == ""
+
+    def test_location_to_dict(self, sample_location):
+        """Test location serialization to dict."""
+        data = sample_location.to_dict()
+
+        assert data["file"] == "src/app.py"
+        assert data["line_start"] == 42
+        assert data["line_end"] == 45
+        assert data["column_start"] == 8
+        assert data["column_end"] == 50
+        assert "user_id" in data["code_snippet"]
+        assert data["context_snippet"] is not None
+
+    def test_location_from_dict(self, sample_location):
+        """Test location deserialization from dict."""
+        data = sample_location.to_dict()
+        restored = Location.from_dict(data)
+
+        assert restored.file == sample_location.file
+        assert restored.line_start == sample_location.line_start
+        assert restored.line_end == sample_location.line_end
+        assert restored.column_start == sample_location.column_start
+        assert restored.code_snippet == sample_location.code_snippet
+
+    def test_location_from_dict_minimal(self):
+        """Test location deserialization with minimal fields."""
+        data = {"file": "test.py", "line_start": 10, "line_end": 15}
+        loc = Location.from_dict(data)
+
+        assert loc.file == Path("test.py")
+        assert loc.line_start == 10
+        assert loc.column_start is None
+
+
+class TestFinding:
+    """Tests for Finding dataclass."""
+
+    @pytest.fixture
+    def sample_finding(self):
+        """Create a sample finding for testing."""
+        return Finding(
+            id="SEMGREP-CWE-89-001",
+            scanner="semgrep",
+            severity=Severity.HIGH,
+            title="SQL Injection",
+            description="User input directly concatenated into SQL query",
+            location=Location(
+                file=Path("src/db.py"),
+                line_start=42,
+                line_end=45,
+                code_snippet='query = "SELECT * FROM users WHERE id = " + user_id',
+            ),
+            cwe_id="CWE-89",
+            cvss_score=8.5,
+            confidence=Confidence.HIGH,
+            remediation="Use parameterized queries instead",
+            references=["https://owasp.org/SQL_Injection"],
+        )
+
+    def test_finding_creation(self, sample_finding):
+        """Test basic finding creation."""
+        assert sample_finding.id == "SEMGREP-CWE-89-001"
+        assert sample_finding.scanner == "semgrep"
+        assert sample_finding.severity == Severity.HIGH
+        assert sample_finding.title == "SQL Injection"
+        assert sample_finding.cwe_id == "CWE-89"
+        assert sample_finding.cvss_score == 8.5
+
+    def test_finding_minimal(self):
+        """Test finding with minimal required fields."""
+        finding = Finding(
+            id="TEST-001",
+            scanner="test",
+            severity=Severity.INFO,
+            title="Test Finding",
+            description="Test description",
+            location=Location(file=Path("test.py"), line_start=1, line_end=1),
+        )
+
+        assert finding.cwe_id is None
+        assert finding.cvss_score is None
+        assert finding.confidence == Confidence.MEDIUM
+        assert finding.remediation is None
+        assert finding.references == []
+
+    def test_finding_fingerprint(self, sample_finding):
+        """Test fingerprint generation."""
+        fp = sample_finding.fingerprint()
+
+        assert len(fp) == 16
+        assert fp.isalnum()
+
+    def test_finding_fingerprint_consistency(self, sample_finding):
+        """Test fingerprint is consistent for same finding."""
+        fp1 = sample_finding.fingerprint()
+        fp2 = sample_finding.fingerprint()
+
+        assert fp1 == fp2
+
+    def test_finding_fingerprint_uniqueness(self, sample_finding):
+        """Test different findings have different fingerprints."""
+        other = Finding(
+            id="OTHER-001",
+            scanner="other",
+            severity=Severity.LOW,
+            title="Different Finding",
+            description="Different",
+            location=Location(file=Path("other.py"), line_start=100, line_end=105),
+        )
+
+        assert sample_finding.fingerprint() != other.fingerprint()
+
+    def test_finding_fingerprint_same_location_same_cwe(self, sample_finding):
+        """Test findings with same location and CWE have same fingerprint."""
+        other = Finding(
+            id="CODEQL-001",  # Different ID
+            scanner="codeql",  # Different scanner
+            severity=Severity.CRITICAL,  # Different severity
+            title="SQL Injection",
+            description="Different description",
+            location=Location(
+                file=Path("src/db.py"),  # Same file
+                line_start=42,  # Same lines
+                line_end=45,
+            ),
+            cwe_id="CWE-89",  # Same CWE
+        )
+
+        assert sample_finding.fingerprint() == other.fingerprint()
+
+    def test_finding_merge_basic(self, sample_finding):
+        """Test basic merge of duplicate findings."""
+        other = Finding(
+            id="CODEQL-001",
+            scanner="codeql",
+            severity=Severity.HIGH,
+            title="SQL Injection",
+            description="CodeQL detected SQL injection",
+            location=Location(
+                file=Path("src/db.py"),
+                line_start=42,
+                line_end=45,
+            ),
+            cwe_id="CWE-89",
+            confidence=Confidence.MEDIUM,
+            references=["https://codeql.example.com"],
+        )
+
+        sample_finding.merge(other)
+
+        # Confidence should increase when both agree
+        assert sample_finding.confidence == Confidence.HIGH
+
+        # References should be combined
+        assert "https://owasp.org/SQL_Injection" in sample_finding.references
+        assert "https://codeql.example.com" in sample_finding.references
+
+        # Scanner should be tracked in metadata
+        assert "codeql" in sample_finding.metadata.get("merged_scanners", [])
+
+    def test_finding_merge_takes_higher_severity(self, sample_finding):
+        """Test merge takes higher severity."""
+        other = Finding(
+            id="CODEQL-001",
+            scanner="codeql",
+            severity=Severity.CRITICAL,  # Higher than sample's HIGH
+            title="SQL Injection",
+            description="Critical SQL injection",
+            location=Location(
+                file=Path("src/db.py"),
+                line_start=42,
+                line_end=45,
+            ),
+            cwe_id="CWE-89",
+        )
+
+        sample_finding.merge(other)
+
+        assert sample_finding.severity == Severity.CRITICAL
+
+    def test_finding_merge_different_fingerprint_raises(self, sample_finding):
+        """Test merging different findings raises error."""
+        other = Finding(
+            id="OTHER-001",
+            scanner="other",
+            severity=Severity.LOW,
+            title="Different",
+            description="Different finding",
+            location=Location(file=Path("other.py"), line_start=1, line_end=1),
+        )
+
+        with pytest.raises(ValueError, match="different fingerprints"):
+            sample_finding.merge(other)
+
+    def test_finding_to_dict(self, sample_finding):
+        """Test finding serialization to dict."""
+        data = sample_finding.to_dict()
+
+        assert data["id"] == "SEMGREP-CWE-89-001"
+        assert data["scanner"] == "semgrep"
+        assert data["severity"] == "high"
+        assert data["title"] == "SQL Injection"
+        assert data["cwe_id"] == "CWE-89"
+        assert data["cvss_score"] == 8.5
+        assert data["confidence"] == "high"
+        assert "location" in data
+        assert data["location"]["file"] == "src/db.py"
+
+    def test_finding_from_dict(self, sample_finding):
+        """Test finding deserialization from dict."""
+        data = sample_finding.to_dict()
+        restored = Finding.from_dict(data)
+
+        assert restored.id == sample_finding.id
+        assert restored.scanner == sample_finding.scanner
+        assert restored.severity == sample_finding.severity
+        assert restored.title == sample_finding.title
+        assert restored.cwe_id == sample_finding.cwe_id
+        assert restored.location.file == sample_finding.location.file
+
+    def test_finding_to_sarif(self, sample_finding):
+        """Test SARIF conversion."""
+        sarif = sample_finding.to_sarif()
+
+        assert sarif["ruleId"] == "CWE-89"
+        assert sarif["level"] == "error"  # HIGH maps to error
+        assert sarif["message"]["text"] == sample_finding.description
+
+        # Check location
+        loc = sarif["locations"][0]["physicalLocation"]
+        assert loc["artifactLocation"]["uri"] == "src/db.py"
+        assert loc["region"]["startLine"] == 42
+        assert loc["region"]["endLine"] == 45
+
+        # Check properties
+        assert sarif["properties"]["scanner"] == "semgrep"
+        assert sarif["properties"]["cvss"] == 8.5
+
+    def test_finding_sarif_severity_mapping(self):
+        """Test all severities map to correct SARIF levels."""
+        test_cases = [
+            (Severity.CRITICAL, "error"),
+            (Severity.HIGH, "error"),
+            (Severity.MEDIUM, "warning"),
+            (Severity.LOW, "note"),
+            (Severity.INFO, "note"),
+        ]
+
+        for severity, expected_level in test_cases:
+            finding = Finding(
+                id="TEST",
+                scanner="test",
+                severity=severity,
+                title="Test",
+                description="Test",
+                location=Location(file=Path("test.py"), line_start=1, line_end=1),
+            )
+            sarif = finding.to_sarif()
+            assert sarif["level"] == expected_level, (
+                f"{severity} should map to {expected_level}"
+            )
+
+    def test_finding_sarif_without_cwe(self):
+        """Test SARIF conversion uses ID when CWE is missing."""
+        finding = Finding(
+            id="CUSTOM-001",
+            scanner="custom",
+            severity=Severity.MEDIUM,
+            title="Custom Finding",
+            description="No CWE",
+            location=Location(file=Path("test.py"), line_start=1, line_end=1),
+            cwe_id=None,
+        )
+        sarif = finding.to_sarif()
+
+        assert sarif["ruleId"] == "CUSTOM-001"
+
+    def test_finding_from_dict_defaults(self):
+        """Test from_dict uses correct defaults."""
+        data = {
+            "id": "TEST-001",
+            "scanner": "test",
+            "severity": "medium",
+            "title": "Test",
+            "description": "Test description",
+            "location": {"file": "test.py", "line_start": 1, "line_end": 1},
+        }
+        finding = Finding.from_dict(data)
+
+        assert finding.confidence == Confidence.MEDIUM
+        assert finding.remediation is None
+        assert finding.references == []
+        assert finding.metadata == {}
+
+
+class TestFindingEdgeCases:
+    """Edge case tests for Finding."""
+
+    def test_finding_with_empty_references(self):
+        """Test finding with explicitly empty references."""
+        finding = Finding(
+            id="TEST",
+            scanner="test",
+            severity=Severity.INFO,
+            title="Test",
+            description="Test",
+            location=Location(file=Path("test.py"), line_start=1, line_end=1),
+            references=[],
+        )
+
+        data = finding.to_dict()
+        assert data["references"] == []
+
+    def test_finding_merge_deduplicates_references(self):
+        """Test merge deduplicates references."""
+        finding1 = Finding(
+            id="TEST-1",
+            scanner="test1",
+            severity=Severity.HIGH,
+            title="Test",
+            description="Test",
+            location=Location(file=Path("test.py"), line_start=1, line_end=1),
+            cwe_id="CWE-1",
+            references=["https://example.com/1", "https://example.com/2"],
+        )
+        finding2 = Finding(
+            id="TEST-2",
+            scanner="test2",
+            severity=Severity.HIGH,
+            title="Test",
+            description="Test",
+            location=Location(file=Path("test.py"), line_start=1, line_end=1),
+            cwe_id="CWE-1",
+            references=["https://example.com/2", "https://example.com/3"],  # Overlap
+        )
+
+        finding1.merge(finding2)
+
+        # Should have 3 unique references
+        assert len(finding1.references) == 3
+        assert "https://example.com/1" in finding1.references
+        assert "https://example.com/2" in finding1.references
+        assert "https://example.com/3" in finding1.references
+
+    def test_finding_fingerprint_uses_title_when_no_cwe(self):
+        """Test fingerprint uses title when CWE is None."""
+        finding1 = Finding(
+            id="TEST-1",
+            scanner="test",
+            severity=Severity.HIGH,
+            title="Same Title",
+            description="Test",
+            location=Location(file=Path("test.py"), line_start=1, line_end=1),
+            cwe_id=None,
+        )
+        finding2 = Finding(
+            id="TEST-2",
+            scanner="test",
+            severity=Severity.HIGH,
+            title="Same Title",  # Same title
+            description="Test",
+            location=Location(file=Path("test.py"), line_start=1, line_end=1),
+            cwe_id=None,
+        )
+        finding3 = Finding(
+            id="TEST-3",
+            scanner="test",
+            severity=Severity.HIGH,
+            title="Different Title",  # Different title
+            description="Test",
+            location=Location(file=Path("test.py"), line_start=1, line_end=1),
+            cwe_id=None,
+        )
+
+        # Same location and title should match
+        assert finding1.fingerprint() == finding2.fingerprint()
+        # Different title should not match
+        assert finding1.fingerprint() != finding3.fingerprint()

--- a/tests/security/test_orchestrator.py
+++ b/tests/security/test_orchestrator.py
@@ -1,0 +1,436 @@
+"""Tests for scanner orchestrator.
+
+Tests cover:
+- Scanner registration
+- Parallel and sequential scanning
+- Deduplication of findings
+- Error handling and graceful degradation
+"""
+
+from pathlib import Path
+
+import pytest
+
+from specify_cli.security.adapters.base import ScannerAdapter
+from specify_cli.security.models import Confidence, Finding, Location, Severity
+from specify_cli.security.orchestrator import ScannerOrchestrator
+
+
+class MockAdapter(ScannerAdapter):
+    """Mock scanner adapter for testing."""
+
+    def __init__(
+        self,
+        name: str = "mock",
+        available: bool = True,
+        findings: list[Finding] | None = None,
+        raises: Exception | None = None,
+    ):
+        self._name = name
+        self._available = available
+        self._findings = findings or []
+        self._raises = raises
+        self.scan_count = 0
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def version(self) -> str:
+        return "1.0.0"
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def scan(self, target: Path, config: dict | None = None) -> list[Finding]:
+        self.scan_count += 1
+        if self._raises:
+            raise self._raises
+        return self._findings
+
+    def get_install_instructions(self) -> str:
+        return f"Install {self._name}"
+
+
+def make_finding(
+    scanner: str = "test",
+    file: str = "test.py",
+    line: int = 1,
+    cwe: str | None = "CWE-1",
+    severity: Severity = Severity.HIGH,
+) -> Finding:
+    """Helper to create test findings."""
+    return Finding(
+        id=f"{scanner.upper()}-001",
+        scanner=scanner,
+        severity=severity,
+        title=f"{scanner} Finding",
+        description="Test finding",
+        location=Location(file=Path(file), line_start=line, line_end=line + 2),
+        cwe_id=cwe,
+    )
+
+
+class TestScannerOrchestrator:
+    """Tests for ScannerOrchestrator."""
+
+    @pytest.fixture
+    def orchestrator(self):
+        """Create an empty orchestrator."""
+        return ScannerOrchestrator()
+
+    @pytest.fixture
+    def temp_dir(self, tmp_path):
+        """Create a temporary directory for scanning."""
+        test_file = tmp_path / "test.py"
+        test_file.write_text("print('hello')")
+        return tmp_path
+
+    def test_register_adapter(self, orchestrator):
+        """Test registering a scanner adapter."""
+        adapter = MockAdapter(name="semgrep")
+        orchestrator.register(adapter)
+
+        assert "semgrep" in orchestrator.list_scanners()
+
+    def test_register_duplicate_adapter_raises(self, orchestrator):
+        """Test registering duplicate adapter raises error."""
+        orchestrator.register(MockAdapter(name="semgrep"))
+
+        with pytest.raises(ValueError, match="already registered"):
+            orchestrator.register(MockAdapter(name="semgrep"))
+
+    def test_list_scanners(self, orchestrator):
+        """Test listing registered scanners."""
+        orchestrator.register(MockAdapter(name="scanner1"))
+        orchestrator.register(MockAdapter(name="scanner2"))
+
+        scanners = orchestrator.list_scanners()
+        assert "scanner1" in scanners
+        assert "scanner2" in scanners
+
+    def test_get_adapter(self, orchestrator):
+        """Test getting adapter by name."""
+        adapter = MockAdapter(name="test")
+        orchestrator.register(adapter)
+
+        assert orchestrator.get_adapter("test") is adapter
+        assert orchestrator.get_adapter("nonexistent") is None
+
+    def test_scan_basic(self, orchestrator, temp_dir):
+        """Test basic scanning with single adapter."""
+        findings = [make_finding(scanner="semgrep")]
+        adapter = MockAdapter(name="semgrep", findings=findings)
+        orchestrator.register(adapter)
+
+        results = orchestrator.scan(temp_dir)
+
+        assert len(results) == 1
+        assert results[0].scanner == "semgrep"
+        assert adapter.scan_count == 1
+
+    def test_scan_target_not_exists_raises(self, orchestrator):
+        """Test scanning nonexistent path raises error."""
+        orchestrator.register(MockAdapter())
+
+        with pytest.raises(ValueError, match="does not exist"):
+            orchestrator.scan(Path("/nonexistent/path"))
+
+    def test_scan_no_adapters_raises(self, orchestrator, temp_dir):
+        """Test scanning with no adapters raises error."""
+        with pytest.raises(ValueError, match="No scanner adapters"):
+            orchestrator.scan(temp_dir)
+
+    def test_scan_unregistered_scanner_raises(self, orchestrator, temp_dir):
+        """Test requesting unregistered scanner raises error."""
+        orchestrator.register(MockAdapter(name="semgrep"))
+
+        with pytest.raises(RuntimeError, match="not registered"):
+            orchestrator.scan(temp_dir, scanners=["nonexistent"])
+
+    def test_scan_unavailable_scanner_raises(self, orchestrator, temp_dir):
+        """Test scanning with unavailable scanner raises error."""
+        adapter = MockAdapter(name="semgrep", available=False)
+        orchestrator.register(adapter)
+
+        with pytest.raises(RuntimeError, match="not available"):
+            orchestrator.scan(temp_dir, scanners=["semgrep"])
+
+    def test_scan_sequential(self, orchestrator, temp_dir):
+        """Test sequential scanning."""
+        adapter1 = MockAdapter(
+            name="scanner1", findings=[make_finding(scanner="scanner1")]
+        )
+        adapter2 = MockAdapter(
+            name="scanner2", findings=[make_finding(scanner="scanner2")]
+        )
+        orchestrator.register(adapter1)
+        orchestrator.register(adapter2)
+
+        results = orchestrator.scan(temp_dir, parallel=False, deduplicate=False)
+
+        assert len(results) == 2
+        assert adapter1.scan_count == 1
+        assert adapter2.scan_count == 1
+
+    def test_scan_parallel(self, orchestrator, temp_dir):
+        """Test parallel scanning."""
+        adapter1 = MockAdapter(
+            name="scanner1", findings=[make_finding(scanner="scanner1")]
+        )
+        adapter2 = MockAdapter(
+            name="scanner2", findings=[make_finding(scanner="scanner2")]
+        )
+        orchestrator.register(adapter1)
+        orchestrator.register(adapter2)
+
+        results = orchestrator.scan(temp_dir, parallel=True, deduplicate=False)
+
+        assert len(results) == 2
+        assert adapter1.scan_count == 1
+        assert adapter2.scan_count == 1
+
+    def test_scan_with_config(self, orchestrator, temp_dir):
+        """Test scanning with scanner-specific config."""
+
+        class ConfigCapturingAdapter(MockAdapter):
+            captured_config = None
+
+            def scan(self, target: Path, config: dict | None = None) -> list[Finding]:
+                ConfigCapturingAdapter.captured_config = config
+                return []
+
+        adapter = ConfigCapturingAdapter(name="test")
+        orchestrator.register(adapter)
+
+        config = {"test": {"rules": ["auto"], "timeout": 300}}
+        orchestrator.scan(temp_dir, config=config)
+
+        assert ConfigCapturingAdapter.captured_config == {
+            "rules": ["auto"],
+            "timeout": 300,
+        }
+
+    def test_scan_graceful_degradation_sequential(self, orchestrator, temp_dir, capsys):
+        """Test sequential scan continues after adapter failure."""
+        adapter1 = MockAdapter(name="failing", raises=RuntimeError("Scan failed"))
+        adapter2 = MockAdapter(
+            name="working", findings=[make_finding(scanner="working")]
+        )
+        orchestrator.register(adapter1)
+        orchestrator.register(adapter2)
+
+        results = orchestrator.scan(temp_dir, parallel=False, deduplicate=False)
+
+        # Should have results from working adapter
+        assert len(results) == 1
+        assert results[0].scanner == "working"
+
+        # Warning should be printed
+        captured = capsys.readouterr()
+        assert "failing scan failed" in captured.out
+
+    def test_scan_graceful_degradation_parallel(self, orchestrator, temp_dir, capsys):
+        """Test parallel scan continues after adapter failure."""
+        adapter1 = MockAdapter(name="failing", raises=RuntimeError("Scan failed"))
+        adapter2 = MockAdapter(
+            name="working", findings=[make_finding(scanner="working")]
+        )
+        orchestrator.register(adapter1)
+        orchestrator.register(adapter2)
+
+        results = orchestrator.scan(temp_dir, parallel=True, deduplicate=False)
+
+        # Should have results from working adapter
+        assert len(results) == 1
+        assert results[0].scanner == "working"
+
+
+class TestDeduplication:
+    """Tests for finding deduplication."""
+
+    @pytest.fixture
+    def orchestrator(self):
+        return ScannerOrchestrator()
+
+    @pytest.fixture
+    def temp_dir(self, tmp_path):
+        test_file = tmp_path / "test.py"
+        test_file.write_text("print('hello')")
+        return tmp_path
+
+    def test_deduplicate_removes_duplicates(self, orchestrator):
+        """Test deduplication removes findings with same fingerprint."""
+        # Two findings with same location and CWE
+        finding1 = make_finding(
+            scanner="semgrep", file="test.py", line=10, cwe="CWE-89"
+        )
+        finding2 = make_finding(scanner="codeql", file="test.py", line=10, cwe="CWE-89")
+
+        results = orchestrator.deduplicate([finding1, finding2])
+
+        assert len(results) == 1
+
+    def test_deduplicate_keeps_unique_findings(self, orchestrator):
+        """Test deduplication keeps findings with different fingerprints."""
+        finding1 = make_finding(
+            scanner="semgrep", file="test.py", line=10, cwe="CWE-89"
+        )
+        finding2 = make_finding(
+            scanner="semgrep", file="other.py", line=20, cwe="CWE-79"
+        )
+
+        results = orchestrator.deduplicate([finding1, finding2])
+
+        assert len(results) == 2
+
+    def test_deduplicate_merges_metadata(self, orchestrator):
+        """Test deduplication merges metadata from duplicates."""
+        finding1 = make_finding(
+            scanner="semgrep", file="test.py", line=10, cwe="CWE-89"
+        )
+        finding1.references = ["https://semgrep.example.com"]
+        finding1.confidence = Confidence.MEDIUM
+
+        finding2 = make_finding(scanner="codeql", file="test.py", line=10, cwe="CWE-89")
+        finding2.references = ["https://codeql.example.com"]
+        finding2.confidence = Confidence.MEDIUM
+
+        results = orchestrator.deduplicate([finding1, finding2])
+
+        assert len(results) == 1
+        # References should be merged
+        assert len(results[0].references) == 2
+        # Confidence should increase
+        assert results[0].confidence == Confidence.HIGH
+        # Merged scanners should be tracked
+        assert "codeql" in results[0].metadata.get("merged_scanners", [])
+
+    def test_scan_with_deduplication(self, orchestrator, temp_dir):
+        """Test scan applies deduplication by default."""
+        # Both scanners find the same vulnerability
+        same_finding1 = make_finding(
+            scanner="scanner1", file="test.py", line=10, cwe="CWE-89"
+        )
+        same_finding2 = make_finding(
+            scanner="scanner2", file="test.py", line=10, cwe="CWE-89"
+        )
+
+        adapter1 = MockAdapter(name="scanner1", findings=[same_finding1])
+        adapter2 = MockAdapter(name="scanner2", findings=[same_finding2])
+        orchestrator.register(adapter1)
+        orchestrator.register(adapter2)
+
+        # Deduplication is on by default
+        results = orchestrator.scan(temp_dir)
+
+        assert len(results) == 1
+
+    def test_scan_without_deduplication(self, orchestrator, temp_dir):
+        """Test scan can skip deduplication."""
+        same_finding1 = make_finding(
+            scanner="scanner1", file="test.py", line=10, cwe="CWE-89"
+        )
+        same_finding2 = make_finding(
+            scanner="scanner2", file="test.py", line=10, cwe="CWE-89"
+        )
+
+        adapter1 = MockAdapter(name="scanner1", findings=[same_finding1])
+        adapter2 = MockAdapter(name="scanner2", findings=[same_finding2])
+        orchestrator.register(adapter1)
+        orchestrator.register(adapter2)
+
+        results = orchestrator.scan(temp_dir, deduplicate=False)
+
+        assert len(results) == 2
+
+
+class TestOrchestratorWithInitialAdapters:
+    """Tests for orchestrator initialization with adapters."""
+
+    def test_init_with_adapters(self, tmp_path):
+        """Test orchestrator can be initialized with adapters."""
+        test_file = tmp_path / "test.py"
+        test_file.write_text("print('hello')")
+
+        adapter1 = MockAdapter(
+            name="scanner1", findings=[make_finding(scanner="scanner1")]
+        )
+        adapter2 = MockAdapter(
+            name="scanner2", findings=[make_finding(scanner="scanner2")]
+        )
+
+        orchestrator = ScannerOrchestrator(adapters=[adapter1, adapter2])
+
+        assert len(orchestrator.list_scanners()) == 2
+        assert "scanner1" in orchestrator.list_scanners()
+        assert "scanner2" in orchestrator.list_scanners()
+
+    def test_init_empty(self):
+        """Test orchestrator can be initialized empty."""
+        orchestrator = ScannerOrchestrator()
+
+        assert len(orchestrator.list_scanners()) == 0
+
+
+class TestScannerSelection:
+    """Tests for scanner selection during scan."""
+
+    @pytest.fixture
+    def orchestrator_with_scanners(self, tmp_path):
+        """Create orchestrator with multiple scanners."""
+        test_file = tmp_path / "test.py"
+        test_file.write_text("print('hello')")
+
+        orchestrator = ScannerOrchestrator()
+        orchestrator.register(
+            MockAdapter(
+                name="scanner1",
+                findings=[make_finding(scanner="scanner1", file="a.py", line=1)],
+            )
+        )
+        orchestrator.register(
+            MockAdapter(
+                name="scanner2",
+                findings=[make_finding(scanner="scanner2", file="b.py", line=2)],
+            )
+        )
+        orchestrator.register(
+            MockAdapter(
+                name="scanner3",
+                findings=[make_finding(scanner="scanner3", file="c.py", line=3)],
+            )
+        )
+
+        return orchestrator, tmp_path
+
+    def test_scan_all_scanners_by_default(self, orchestrator_with_scanners):
+        """Test all registered scanners are used by default."""
+        orchestrator, temp_dir = orchestrator_with_scanners
+
+        results = orchestrator.scan(temp_dir, deduplicate=False)
+
+        scanners_used = {f.scanner for f in results}
+        assert scanners_used == {"scanner1", "scanner2", "scanner3"}
+
+    def test_scan_specific_scanners(self, orchestrator_with_scanners):
+        """Test only specified scanners are used."""
+        orchestrator, temp_dir = orchestrator_with_scanners
+
+        results = orchestrator.scan(
+            temp_dir, scanners=["scanner1", "scanner3"], deduplicate=False
+        )
+
+        scanners_used = {f.scanner for f in results}
+        assert scanners_used == {"scanner1", "scanner3"}
+        assert "scanner2" not in scanners_used
+
+    def test_scan_single_scanner(self, orchestrator_with_scanners):
+        """Test scanning with single scanner."""
+        orchestrator, temp_dir = orchestrator_with_scanners
+
+        results = orchestrator.scan(temp_dir, scanners=["scanner2"], deduplicate=False)
+
+        assert len(results) == 1
+        assert results[0].scanner == "scanner2"


### PR DESCRIPTION
## Summary

Implements task-218 + task-219: Security documentation and test suite.

### Documentation (task-218)

- `docs/guides/security-quickstart.md` - Getting started
- `docs/reference/jpspec-security-commands.md` - CLI reference
- `docs/guides/security-cicd-integration.md` - CI/CD examples
- `docs/reference/security-threat-model.md` - Threat analysis
- `docs/reference/security-privacy-policy.md` - AI data handling
- `docs/guides/security-custom-rules.md` - Custom rules guide

### Test Suite (task-219)

85 unit tests:
- `test_models.py` - Finding, Location, Severity
- `test_orchestrator.py` - Scanner orchestration
- `test_semgrep.py` - Semgrep adapter with mocks

## Test Plan

- [x] 85 tests pass
- [x] Ruff lint passes
- [x] Ruff format passes
- [x] DCO sign-off present

🤖 Generated with [Claude Code](https://claude.com/claude-code)