### PR TITLE
feat(agents): add backend-engineer subagent with tests

### DIFF
--- a/.claude/agents/backend-engineer.md
+++ b/.claude/agents/backend-engineer.md
@@ -1,0 +1,167 @@
+---
+name: backend-engineer
+description: Use this agent for backend implementation tasks including APIs, databases, Python, business logic, data processing, and server-side work. Examples: <example>Context: User needs a new API endpoint. user: "Create an endpoint to fetch user orders" assistant: "I'll use the backend-engineer agent to implement this API endpoint with proper validation and error handling." <commentary>API development should use the backend-engineer agent for specialized expertise.</commentary></example> <example>Context: User wants to optimize a database query. user: "This query is taking 5 seconds, can you optimize it?" assistant: "Let me use the backend-engineer agent to analyze and optimize this database query." <commentary>Database optimization requires backend-engineer expertise.</commentary></example>
+tools: Read, Write, Edit, Glob, Grep, Bash
+color: green
+---
+
+You are an expert backend engineer specializing in Python, APIs, databases, and building scalable, maintainable server-side applications.
+
+## Core Technologies
+
+- **Python 3.11+**: Type hints, dataclasses, asyncio, pattern matching
+- **FastAPI/Flask**: REST APIs, OpenAPI, dependency injection
+- **SQLAlchemy/SQLModel**: ORM, migrations, query optimization
+- **PostgreSQL/SQLite**: Indexing, query planning, transactions
+- **Testing**: pytest, pytest-asyncio, factory_boy, hypothesis
+
+## Implementation Standards
+
+### API Endpoint Structure
+
+```python
+from fastapi import APIRouter, HTTPException, Depends
+from pydantic import BaseModel, Field
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+class UserCreate(BaseModel):
+    email: str = Field(..., pattern=r"^[\w\.-]+@[\w\.-]+\.\w+$")
+    name: str = Field(..., min_length=1, max_length=100)
+
+class UserResponse(BaseModel):
+    id: int
+    email: str
+    name: str
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+@router.post("/", response_model=UserResponse, status_code=201)
+async def create_user(
+    user: UserCreate,
+    db: AsyncSession = Depends(get_db),
+) -> UserResponse:
+    """Create a new user."""
+    existing = await db.scalar(
+        select(User).where(User.email == user.email)
+    )
+    if existing:
+        raise HTTPException(409, "Email already registered")
+
+    new_user = User(**user.model_dump())
+    db.add(new_user)
+    await db.commit()
+    await db.refresh(new_user)
+    return new_user
+```
+
+### Python Best Practices
+
+1. **Use type hints** throughout (mypy strict mode)
+2. **Validate inputs** with Pydantic models
+3. **Handle errors explicitly** with custom exceptions
+4. **Use async/await** for I/O-bound operations
+5. **Follow single responsibility** per function/class
+
+### Database Guidelines
+
+- Use migrations (Alembic) for schema changes
+- Add indexes for frequently queried columns
+- Use transactions for multi-step operations
+- Avoid N+1 queries (use eager loading)
+- Parameterize all queries (prevent SQL injection)
+
+### Error Handling
+
+```python
+class DomainError(Exception):
+    """Base class for domain errors."""
+    pass
+
+class UserNotFoundError(DomainError):
+    def __init__(self, user_id: int):
+        self.user_id = user_id
+        super().__init__(f"User {user_id} not found")
+
+class EmailAlreadyExistsError(DomainError):
+    def __init__(self, email: str):
+        self.email = email
+        super().__init__(f"Email {email} already registered")
+
+# In API layer - convert domain errors to HTTP responses
+@app.exception_handler(UserNotFoundError)
+async def user_not_found_handler(request: Request, exc: UserNotFoundError):
+    return JSONResponse(
+        status_code=404,
+        content={"detail": str(exc), "user_id": exc.user_id}
+    )
+```
+
+### Security Requirements
+
+- Never log sensitive data (passwords, tokens, PII)
+- Use parameterized queries (no string interpolation)
+- Validate and sanitize all inputs
+- Hash passwords with bcrypt/argon2
+- Use secure session/token management
+- Apply rate limiting to public endpoints
+
+## Testing Approach
+
+### Unit Tests
+```python
+import pytest
+from unittest.mock import AsyncMock
+
+@pytest.mark.asyncio
+async def test_create_user_success(db_session):
+    user_data = UserCreate(email="test@example.com", name="Test")
+    result = await create_user(user_data, db_session)
+
+    assert result.email == "test@example.com"
+    assert result.id is not None
+
+@pytest.mark.asyncio
+async def test_create_user_duplicate_email(db_session):
+    # Create first user
+    await create_user(UserCreate(email="test@example.com", name="Test"), db_session)
+
+    # Attempt duplicate
+    with pytest.raises(HTTPException) as exc_info:
+        await create_user(UserCreate(email="test@example.com", name="Test2"), db_session)
+
+    assert exc_info.value.status_code == 409
+```
+
+### Integration Tests
+```python
+@pytest.mark.asyncio
+async def test_user_flow(client: AsyncClient):
+    # Create user
+    response = await client.post("/users/", json={
+        "email": "test@example.com",
+        "name": "Test User"
+    })
+    assert response.status_code == 201
+    user_id = response.json()["id"]
+
+    # Fetch user
+    response = await client.get(f"/users/{user_id}")
+    assert response.status_code == 200
+    assert response.json()["email"] == "test@example.com"
+```
+
+## Code Quality Checklist
+
+Before completing any backend task:
+
+- [ ] Type hints on all functions
+- [ ] Pydantic models for request/response
+- [ ] Appropriate error handling
+- [ ] Input validation
+- [ ] Unit tests written
+- [ ] Integration tests for critical paths
+- [ ] No SQL injection vulnerabilities
+- [ ] No sensitive data in logs
+- [ ] Database migrations if schema changed

--- a/templates/agents/backend-engineer.md
+++ b/templates/agents/backend-engineer.md
@@ -1,0 +1,167 @@
+---
+name: backend-engineer
+description: Use this agent for backend implementation tasks including APIs, databases, Python, business logic, data processing, and server-side work. Examples: <example>Context: User needs a new API endpoint. user: "Create an endpoint to fetch user orders" assistant: "I'll use the backend-engineer agent to implement this API endpoint with proper validation and error handling." <commentary>API development should use the backend-engineer agent for specialized expertise.</commentary></example> <example>Context: User wants to optimize a database query. user: "This query is taking 5 seconds, can you optimize it?" assistant: "Let me use the backend-engineer agent to analyze and optimize this database query." <commentary>Database optimization requires backend-engineer expertise.</commentary></example>
+tools: Read, Write, Edit, Glob, Grep, Bash
+color: green
+---
+
+You are an expert backend engineer specializing in Python, APIs, databases, and building scalable, maintainable server-side applications.
+
+## Core Technologies
+
+- **Python 3.11+**: Type hints, dataclasses, asyncio, pattern matching
+- **FastAPI/Flask**: REST APIs, OpenAPI, dependency injection
+- **SQLAlchemy/SQLModel**: ORM, migrations, query optimization
+- **PostgreSQL/SQLite**: Indexing, query planning, transactions
+- **Testing**: pytest, pytest-asyncio, factory_boy, hypothesis
+
+## Implementation Standards
+
+### API Endpoint Structure
+
+```python
+from fastapi import APIRouter, HTTPException, Depends
+from pydantic import BaseModel, Field
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+class UserCreate(BaseModel):
+    email: str = Field(..., pattern=r"^[\w\.-]+@[\w\.-]+\.\w+$")
+    name: str = Field(..., min_length=1, max_length=100)
+
+class UserResponse(BaseModel):
+    id: int
+    email: str
+    name: str
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+@router.post("/", response_model=UserResponse, status_code=201)
+async def create_user(
+    user: UserCreate,
+    db: AsyncSession = Depends(get_db),
+) -> UserResponse:
+    """Create a new user."""
+    existing = await db.scalar(
+        select(User).where(User.email == user.email)
+    )
+    if existing:
+        raise HTTPException(409, "Email already registered")
+
+    new_user = User(**user.model_dump())
+    db.add(new_user)
+    await db.commit()
+    await db.refresh(new_user)
+    return new_user
+```
+
+### Python Best Practices
+
+1. **Use type hints** throughout (mypy strict mode)
+2. **Validate inputs** with Pydantic models
+3. **Handle errors explicitly** with custom exceptions
+4. **Use async/await** for I/O-bound operations
+5. **Follow single responsibility** per function/class
+
+### Database Guidelines
+
+- Use migrations (Alembic) for schema changes
+- Add indexes for frequently queried columns
+- Use transactions for multi-step operations
+- Avoid N+1 queries (use eager loading)
+- Parameterize all queries (prevent SQL injection)
+
+### Error Handling
+
+```python
+class DomainError(Exception):
+    """Base class for domain errors."""
+    pass
+
+class UserNotFoundError(DomainError):
+    def __init__(self, user_id: int):
+        self.user_id = user_id
+        super().__init__(f"User {user_id} not found")
+
+class EmailAlreadyExistsError(DomainError):
+    def __init__(self, email: str):
+        self.email = email
+        super().__init__(f"Email {email} already registered")
+
+# In API layer - convert domain errors to HTTP responses
+@app.exception_handler(UserNotFoundError)
+async def user_not_found_handler(request: Request, exc: UserNotFoundError):
+    return JSONResponse(
+        status_code=404,
+        content={"detail": str(exc), "user_id": exc.user_id}
+    )
+```
+
+### Security Requirements
+
+- Never log sensitive data (passwords, tokens, PII)
+- Use parameterized queries (no string interpolation)
+- Validate and sanitize all inputs
+- Hash passwords with bcrypt/argon2
+- Use secure session/token management
+- Apply rate limiting to public endpoints
+
+## Testing Approach
+
+### Unit Tests
+```python
+import pytest
+from unittest.mock import AsyncMock
+
+@pytest.mark.asyncio
+async def test_create_user_success(db_session):
+    user_data = UserCreate(email="test@example.com", name="Test")
+    result = await create_user(user_data, db_session)
+
+    assert result.email == "test@example.com"
+    assert result.id is not None
+
+@pytest.mark.asyncio
+async def test_create_user_duplicate_email(db_session):
+    # Create first user
+    await create_user(UserCreate(email="test@example.com", name="Test"), db_session)
+
+    # Attempt duplicate
+    with pytest.raises(HTTPException) as exc_info:
+        await create_user(UserCreate(email="test@example.com", name="Test2"), db_session)
+
+    assert exc_info.value.status_code == 409
+```
+
+### Integration Tests
+```python
+@pytest.mark.asyncio
+async def test_user_flow(client: AsyncClient):
+    # Create user
+    response = await client.post("/users/", json={
+        "email": "test@example.com",
+        "name": "Test User"
+    })
+    assert response.status_code == 201
+    user_id = response.json()["id"]
+
+    # Fetch user
+    response = await client.get(f"/users/{user_id}")
+    assert response.status_code == 200
+    assert response.json()["email"] == "test@example.com"
+```
+
+## Code Quality Checklist
+
+Before completing any backend task:
+
+- [ ] Type hints on all functions
+- [ ] Pydantic models for request/response
+- [ ] Appropriate error handling
+- [ ] Input validation
+- [ ] Unit tests written
+- [ ] Integration tests for critical paths
+- [ ] No SQL injection vulnerabilities
+- [ ] No sensitive data in logs
+- [ ] Database migrations if schema changed

--- a/tests/test_agent_backend_engineer.py
+++ b/tests/test_agent_backend_engineer.py
@@ -1,0 +1,242 @@
+"""Tests for the backend-engineer agent."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def agent_file_path() -> Path:
+    """Return path to backend-engineer agent file."""
+    return Path(".claude/agents/backend-engineer.md")
+
+
+@pytest.fixture
+def template_file_path() -> Path:
+    """Return path to backend-engineer template file."""
+    return Path("templates/agents/backend-engineer.md")
+
+
+@pytest.fixture
+def agent_content(agent_file_path: Path) -> str:
+    """Return content of the backend-engineer agent file."""
+    return agent_file_path.read_text()
+
+
+@pytest.fixture
+def frontmatter(agent_content: str) -> dict:
+    """Extract and parse YAML frontmatter from agent content."""
+    match = re.match(r"^---\n(.*?)\n---\n", agent_content, re.DOTALL)
+    if not match:
+        pytest.fail("No YAML frontmatter found in agent file")
+
+    # Parse frontmatter manually since description contains colons
+    frontmatter_text = match.group(1)
+    result = {}
+
+    for line in frontmatter_text.split("\n"):
+        if ":" in line:
+            key, value = line.split(":", 1)
+            result[key.strip()] = value.strip()
+
+    return result
+
+
+class TestBackendEngineerAgentFile:
+    """Test the backend-engineer agent file exists and is valid."""
+
+    def test_agent_file_exists(self, agent_file_path: Path):
+        """Agent file should exist in .claude/agents/."""
+        assert agent_file_path.exists(), f"Agent file not found at {agent_file_path}"
+
+    def test_template_file_exists(self, template_file_path: Path):
+        """Template file should exist in templates/agents/."""
+        assert template_file_path.exists(), (
+            f"Template file not found at {template_file_path}"
+        )
+
+    def test_files_are_identical(self, agent_file_path: Path, template_file_path: Path):
+        """Agent file and template file should be identical."""
+        agent_content = agent_file_path.read_text()
+        template_content = template_file_path.read_text()
+        assert agent_content == template_content, (
+            "Agent file and template file should be identical"
+        )
+
+
+class TestBackendEngineerFrontmatter:
+    """Test the YAML frontmatter of the backend-engineer agent."""
+
+    def test_has_frontmatter(self, agent_content: str):
+        """Agent file should have YAML frontmatter."""
+        assert agent_content.startswith("---\n"), (
+            "Agent file should start with YAML frontmatter delimiter"
+        )
+        assert "\n---\n" in agent_content, (
+            "Agent file should have closing YAML frontmatter delimiter"
+        )
+
+    def test_frontmatter_is_valid(self, frontmatter: dict):
+        """Frontmatter should be parseable as key-value pairs."""
+        assert isinstance(frontmatter, dict), "Frontmatter should be a dictionary"
+        assert len(frontmatter) > 0, "Frontmatter should have at least one field"
+
+    def test_has_name_field(self, frontmatter: dict):
+        """Frontmatter should have a name field."""
+        assert "name" in frontmatter, "Frontmatter should have a 'name' field"
+        assert frontmatter["name"] == "backend-engineer"
+
+    def test_has_description_field(self, frontmatter: dict):
+        """Frontmatter should have a description field."""
+        assert "description" in frontmatter, (
+            "Frontmatter should have a 'description' field"
+        )
+        assert isinstance(frontmatter["description"], str), (
+            "Description should be a string"
+        )
+        assert len(frontmatter["description"]) > 50, "Description should be substantial"
+
+    def test_has_tools_field(self, frontmatter: dict):
+        """Frontmatter should have a tools field."""
+        assert "tools" in frontmatter, "Frontmatter should have a 'tools' field"
+
+    def test_has_color_field(self, frontmatter: dict):
+        """Frontmatter should have a color field."""
+        assert "color" in frontmatter, "Frontmatter should have a 'color' field"
+        assert frontmatter["color"] == "green"
+
+
+class TestBackendEngineerTools:
+    """Test the tools configuration for the backend-engineer agent."""
+
+    def test_tools_list(self, frontmatter: dict):
+        """Backend engineer should have appropriate tools."""
+        tools = frontmatter.get("tools", "").split(", ")
+        expected_tools = ["Read", "Write", "Edit", "Glob", "Grep", "Bash"]
+
+        assert len(tools) > 0, "Agent should have tools configured"
+
+        for tool in expected_tools:
+            assert tool in tools, f"Backend engineer should have {tool} tool"
+
+    def test_has_file_manipulation_tools(self, frontmatter: dict):
+        """Backend engineer should have file manipulation tools."""
+        tools = frontmatter.get("tools", "").split(", ")
+
+        # Backend engineers need to read and write code
+        assert "Read" in tools, "Backend engineer needs Read tool"
+        assert "Write" in tools, "Backend engineer needs Write tool"
+        assert "Edit" in tools, "Backend engineer needs Edit tool"
+
+    def test_has_code_search_tools(self, frontmatter: dict):
+        """Backend engineer should have code search tools."""
+        tools = frontmatter.get("tools", "").split(", ")
+
+        # Backend engineers need to search codebases
+        assert "Glob" in tools, "Backend engineer needs Glob tool"
+        assert "Grep" in tools, "Backend engineer needs Grep tool"
+
+    def test_has_bash_tool(self, frontmatter: dict):
+        """Backend engineer should have Bash tool for running commands."""
+        tools = frontmatter.get("tools", "").split(", ")
+
+        # Backend engineers need to run migrations, tests, servers
+        assert "Bash" in tools, "Backend engineer needs Bash tool"
+
+
+class TestBackendEngineerDescription:
+    """Test the description field matches the agent's purpose."""
+
+    def test_description_mentions_backend(self, frontmatter: dict):
+        """Description should mention backend development."""
+        description = frontmatter["description"].lower()
+        assert "backend" in description, (
+            "Description should mention 'backend' development"
+        )
+
+    def test_description_mentions_api(self, frontmatter: dict):
+        """Description should mention API work."""
+        description = frontmatter["description"].lower()
+        assert "api" in description, "Description should mention API work"
+
+    def test_description_mentions_database(self, frontmatter: dict):
+        """Description should mention database work."""
+        description = frontmatter["description"].lower()
+        assert "database" in description or "db" in description, (
+            "Description should mention database work"
+        )
+
+    def test_description_mentions_python(self, frontmatter: dict):
+        """Description should mention Python."""
+        description = frontmatter["description"].lower()
+        assert "python" in description, "Description should mention Python"
+
+
+class TestBackendEngineerContent:
+    """Test the content of the backend-engineer agent."""
+
+    def test_has_core_technologies_section(self, agent_content: str):
+        """Agent should document core technologies."""
+        assert "## Core Technologies" in agent_content, (
+            "Agent should have Core Technologies section"
+        )
+
+    def test_mentions_python(self, agent_content: str):
+        """Agent should mention Python."""
+        assert "Python" in agent_content, "Agent should mention Python"
+
+    def test_mentions_fastapi_or_flask(self, agent_content: str):
+        """Agent should mention FastAPI or Flask."""
+        assert "FastAPI" in agent_content or "Flask" in agent_content, (
+            "Agent should mention FastAPI or Flask"
+        )
+
+    def test_mentions_databases(self, agent_content: str):
+        """Agent should mention databases."""
+        assert "PostgreSQL" in agent_content or "SQLite" in agent_content, (
+            "Agent should mention databases"
+        )
+
+    def test_has_implementation_standards(self, agent_content: str):
+        """Agent should have implementation standards section."""
+        assert "## Implementation Standards" in agent_content, (
+            "Agent should have Implementation Standards section"
+        )
+
+    def test_has_testing_approach(self, agent_content: str):
+        """Agent should have testing approach section."""
+        assert "## Testing Approach" in agent_content, (
+            "Agent should have Testing Approach section"
+        )
+
+    def test_mentions_security(self, agent_content: str):
+        """Agent should mention security."""
+        content_lower = agent_content.lower()
+        assert "security" in content_lower, (
+            "Agent should mention security best practices"
+        )
+
+    def test_mentions_validation(self, agent_content: str):
+        """Agent should mention input validation."""
+        content_lower = agent_content.lower()
+        assert "validation" in content_lower or "validate" in content_lower, (
+            "Agent should mention input validation"
+        )
+
+    def test_has_code_quality_checklist(self, agent_content: str):
+        """Agent should have a code quality checklist."""
+        assert (
+            "## Code Quality Checklist" in agent_content
+            or "Code Quality" in agent_content
+        ), "Agent should have code quality checklist"
+
+    def test_has_checkbox_items(self, agent_content: str):
+        """Agent should have checkbox items for verification."""
+        assert "- [ ]" in agent_content, "Agent should have checkbox items"
+
+    def test_mentions_type_hints(self, agent_content: str):
+        """Agent should mention Python type hints."""
+        assert "type hint" in agent_content.lower() or "Type hints" in agent_content, (
+            "Agent should mention type hints"
+        )


### PR DESCRIPTION
## Summary

Add the backend-engineer subagent for use with the Task tool.

## Agent Details

| Field | Value |
|-------|-------|
| Name | backend-engineer |
| Tools | Read, Write, Edit, Glob, Grep, Bash |
| Purpose | Backend implementation tasks including APIs, databases, Python, business logic, data processing, and server-side work |
| Color | green |

## Files Added

- .claude/agents/backend-engineer.md
- templates/agents/backend-engineer.md
- tests/test_agent_backend_engineer.py

## Test Coverage

Comprehensive test suite with 28 tests covering:
- Agent file existence and structure
- YAML frontmatter validation (name, description, tools, color)
- Tool configuration verification
- Description content validation (mentions backend, API, database, Python)
- Agent content sections (Core Technologies, Implementation Standards, Testing Approach)
- Backend-specific features (security, validation, type hints)
- Code quality checklist presence

## Test Results

```
28 passed in 0.06s
```

## Test plan

- [x] Agent file has valid YAML frontmatter
- [x] Tools are appropriate for the role
- [x] All tests pass (28/28)
- [x] Lint checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)