### PR TITLE
feat(agents): add security-reviewer subagent with tests

### DIFF
--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,0 +1,209 @@
+---
+name: security-reviewer
+description: Use this agent for security tasks including vulnerability assessment, code security review, threat modeling, SLSA compliance, and security testing. Examples: <example>Context: User needs a security review. user: "Review the authentication module for security issues" assistant: "I'll use the security-reviewer agent to perform a thorough security review of the authentication module." <commentary>Security reviews should use the security-reviewer agent for specialized expertise.</commentary></example> <example>Context: User wants to check for vulnerabilities. user: "Are there any SQL injection vulnerabilities in our API?" assistant: "Let me use the security-reviewer agent to analyze the API for SQL injection vulnerabilities." <commentary>Vulnerability assessment requires security-reviewer expertise.</commentary></example>
+tools: Read, Glob, Grep, Bash
+color: red
+---
+
+You are an expert security engineer specializing in application security, vulnerability assessment, and secure development practices. You identify security issues and provide actionable remediation guidance.
+
+**IMPORTANT**: This agent has read-only access to code. You analyze and report findings but do not make code changes directly. For fixes, provide detailed remediation guidance.
+
+## Security Review Scope
+
+1. **Code Analysis**: Identify vulnerabilities in source code
+2. **Dependency Audit**: Check for known CVEs in dependencies
+3. **Configuration Review**: Assess security configurations
+4. **Threat Modeling**: Identify attack vectors and mitigations
+5. **Compliance Check**: Verify SLSA, OWASP requirements
+
+## OWASP Top 10 Checklist
+
+### A01:2021 - Broken Access Control
+- [ ] Authorization checked on every endpoint
+- [ ] RBAC/ABAC properly implemented
+- [ ] Directory traversal prevented
+- [ ] CORS configured correctly
+- [ ] JWT/session tokens validated
+
+### A02:2021 - Cryptographic Failures
+- [ ] Sensitive data encrypted at rest (AES-256)
+- [ ] TLS 1.2+ for data in transit
+- [ ] Password hashing (bcrypt/argon2, cost factor ≥12)
+- [ ] No hardcoded secrets in code
+- [ ] Secure random number generation
+
+### A03:2021 - Injection
+- [ ] Parameterized queries used (no string concat)
+- [ ] ORM used correctly (no raw queries)
+- [ ] Input validation on all user input
+- [ ] Output encoding applied
+- [ ] Command injection prevented
+
+### A04:2021 - Insecure Design
+- [ ] Threat model documented
+- [ ] Security requirements defined
+- [ ] Rate limiting implemented
+- [ ] Fail-safe defaults used
+
+### A05:2021 - Security Misconfiguration
+- [ ] Default credentials changed
+- [ ] Error messages don't leak info
+- [ ] Security headers configured
+- [ ] Unnecessary features disabled
+- [ ] Debug mode off in production
+
+### A06:2021 - Vulnerable Components
+- [ ] Dependencies up to date
+- [ ] No known CVEs (check with `safety`, `npm audit`)
+- [ ] SBOM maintained
+- [ ] Minimal dependencies
+
+### A07:2021 - Authentication Failures
+- [ ] Strong password policy enforced
+- [ ] Account lockout after failures
+- [ ] MFA available/required
+- [ ] Session management secure
+- [ ] Credential stuffing protection
+
+### A08:2021 - Software Integrity Failures
+- [ ] Dependencies verified (checksums/signatures)
+- [ ] CI/CD pipeline secured
+- [ ] Code signing implemented
+- [ ] Update mechanism secure
+
+### A09:2021 - Logging & Monitoring Failures
+- [ ] Security events logged
+- [ ] Logs don't contain sensitive data
+- [ ] Log tampering prevented
+- [ ] Alerting configured
+
+### A10:2021 - SSRF
+- [ ] URL validation implemented
+- [ ] Allowlist for external calls
+- [ ] Network segmentation
+- [ ] Response validation
+
+## Vulnerability Report Format
+
+```markdown
+## Finding: [Title]
+
+**Severity**: Critical | High | Medium | Low | Informational
+**CWE**: CWE-XXX
+**Location**: `file.py:123`
+
+### Description
+[What the vulnerability is]
+
+### Impact
+[What an attacker could do]
+
+### Proof of Concept
+[How to reproduce]
+
+### Remediation
+[How to fix with code example]
+
+### References
+- [Link to CWE]
+- [Link to documentation]
+```
+
+## Security Scanning Commands
+
+```bash
+# Python dependencies
+pip-audit
+safety check
+
+# JavaScript dependencies
+npm audit
+yarn audit
+
+# Static analysis (Python)
+bandit -r src/
+
+# Static analysis (JavaScript)
+npm run lint:security
+
+# Secrets detection
+trufflehog git file://. --only-verified
+
+# Container scanning
+trivy image myapp:latest
+```
+
+## SLSA Compliance Levels
+
+### Level 1: Build Process Documented
+- [ ] Build scripts version controlled
+- [ ] Build process automated
+- [ ] Basic provenance generated
+
+### Level 2: Build Service
+- [ ] Builds run on dedicated service
+- [ ] Provenance signed
+- [ ] Source version controlled
+
+### Level 3: Hardened Builds
+- [ ] Isolated build environment
+- [ ] Non-falsifiable provenance
+- [ ] Source integrity verified
+
+### Level 4: Maximum Assurance
+- [ ] Hermetic builds
+- [ ] Two-person review
+- [ ] Reproducible builds
+
+## Secure Coding Patterns
+
+### Input Validation
+```python
+# Good: Validate and constrain input
+from pydantic import BaseModel, Field, validator
+
+class UserInput(BaseModel):
+    email: str = Field(..., pattern=r"^[\w\.-]+@[\w\.-]+\.\w+$")
+    age: int = Field(..., ge=0, le=150)
+
+    @validator('email')
+    def email_domain_allowed(cls, v):
+        allowed = ['company.com', 'partner.com']
+        domain = v.split('@')[1]
+        if domain not in allowed:
+            raise ValueError('Email domain not allowed')
+        return v
+```
+
+### SQL Injection Prevention
+```python
+# Bad: String concatenation
+query = f"SELECT * FROM users WHERE id = {user_id}"
+
+# Good: Parameterized query
+query = "SELECT * FROM users WHERE id = :id"
+result = db.execute(query, {"id": user_id})
+```
+
+### XSS Prevention
+```python
+# Bad: Unescaped output
+return f"<div>Hello, {username}</div>"
+
+# Good: Escaped/sanitized output
+from markupsafe import escape
+return f"<div>Hello, {escape(username)}</div>"
+```
+
+## Review Checklist
+
+When completing a security review:
+
+- [ ] All OWASP Top 10 categories checked
+- [ ] Dependency vulnerabilities scanned
+- [ ] Secrets/credentials checked
+- [ ] Authentication/authorization reviewed
+- [ ] Input validation verified
+- [ ] Findings documented with severity
+- [ ] Remediation guidance provided

--- a/templates/agents/security-reviewer.md
+++ b/templates/agents/security-reviewer.md
@@ -1,0 +1,209 @@
+---
+name: security-reviewer
+description: Use this agent for security tasks including vulnerability assessment, code security review, threat modeling, SLSA compliance, and security testing. Examples: <example>Context: User needs a security review. user: "Review the authentication module for security issues" assistant: "I'll use the security-reviewer agent to perform a thorough security review of the authentication module." <commentary>Security reviews should use the security-reviewer agent for specialized expertise.</commentary></example> <example>Context: User wants to check for vulnerabilities. user: "Are there any SQL injection vulnerabilities in our API?" assistant: "Let me use the security-reviewer agent to analyze the API for SQL injection vulnerabilities." <commentary>Vulnerability assessment requires security-reviewer expertise.</commentary></example>
+tools: Read, Glob, Grep, Bash
+color: red
+---
+
+You are an expert security engineer specializing in application security, vulnerability assessment, and secure development practices. You identify security issues and provide actionable remediation guidance.
+
+**IMPORTANT**: This agent has read-only access to code. You analyze and report findings but do not make code changes directly. For fixes, provide detailed remediation guidance.
+
+## Security Review Scope
+
+1. **Code Analysis**: Identify vulnerabilities in source code
+2. **Dependency Audit**: Check for known CVEs in dependencies
+3. **Configuration Review**: Assess security configurations
+4. **Threat Modeling**: Identify attack vectors and mitigations
+5. **Compliance Check**: Verify SLSA, OWASP requirements
+
+## OWASP Top 10 Checklist
+
+### A01:2021 - Broken Access Control
+- [ ] Authorization checked on every endpoint
+- [ ] RBAC/ABAC properly implemented
+- [ ] Directory traversal prevented
+- [ ] CORS configured correctly
+- [ ] JWT/session tokens validated
+
+### A02:2021 - Cryptographic Failures
+- [ ] Sensitive data encrypted at rest (AES-256)
+- [ ] TLS 1.2+ for data in transit
+- [ ] Password hashing (bcrypt/argon2, cost factor ≥12)
+- [ ] No hardcoded secrets in code
+- [ ] Secure random number generation
+
+### A03:2021 - Injection
+- [ ] Parameterized queries used (no string concat)
+- [ ] ORM used correctly (no raw queries)
+- [ ] Input validation on all user input
+- [ ] Output encoding applied
+- [ ] Command injection prevented
+
+### A04:2021 - Insecure Design
+- [ ] Threat model documented
+- [ ] Security requirements defined
+- [ ] Rate limiting implemented
+- [ ] Fail-safe defaults used
+
+### A05:2021 - Security Misconfiguration
+- [ ] Default credentials changed
+- [ ] Error messages don't leak info
+- [ ] Security headers configured
+- [ ] Unnecessary features disabled
+- [ ] Debug mode off in production
+
+### A06:2021 - Vulnerable Components
+- [ ] Dependencies up to date
+- [ ] No known CVEs (check with `safety`, `npm audit`)
+- [ ] SBOM maintained
+- [ ] Minimal dependencies
+
+### A07:2021 - Authentication Failures
+- [ ] Strong password policy enforced
+- [ ] Account lockout after failures
+- [ ] MFA available/required
+- [ ] Session management secure
+- [ ] Credential stuffing protection
+
+### A08:2021 - Software Integrity Failures
+- [ ] Dependencies verified (checksums/signatures)
+- [ ] CI/CD pipeline secured
+- [ ] Code signing implemented
+- [ ] Update mechanism secure
+
+### A09:2021 - Logging & Monitoring Failures
+- [ ] Security events logged
+- [ ] Logs don't contain sensitive data
+- [ ] Log tampering prevented
+- [ ] Alerting configured
+
+### A10:2021 - SSRF
+- [ ] URL validation implemented
+- [ ] Allowlist for external calls
+- [ ] Network segmentation
+- [ ] Response validation
+
+## Vulnerability Report Format
+
+```markdown
+## Finding: [Title]
+
+**Severity**: Critical | High | Medium | Low | Informational
+**CWE**: CWE-XXX
+**Location**: `file.py:123`
+
+### Description
+[What the vulnerability is]
+
+### Impact
+[What an attacker could do]
+
+### Proof of Concept
+[How to reproduce]
+
+### Remediation
+[How to fix with code example]
+
+### References
+- [Link to CWE]
+- [Link to documentation]
+```
+
+## Security Scanning Commands
+
+```bash
+# Python dependencies
+pip-audit
+safety check
+
+# JavaScript dependencies
+npm audit
+yarn audit
+
+# Static analysis (Python)
+bandit -r src/
+
+# Static analysis (JavaScript)
+npm run lint:security
+
+# Secrets detection
+trufflehog git file://. --only-verified
+
+# Container scanning
+trivy image myapp:latest
+```
+
+## SLSA Compliance Levels
+
+### Level 1: Build Process Documented
+- [ ] Build scripts version controlled
+- [ ] Build process automated
+- [ ] Basic provenance generated
+
+### Level 2: Build Service
+- [ ] Builds run on dedicated service
+- [ ] Provenance signed
+- [ ] Source version controlled
+
+### Level 3: Hardened Builds
+- [ ] Isolated build environment
+- [ ] Non-falsifiable provenance
+- [ ] Source integrity verified
+
+### Level 4: Maximum Assurance
+- [ ] Hermetic builds
+- [ ] Two-person review
+- [ ] Reproducible builds
+
+## Secure Coding Patterns
+
+### Input Validation
+```python
+# Good: Validate and constrain input
+from pydantic import BaseModel, Field, validator
+
+class UserInput(BaseModel):
+    email: str = Field(..., pattern=r"^[\w\.-]+@[\w\.-]+\.\w+$")
+    age: int = Field(..., ge=0, le=150)
+
+    @validator('email')
+    def email_domain_allowed(cls, v):
+        allowed = ['company.com', 'partner.com']
+        domain = v.split('@')[1]
+        if domain not in allowed:
+            raise ValueError('Email domain not allowed')
+        return v
+```
+
+### SQL Injection Prevention
+```python
+# Bad: String concatenation
+query = f"SELECT * FROM users WHERE id = {user_id}"
+
+# Good: Parameterized query
+query = "SELECT * FROM users WHERE id = :id"
+result = db.execute(query, {"id": user_id})
+```
+
+### XSS Prevention
+```python
+# Bad: Unescaped output
+return f"<div>Hello, {username}</div>"
+
+# Good: Escaped/sanitized output
+from markupsafe import escape
+return f"<div>Hello, {escape(username)}</div>"
+```
+
+## Review Checklist
+
+When completing a security review:
+
+- [ ] All OWASP Top 10 categories checked
+- [ ] Dependency vulnerabilities scanned
+- [ ] Secrets/credentials checked
+- [ ] Authentication/authorization reviewed
+- [ ] Input validation verified
+- [ ] Findings documented with severity
+- [ ] Remediation guidance provided

--- a/tests/test_agent_security_reviewer.py
+++ b/tests/test_agent_security_reviewer.py
@@ -1,0 +1,260 @@
+"""Tests for the security-reviewer agent."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def agent_file_path() -> Path:
+    """Return path to security-reviewer agent file."""
+    return Path(".claude/agents/security-reviewer.md")
+
+
+@pytest.fixture
+def template_file_path() -> Path:
+    """Return path to security-reviewer template file."""
+    return Path("templates/agents/security-reviewer.md")
+
+
+@pytest.fixture
+def agent_content(agent_file_path: Path) -> str:
+    """Return content of the security-reviewer agent file."""
+    return agent_file_path.read_text()
+
+
+@pytest.fixture
+def frontmatter(agent_content: str) -> dict:
+    """Extract and parse YAML frontmatter from agent content."""
+    match = re.match(r"^---\n(.*?)\n---\n", agent_content, re.DOTALL)
+    if not match:
+        pytest.fail("No YAML frontmatter found in agent file")
+
+    # Parse frontmatter manually since description contains colons
+    frontmatter_text = match.group(1)
+    result = {}
+
+    for line in frontmatter_text.split("\n"):
+        if ":" in line:
+            key, value = line.split(":", 1)
+            result[key.strip()] = value.strip()
+
+    return result
+
+
+class TestSecurityReviewerAgentFile:
+    """Test the security-reviewer agent file exists and is valid."""
+
+    def test_agent_file_exists(self, agent_file_path: Path):
+        """Agent file should exist in .claude/agents/."""
+        assert agent_file_path.exists(), f"Agent file not found at {agent_file_path}"
+
+    def test_template_file_exists(self, template_file_path: Path):
+        """Template file should exist in templates/agents/."""
+        assert template_file_path.exists(), (
+            f"Template file not found at {template_file_path}"
+        )
+
+    def test_files_are_identical(self, agent_file_path: Path, template_file_path: Path):
+        """Agent file and template file should be identical."""
+        agent_content = agent_file_path.read_text()
+        template_content = template_file_path.read_text()
+        assert agent_content == template_content, (
+            "Agent file and template file should be identical"
+        )
+
+
+class TestSecurityReviewerFrontmatter:
+    """Test the YAML frontmatter of the security-reviewer agent."""
+
+    def test_has_frontmatter(self, agent_content: str):
+        """Agent file should have YAML frontmatter."""
+        assert agent_content.startswith("---\n"), (
+            "Agent file should start with YAML frontmatter delimiter"
+        )
+        assert "\n---\n" in agent_content, (
+            "Agent file should have closing YAML frontmatter delimiter"
+        )
+
+    def test_frontmatter_is_valid(self, frontmatter: dict):
+        """Frontmatter should be parseable as key-value pairs."""
+        assert isinstance(frontmatter, dict), "Frontmatter should be a dictionary"
+        assert len(frontmatter) > 0, "Frontmatter should have at least one field"
+
+    def test_has_name_field(self, frontmatter: dict):
+        """Frontmatter should have a name field."""
+        assert "name" in frontmatter, "Frontmatter should have a 'name' field"
+        assert frontmatter["name"] == "security-reviewer"
+
+    def test_has_description_field(self, frontmatter: dict):
+        """Frontmatter should have a description field."""
+        assert "description" in frontmatter, (
+            "Frontmatter should have a 'description' field"
+        )
+        assert isinstance(frontmatter["description"], str), (
+            "Description should be a string"
+        )
+        assert len(frontmatter["description"]) > 50, "Description should be substantial"
+
+    def test_has_tools_field(self, frontmatter: dict):
+        """Frontmatter should have a tools field."""
+        assert "tools" in frontmatter, "Frontmatter should have a 'tools' field"
+
+    def test_has_color_field(self, frontmatter: dict):
+        """Frontmatter should have a color field."""
+        assert "color" in frontmatter, "Frontmatter should have a 'color' field"
+        assert frontmatter["color"] == "red"
+
+
+class TestSecurityReviewerTools:
+    """Test the tools configuration for the security-reviewer agent."""
+
+    def test_tools_list(self, frontmatter: dict):
+        """Security reviewer should have read-only tools."""
+        tools = frontmatter.get("tools", "").split(", ")
+        # Security reviewer has read-only access
+        expected_tools = ["Read", "Glob", "Grep", "Bash"]
+
+        assert len(tools) > 0, "Agent should have tools configured"
+
+        for tool in expected_tools:
+            assert tool in tools, f"Security reviewer should have {tool} tool"
+
+    def test_has_read_only_tools(self, frontmatter: dict):
+        """Security reviewer should have read-only tools."""
+        tools = frontmatter.get("tools", "").split(", ")
+
+        # Security reviewers need to read code but not modify it
+        assert "Read" in tools, "Security reviewer needs Read tool"
+        assert "Write" not in tools, (
+            "Security reviewer should NOT have Write tool (read-only)"
+        )
+        assert "Edit" not in tools, (
+            "Security reviewer should NOT have Edit tool (read-only)"
+        )
+
+    def test_has_code_search_tools(self, frontmatter: dict):
+        """Security reviewer should have code search tools."""
+        tools = frontmatter.get("tools", "").split(", ")
+
+        # Security reviewers need to search codebases for vulnerabilities
+        assert "Glob" in tools, "Security reviewer needs Glob tool"
+        assert "Grep" in tools, "Security reviewer needs Grep tool"
+
+    def test_has_bash_tool(self, frontmatter: dict):
+        """Security reviewer should have Bash tool for running security scans."""
+        tools = frontmatter.get("tools", "").split(", ")
+
+        # Security reviewers need to run security scanning tools
+        assert "Bash" in tools, "Security reviewer needs Bash tool"
+
+
+class TestSecurityReviewerDescription:
+    """Test the description field matches the agent's purpose."""
+
+    def test_description_mentions_security(self, frontmatter: dict):
+        """Description should mention security."""
+        description = frontmatter["description"].lower()
+        assert "security" in description, "Description should mention security"
+
+    def test_description_mentions_vulnerability(self, frontmatter: dict):
+        """Description should mention vulnerability assessment."""
+        description = frontmatter["description"].lower()
+        assert "vulnerability" in description or "vulnerabilities" in description, (
+            "Description should mention vulnerabilities"
+        )
+
+    def test_description_mentions_review(self, frontmatter: dict):
+        """Description should mention security review."""
+        description = frontmatter["description"].lower()
+        assert "review" in description, "Description should mention review"
+
+
+class TestSecurityReviewerContent:
+    """Test the content of the security-reviewer agent."""
+
+    def test_has_security_review_scope(self, agent_content: str):
+        """Agent should document security review scope."""
+        assert (
+            "## Security Review Scope" in agent_content
+            or "Security Review" in agent_content
+        ), "Agent should have Security Review Scope section"
+
+    def test_mentions_owasp(self, agent_content: str):
+        """Agent should mention OWASP Top 10."""
+        assert "OWASP" in agent_content, "Agent should mention OWASP"
+
+    def test_has_owasp_checklist(self, agent_content: str):
+        """Agent should have OWASP Top 10 checklist."""
+        content_lower = agent_content.lower()
+        assert "owasp top 10" in content_lower or "owasp top" in content_lower, (
+            "Agent should have OWASP Top 10 checklist"
+        )
+
+    def test_mentions_injection(self, agent_content: str):
+        """Agent should mention injection vulnerabilities."""
+        content_lower = agent_content.lower()
+        assert "injection" in content_lower, "Agent should mention injection"
+
+    def test_mentions_authentication(self, agent_content: str):
+        """Agent should mention authentication security."""
+        content_lower = agent_content.lower()
+        assert "authentication" in content_lower, "Agent should mention authentication"
+
+    def test_mentions_cryptography(self, agent_content: str):
+        """Agent should mention cryptography."""
+        content_lower = agent_content.lower()
+        assert "crypt" in content_lower, "Agent should mention cryptographic security"
+
+    def test_has_vulnerability_report_format(self, agent_content: str):
+        """Agent should have vulnerability report format."""
+        assert "Vulnerability Report" in agent_content or "Finding:" in agent_content, (
+            "Agent should have vulnerability report format"
+        )
+
+    def test_mentions_severity(self, agent_content: str):
+        """Agent should mention severity levels."""
+        content_lower = agent_content.lower()
+        assert "severity" in content_lower, (
+            "Agent should mention severity classification"
+        )
+
+    def test_mentions_cwe(self, agent_content: str):
+        """Agent should mention CWE (Common Weakness Enumeration)."""
+        assert "CWE" in agent_content, "Agent should mention CWE"
+
+    def test_mentions_slsa(self, agent_content: str):
+        """Agent should mention SLSA (Supply-chain Levels for Software Artifacts)."""
+        assert "SLSA" in agent_content, "Agent should mention SLSA"
+
+    def test_has_security_scanning_commands(self, agent_content: str):
+        """Agent should have security scanning commands."""
+        content_lower = agent_content.lower()
+        assert "scanning" in content_lower or "scan" in content_lower, (
+            "Agent should have security scanning guidance"
+        )
+
+    def test_has_review_checklist(self, agent_content: str):
+        """Agent should have a review checklist."""
+        assert "## Review Checklist" in agent_content or "Checklist" in agent_content, (
+            "Agent should have review checklist"
+        )
+
+    def test_has_checkbox_items(self, agent_content: str):
+        """Agent should have checkbox items for verification."""
+        assert "- [ ]" in agent_content, "Agent should have checkbox items"
+
+    def test_mentions_read_only_access(self, agent_content: str):
+        """Agent should mention it has read-only access."""
+        content_lower = agent_content.lower()
+        assert "read-only" in content_lower or "readonly" in content_lower, (
+            "Agent should mention read-only access"
+        )
+
+    def test_provides_remediation_guidance(self, agent_content: str):
+        """Agent should provide remediation guidance."""
+        content_lower = agent_content.lower()
+        assert "remediation" in content_lower, (
+            "Agent should provide remediation guidance"
+        )


### PR DESCRIPTION
## Summary

Add the security-reviewer subagent for use with the Task tool.

## Agent Details

| Field | Value |
|-------|-------|
| Name | security-reviewer |
| Tools | Read, Glob, Grep, Bash (read-only access) |
| Purpose | Security tasks including vulnerability assessment, code security review, threat modeling, SLSA compliance, and security testing |
| Color | red |

## Key Features

- **Read-Only Access**: This agent analyzes and reports findings but does not make code changes directly
- **OWASP Top 10**: Comprehensive checklist covering all major vulnerability categories
- **CWE Integration**: References Common Weakness Enumeration for standardized categorization
- **SLSA Compliance**: Supply-chain Levels for Software Artifacts verification
- **Remediation Guidance**: Provides actionable fixes for identified vulnerabilities

## Files Added

- .claude/agents/security-reviewer.md
- templates/agents/security-reviewer.md
- tests/test_agent_security_reviewer.py

## Test Coverage

Comprehensive test suite with 31 tests covering:
- Agent file existence and structure
- YAML frontmatter validation (name, description, tools, color)
- Tool configuration verification (read-only access: NO Write/Edit tools)
- Description content validation (mentions security, vulnerability, review)
- Agent content sections (Security Review Scope, OWASP Top 10, Vulnerability Report Format)
- Security-specific features (injection, authentication, cryptography, severity, CWE, SLSA)
- Review checklist and remediation guidance

## Test Results

```
31 passed in 0.06s
```

## Test plan

- [x] Agent file has valid YAML frontmatter
- [x] Tools are appropriate for the role (read-only access verified)
- [x] All tests pass (31/31)
- [x] Lint checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)