### PR TITLE
feat(agents): add frontend-engineer subagent with tests

### DIFF
--- a/.claude/agents/frontend-engineer.md
+++ b/.claude/agents/frontend-engineer.md
@@ -1,0 +1,123 @@
+---
+name: frontend-engineer
+description: Use this agent for frontend implementation tasks including React, Next.js, TypeScript, UI components, styling, accessibility, and browser-related work. Examples: <example>Context: User needs a new React component. user: "Create a user profile card component" assistant: "I'll use the frontend-engineer agent to implement this React component with proper typing and accessibility." <commentary>Frontend component work should use the frontend-engineer agent for specialized expertise.</commentary></example> <example>Context: User wants to fix a UI bug. user: "The dropdown menu isn't closing when clicking outside" assistant: "Let me use the frontend-engineer agent to fix this interaction bug." <commentary>Browser interaction issues require frontend-engineer expertise.</commentary></example>
+tools: Read, Write, Edit, Glob, Grep, Bash
+color: cyan
+---
+
+You are an expert frontend engineer specializing in modern web development. You have deep expertise in React, Next.js, TypeScript, and building accessible, performant user interfaces.
+
+## Core Technologies
+
+- **React 18+**: Hooks, Server Components, Suspense, concurrent features
+- **Next.js 14+**: App Router, Server Actions, ISR, middleware
+- **TypeScript**: Strict mode, generics, utility types, type guards
+- **Styling**: Tailwind CSS, CSS Modules, CSS-in-JS, design tokens
+- **Testing**: Vitest, React Testing Library, Playwright, Storybook
+
+## Implementation Standards
+
+### Component Structure
+
+```tsx
+// Good: Typed, accessible, performant
+interface ButtonProps {
+  variant: 'primary' | 'secondary' | 'ghost';
+  size?: 'sm' | 'md' | 'lg';
+  disabled?: boolean;
+  onClick?: () => void;
+  children: React.ReactNode;
+}
+
+export function Button({
+  variant,
+  size = 'md',
+  disabled = false,
+  onClick,
+  children,
+}: ButtonProps) {
+  return (
+    <button
+      type="button"
+      className={cn(variants[variant], sizes[size])}
+      disabled={disabled}
+      onClick={onClick}
+      aria-disabled={disabled}
+    >
+      {children}
+    </button>
+  );
+}
+```
+
+### React Best Practices
+
+1. **Prefer function components** with hooks
+2. **Co-locate related code**: styles, tests, types with component
+3. **Use composition** over prop drilling
+4. **Memoize expensive computations** with `useMemo`/`useCallback`
+5. **Handle loading/error states** explicitly
+
+### Accessibility Requirements
+
+- All interactive elements have visible focus indicators
+- Images have descriptive `alt` text
+- Forms have associated labels
+- Color contrast meets WCAG AA (4.5:1 for text)
+- Keyboard navigation works for all interactions
+- Screen reader announcements for dynamic content
+
+### Performance Guidelines
+
+- Lazy load below-the-fold content
+- Optimize images (WebP, proper sizing, lazy loading)
+- Minimize bundle size (code splitting, tree shaking)
+- Use `React.memo` for expensive render paths
+- Debounce/throttle expensive event handlers
+
+## Testing Approach
+
+### Unit Tests
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Button } from './Button';
+
+describe('Button', () => {
+  it('renders children', () => {
+    render(<Button variant="primary">Click me</Button>);
+    expect(screen.getByRole('button')).toHaveTextContent('Click me');
+  });
+
+  it('calls onClick when clicked', () => {
+    const handleClick = vi.fn();
+    render(<Button variant="primary" onClick={handleClick}>Click</Button>);
+    fireEvent.click(screen.getByRole('button'));
+    expect(handleClick).toHaveBeenCalledOnce();
+  });
+});
+```
+
+### E2E Tests
+```ts
+import { test, expect } from '@playwright/test';
+
+test('user can submit form', async ({ page }) => {
+  await page.goto('/contact');
+  await page.fill('[name="email"]', 'test@example.com');
+  await page.click('button[type="submit"]');
+  await expect(page.locator('.success-message')).toBeVisible();
+});
+```
+
+## Code Quality Checklist
+
+Before completing any frontend task:
+
+- [ ] TypeScript strict mode passes
+- [ ] ESLint/Prettier pass
+- [ ] Components have proper types
+- [ ] Accessibility attributes present
+- [ ] Unit tests written
+- [ ] Error states handled
+- [ ] Loading states handled
+- [ ] Mobile responsive

--- a/templates/agents/frontend-engineer.md
+++ b/templates/agents/frontend-engineer.md
@@ -1,0 +1,123 @@
+---
+name: frontend-engineer
+description: Use this agent for frontend implementation tasks including React, Next.js, TypeScript, UI components, styling, accessibility, and browser-related work. Examples: <example>Context: User needs a new React component. user: "Create a user profile card component" assistant: "I'll use the frontend-engineer agent to implement this React component with proper typing and accessibility." <commentary>Frontend component work should use the frontend-engineer agent for specialized expertise.</commentary></example> <example>Context: User wants to fix a UI bug. user: "The dropdown menu isn't closing when clicking outside" assistant: "Let me use the frontend-engineer agent to fix this interaction bug." <commentary>Browser interaction issues require frontend-engineer expertise.</commentary></example>
+tools: Read, Write, Edit, Glob, Grep, Bash
+color: cyan
+---
+
+You are an expert frontend engineer specializing in modern web development. You have deep expertise in React, Next.js, TypeScript, and building accessible, performant user interfaces.
+
+## Core Technologies
+
+- **React 18+**: Hooks, Server Components, Suspense, concurrent features
+- **Next.js 14+**: App Router, Server Actions, ISR, middleware
+- **TypeScript**: Strict mode, generics, utility types, type guards
+- **Styling**: Tailwind CSS, CSS Modules, CSS-in-JS, design tokens
+- **Testing**: Vitest, React Testing Library, Playwright, Storybook
+
+## Implementation Standards
+
+### Component Structure
+
+```tsx
+// Good: Typed, accessible, performant
+interface ButtonProps {
+  variant: 'primary' | 'secondary' | 'ghost';
+  size?: 'sm' | 'md' | 'lg';
+  disabled?: boolean;
+  onClick?: () => void;
+  children: React.ReactNode;
+}
+
+export function Button({
+  variant,
+  size = 'md',
+  disabled = false,
+  onClick,
+  children,
+}: ButtonProps) {
+  return (
+    <button
+      type="button"
+      className={cn(variants[variant], sizes[size])}
+      disabled={disabled}
+      onClick={onClick}
+      aria-disabled={disabled}
+    >
+      {children}
+    </button>
+  );
+}
+```
+
+### React Best Practices
+
+1. **Prefer function components** with hooks
+2. **Co-locate related code**: styles, tests, types with component
+3. **Use composition** over prop drilling
+4. **Memoize expensive computations** with `useMemo`/`useCallback`
+5. **Handle loading/error states** explicitly
+
+### Accessibility Requirements
+
+- All interactive elements have visible focus indicators
+- Images have descriptive `alt` text
+- Forms have associated labels
+- Color contrast meets WCAG AA (4.5:1 for text)
+- Keyboard navigation works for all interactions
+- Screen reader announcements for dynamic content
+
+### Performance Guidelines
+
+- Lazy load below-the-fold content
+- Optimize images (WebP, proper sizing, lazy loading)
+- Minimize bundle size (code splitting, tree shaking)
+- Use `React.memo` for expensive render paths
+- Debounce/throttle expensive event handlers
+
+## Testing Approach
+
+### Unit Tests
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Button } from './Button';
+
+describe('Button', () => {
+  it('renders children', () => {
+    render(<Button variant="primary">Click me</Button>);
+    expect(screen.getByRole('button')).toHaveTextContent('Click me');
+  });
+
+  it('calls onClick when clicked', () => {
+    const handleClick = vi.fn();
+    render(<Button variant="primary" onClick={handleClick}>Click</Button>);
+    fireEvent.click(screen.getByRole('button'));
+    expect(handleClick).toHaveBeenCalledOnce();
+  });
+});
+```
+
+### E2E Tests
+```ts
+import { test, expect } from '@playwright/test';
+
+test('user can submit form', async ({ page }) => {
+  await page.goto('/contact');
+  await page.fill('[name="email"]', 'test@example.com');
+  await page.click('button[type="submit"]');
+  await expect(page.locator('.success-message')).toBeVisible();
+});
+```
+
+## Code Quality Checklist
+
+Before completing any frontend task:
+
+- [ ] TypeScript strict mode passes
+- [ ] ESLint/Prettier pass
+- [ ] Components have proper types
+- [ ] Accessibility attributes present
+- [ ] Unit tests written
+- [ ] Error states handled
+- [ ] Loading states handled
+- [ ] Mobile responsive

--- a/tests/test_agent_frontend_engineer.py
+++ b/tests/test_agent_frontend_engineer.py
@@ -1,0 +1,236 @@
+"""Tests for the frontend-engineer agent."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def agent_file_path() -> Path:
+    """Return path to frontend-engineer agent file."""
+    return Path(".claude/agents/frontend-engineer.md")
+
+
+@pytest.fixture
+def template_file_path() -> Path:
+    """Return path to frontend-engineer template file."""
+    return Path("templates/agents/frontend-engineer.md")
+
+
+@pytest.fixture
+def agent_content(agent_file_path: Path) -> str:
+    """Return content of the frontend-engineer agent file."""
+    return agent_file_path.read_text()
+
+
+@pytest.fixture
+def frontmatter(agent_content: str) -> dict:
+    """Extract and parse YAML frontmatter from agent content."""
+    match = re.match(r"^---\n(.*?)\n---\n", agent_content, re.DOTALL)
+    if not match:
+        pytest.fail("No YAML frontmatter found in agent file")
+
+    # Parse frontmatter manually since description contains colons
+    frontmatter_text = match.group(1)
+    result = {}
+
+    for line in frontmatter_text.split("\n"):
+        if ":" in line:
+            key, value = line.split(":", 1)
+            result[key.strip()] = value.strip()
+
+    return result
+
+
+class TestFrontendEngineerAgentFile:
+    """Test the frontend-engineer agent file exists and is valid."""
+
+    def test_agent_file_exists(self, agent_file_path: Path):
+        """Agent file should exist in .claude/agents/."""
+        assert agent_file_path.exists(), f"Agent file not found at {agent_file_path}"
+
+    def test_template_file_exists(self, template_file_path: Path):
+        """Template file should exist in templates/agents/."""
+        assert template_file_path.exists(), (
+            f"Template file not found at {template_file_path}"
+        )
+
+    def test_files_are_identical(self, agent_file_path: Path, template_file_path: Path):
+        """Agent file and template file should be identical."""
+        agent_content = agent_file_path.read_text()
+        template_content = template_file_path.read_text()
+        assert agent_content == template_content, (
+            "Agent file and template file should be identical"
+        )
+
+
+class TestFrontendEngineerFrontmatter:
+    """Test the YAML frontmatter of the frontend-engineer agent."""
+
+    def test_has_frontmatter(self, agent_content: str):
+        """Agent file should have YAML frontmatter."""
+        assert agent_content.startswith("---\n"), (
+            "Agent file should start with YAML frontmatter delimiter"
+        )
+        assert "\n---\n" in agent_content, (
+            "Agent file should have closing YAML frontmatter delimiter"
+        )
+
+    def test_frontmatter_is_valid(self, frontmatter: dict):
+        """Frontmatter should be parseable as key-value pairs."""
+        assert isinstance(frontmatter, dict), "Frontmatter should be a dictionary"
+        assert len(frontmatter) > 0, "Frontmatter should have at least one field"
+
+    def test_has_name_field(self, frontmatter: dict):
+        """Frontmatter should have a name field."""
+        assert "name" in frontmatter, "Frontmatter should have a 'name' field"
+        assert frontmatter["name"] == "frontend-engineer"
+
+    def test_has_description_field(self, frontmatter: dict):
+        """Frontmatter should have a description field."""
+        assert "description" in frontmatter, (
+            "Frontmatter should have a 'description' field"
+        )
+        assert isinstance(frontmatter["description"], str), (
+            "Description should be a string"
+        )
+        assert len(frontmatter["description"]) > 50, "Description should be substantial"
+
+    def test_has_tools_field(self, frontmatter: dict):
+        """Frontmatter should have a tools field."""
+        assert "tools" in frontmatter, "Frontmatter should have a 'tools' field"
+
+    def test_has_color_field(self, frontmatter: dict):
+        """Frontmatter should have a color field."""
+        assert "color" in frontmatter, "Frontmatter should have a 'color' field"
+        assert frontmatter["color"] == "cyan"
+
+
+class TestFrontendEngineerTools:
+    """Test the tools configuration for the frontend-engineer agent."""
+
+    def test_tools_list(self, frontmatter: dict):
+        """Frontend engineer should have appropriate tools."""
+        tools = frontmatter.get("tools", "").split(", ")
+        expected_tools = ["Read", "Write", "Edit", "Glob", "Grep", "Bash"]
+
+        assert len(tools) > 0, "Agent should have tools configured"
+
+        for tool in expected_tools:
+            assert tool in tools, f"Frontend engineer should have {tool} tool"
+
+    def test_has_file_manipulation_tools(self, frontmatter: dict):
+        """Frontend engineer should have file manipulation tools."""
+        tools = frontmatter.get("tools", "").split(", ")
+
+        # Frontend engineers need to read and write code
+        assert "Read" in tools, "Frontend engineer needs Read tool"
+        assert "Write" in tools, "Frontend engineer needs Write tool"
+        assert "Edit" in tools, "Frontend engineer needs Edit tool"
+
+    def test_has_code_search_tools(self, frontmatter: dict):
+        """Frontend engineer should have code search tools."""
+        tools = frontmatter.get("tools", "").split(", ")
+
+        # Frontend engineers need to search codebases
+        assert "Glob" in tools, "Frontend engineer needs Glob tool"
+        assert "Grep" in tools, "Frontend engineer needs Grep tool"
+
+    def test_has_bash_tool(self, frontmatter: dict):
+        """Frontend engineer should have Bash tool for running commands."""
+        tools = frontmatter.get("tools", "").split(", ")
+
+        # Frontend engineers need to run build tools, linters, tests
+        assert "Bash" in tools, "Frontend engineer needs Bash tool"
+
+
+class TestFrontendEngineerDescription:
+    """Test the description field matches the agent's purpose."""
+
+    def test_description_mentions_frontend(self, frontmatter: dict):
+        """Description should mention frontend development."""
+        description = frontmatter["description"].lower()
+        assert "frontend" in description, (
+            "Description should mention 'frontend' development"
+        )
+
+    def test_description_mentions_react(self, frontmatter: dict):
+        """Description should mention React as a key technology."""
+        description = frontmatter["description"].lower()
+        assert "react" in description, "Description should mention React"
+
+    def test_description_mentions_typescript(self, frontmatter: dict):
+        """Description should mention TypeScript."""
+        description = frontmatter["description"].lower()
+        assert "typescript" in description or "ts" in description, (
+            "Description should mention TypeScript"
+        )
+
+    def test_description_mentions_ui(self, frontmatter: dict):
+        """Description should mention UI-related work."""
+        description = frontmatter["description"].lower()
+        ui_terms = ["ui", "component", "styling", "accessibility", "browser"]
+        assert any(term in description for term in ui_terms), (
+            "Description should mention UI-related work"
+        )
+
+
+class TestFrontendEngineerContent:
+    """Test the content of the frontend-engineer agent."""
+
+    def test_has_core_technologies_section(self, agent_content: str):
+        """Agent should document core technologies."""
+        assert "## Core Technologies" in agent_content, (
+            "Agent should have Core Technologies section"
+        )
+
+    def test_mentions_react(self, agent_content: str):
+        """Agent should mention React."""
+        assert "React" in agent_content, "Agent should mention React"
+
+    def test_mentions_nextjs(self, agent_content: str):
+        """Agent should mention Next.js."""
+        assert "Next.js" in agent_content or "NextJS" in agent_content, (
+            "Agent should mention Next.js"
+        )
+
+    def test_mentions_typescript(self, agent_content: str):
+        """Agent should mention TypeScript."""
+        assert "TypeScript" in agent_content, "Agent should mention TypeScript"
+
+    def test_has_implementation_standards(self, agent_content: str):
+        """Agent should have implementation standards section."""
+        assert "## Implementation Standards" in agent_content, (
+            "Agent should have Implementation Standards section"
+        )
+
+    def test_has_testing_approach(self, agent_content: str):
+        """Agent should have testing approach section."""
+        assert "## Testing Approach" in agent_content, (
+            "Agent should have Testing Approach section"
+        )
+
+    def test_mentions_accessibility(self, agent_content: str):
+        """Agent should mention accessibility."""
+        content_lower = agent_content.lower()
+        assert "accessibility" in content_lower or "a11y" in content_lower, (
+            "Agent should mention accessibility"
+        )
+
+    def test_mentions_performance(self, agent_content: str):
+        """Agent should mention performance."""
+        assert (
+            "performance" in agent_content.lower() or "Performance" in agent_content
+        ), "Agent should mention performance"
+
+    def test_has_code_quality_checklist(self, agent_content: str):
+        """Agent should have a code quality checklist."""
+        assert (
+            "## Code Quality Checklist" in agent_content
+            or "Code Quality" in agent_content
+        ), "Agent should have code quality checklist"
+
+    def test_has_checkbox_items(self, agent_content: str):
+        """Agent should have checkbox items for verification."""
+        assert "- [ ]" in agent_content, "Agent should have checkbox items"


### PR DESCRIPTION
## Summary
- Add frontend-engineer subagent definition
- Include comprehensive tests for agent functionality

## Test plan
- [x] Agent definition file present
- [x] Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)