### PR TITLE
docs: add test quality standards from PR cleanup learnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,8 @@ jp-spec-kit/
 
 @import memory/code-standards.md
 
+@import memory/test-quality-standards.md
+
 ## Documentation References
 
 | Topic | Location |

--- a/memory/test-quality-standards.md
+++ b/memory/test-quality-standards.md
@@ -1,0 +1,179 @@
+# Test Quality Standards
+
+This document captures defensive coding patterns for test files, learned from fixing fragile tests in task-087, task-191a, task-191b, and task-191c.
+
+## Required Helper Functions
+
+Every test file that reads project files MUST include these helper functions:
+
+### 1. Project Root Detection
+
+```python
+def get_project_root() -> Path:
+    """Get the project root directory reliably.
+
+    Returns:
+        Path to the project root directory.
+    """
+    return Path(__file__).resolve().parent.parent
+```
+
+**Why**: Using relative paths like `Path(".claude/agents/...")` breaks depending on the working directory. Tests run from different directories (IDE, CI, command line) must work consistently.
+
+**Wrong**:
+```python
+AGENT_DIR = ".claude/agents"  # Fragile!
+return Path(AGENT_DIR) / filename
+```
+
+**Correct**:
+```python
+return get_project_root() / ".claude" / "agents" / filename
+```
+
+### 2. Safe File Reading
+
+```python
+def safe_read_file(file_path: Path) -> Optional[str]:
+    """Safely read a file, returning None if it doesn't exist or can't be read.
+
+    Args:
+        file_path: Path to the file to read.
+
+    Returns:
+        File contents as string, or None if the file can't be read.
+    """
+    try:
+        if file_path.exists() and file_path.is_file():
+            return file_path.read_text(encoding="utf-8")
+    except (OSError, IOError, PermissionError):
+        pass
+    return None
+```
+
+**Why**: Functions named "safe" should not raise exceptions. Return `Optional[str]` to allow graceful handling when files don't exist or can't be read.
+
+**Wrong** (misleading name):
+```python
+def _read_file_safely(file_path: Path) -> str:
+    if not file_path.exists():
+        raise FileNotFoundError(...)  # NOT safe!
+```
+
+**Correct**: Return `None` instead of raising, let callers decide how to handle.
+
+## Required Imports
+
+Always import these types:
+
+```python
+from pathlib import Path
+from typing import Dict, Optional
+
+import pytest
+```
+
+## Constants at Module Level
+
+Define expected values as module-level constants:
+
+```python
+# Constants
+AGENT_NAME = "backend-engineer"
+EXPECTED_COLOR = "green"
+EXPECTED_TOOLS = ["Read", "Write", "Edit", "Glob", "Grep", "Bash"]
+REQUIRED_FRONTMATTER_FIELDS = ["name", "description", "tools", "color"]
+REQUIRED_CONTENT_SECTIONS = [
+    "## Core Technologies",
+    "## Implementation Standards",
+]
+```
+
+## Type Hints
+
+All functions and methods must have complete type hints:
+
+```python
+def test_method(self, fixture: Path) -> None:  # -> None required
+    ...
+
+def helper_function(content: str) -> Dict[str, str]:  # Return type required
+    ...
+```
+
+## File Encoding
+
+Always specify encoding when reading files:
+
+```python
+# Correct
+file_path.read_text(encoding="utf-8")
+
+# Wrong (relies on system default)
+file_path.read_text()
+```
+
+## Assertion Messages
+
+Include meaningful assertion messages that help diagnose failures:
+
+```python
+# Good
+assert agent_path.exists(), f"Agent file not found at {agent_path}"
+assert frontmatter.get("name") == AGENT_NAME, (
+    f"Agent name should be '{AGENT_NAME}', got '{frontmatter.get('name')}'"
+)
+
+# Bad (no context on failure)
+assert agent_path.exists()
+assert frontmatter.get("name") == AGENT_NAME
+```
+
+## Fixture Patterns
+
+Use consistent fixture patterns for shared test data:
+
+```python
+@pytest.fixture
+def agent_path(self) -> Path:
+    """Get path to the agent file."""
+    return get_project_root() / ".claude" / "agents" / "agent-name.md"
+
+@pytest.fixture
+def agent_content(self, agent_path: Path) -> str:
+    """Return content of the agent file."""
+    content = safe_read_file(agent_path)
+    if content is None:
+        pytest.skip(f"Agent file not found: {agent_path}")
+    return content
+```
+
+## Test Organization
+
+Group related tests into classes with clear docstrings:
+
+```python
+class TestAgentFile:
+    """Test the agent file exists and is valid."""
+
+class TestFrontmatter:
+    """Test the YAML frontmatter of the agent."""
+
+class TestTools:
+    """Test the tools configuration for the agent."""
+
+class TestContent:
+    """Test the content of the agent."""
+```
+
+## Checklist for New Test Files
+
+- [ ] `get_project_root()` helper function included
+- [ ] `safe_read_file()` returns `Optional[str]`, not raises
+- [ ] `Optional` imported from typing
+- [ ] All paths use project root detection
+- [ ] `encoding="utf-8"` on all file reads
+- [ ] `-> None` on all test methods
+- [ ] Constants defined at module level
+- [ ] Meaningful assertion messages
+- [ ] Test classes with descriptive docstrings


### PR DESCRIPTION
## Summary
Captures defensive coding patterns learned from fixing fragile tests across multiple PRs:
- task-087 (case studies)
- task-191a (frontend engineer)
- task-191b (backend engineer)
- task-191c (QA engineer)

## Changes
- Added `memory/test-quality-standards.md` - Comprehensive guide with code examples
- Added `@import memory/test-quality-standards.md` to CLAUDE.md

## Key Standards Documented

### Required Helper Functions
1. **`get_project_root()`** - Uses `Path(__file__).resolve().parent.parent` for reliable path detection
2. **`safe_read_file()`** - Returns `Optional[str]` instead of raising exceptions

### Patterns to Follow
- Always use `encoding="utf-8"` on file reads
- Define constants at module level
- Add `-> None` return type hints to all test methods
- Include meaningful assertion messages
- Use consistent fixture patterns

### Checklist Included
The document includes a checklist for new test files to verify all standards are met.

## Why This Matters
These standards prevent:
- Tests breaking when run from different directories
- Misleading function names that raise exceptions
- Type hint omissions
- Inconsistent coding patterns

## Test plan
- [x] CLAUDE.md imports the new standards file
- [x] Standards file contains code examples for all patterns
- [x] Checklist covers all identified issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)