### PR TITLE
feat(security): implement AI triage engine with specialized classifiers

### DIFF
--- a/src/specify_cli/security/triage/__init__.py
+++ b/src/specify_cli/security/triage/__init__.py
@@ -1,0 +1,23 @@
+"""AI-powered vulnerability triage engine.
+
+This module provides AI-assisted classification, risk scoring, clustering,
+and explanation generation for security findings.
+
+See ADR-006 for architectural design decisions.
+"""
+
+from specify_cli.security.triage.models import (
+    Classification,
+    TriageResult,
+    ClusterType,
+)
+from specify_cli.security.triage.engine import TriageEngine
+from specify_cli.security.triage.risk_scorer import RiskScorer
+
+__all__ = [
+    "Classification",
+    "TriageResult",
+    "ClusterType",
+    "TriageEngine",
+    "RiskScorer",
+]

--- a/src/specify_cli/security/triage/classifiers/__init__.py
+++ b/src/specify_cli/security/triage/classifiers/__init__.py
@@ -1,0 +1,35 @@
+"""Vulnerability classifiers for AI triage.
+
+This module provides specialized classifiers for common vulnerability types.
+Each classifier uses AI to determine if a finding is TP, FP, or NI.
+
+See ADR-006 for the Strategy Pattern design.
+"""
+
+from specify_cli.security.triage.classifiers.base import (
+    FindingClassifier,
+    ClassificationResult,
+)
+from specify_cli.security.triage.classifiers.default import DefaultClassifier
+from specify_cli.security.triage.classifiers.sql_injection import (
+    SQLInjectionClassifier,
+)
+from specify_cli.security.triage.classifiers.xss import XSSClassifier
+from specify_cli.security.triage.classifiers.path_traversal import (
+    PathTraversalClassifier,
+)
+from specify_cli.security.triage.classifiers.hardcoded_secrets import (
+    HardcodedSecretsClassifier,
+)
+from specify_cli.security.triage.classifiers.weak_crypto import WeakCryptoClassifier
+
+__all__ = [
+    "FindingClassifier",
+    "ClassificationResult",
+    "DefaultClassifier",
+    "SQLInjectionClassifier",
+    "XSSClassifier",
+    "PathTraversalClassifier",
+    "HardcodedSecretsClassifier",
+    "WeakCryptoClassifier",
+]

--- a/src/specify_cli/security/triage/classifiers/base.py
+++ b/src/specify_cli/security/triage/classifiers/base.py
@@ -1,0 +1,141 @@
+"""Base classifier interface for vulnerability classification.
+
+This module defines the abstract FindingClassifier interface that all
+specialized classifiers must implement. Follows the Strategy Pattern.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from specify_cli.security.models import Finding
+from specify_cli.security.triage.models import Classification
+
+
+class LLMClient(Protocol):
+    """Protocol for LLM client implementations."""
+
+    def complete(self, prompt: str) -> str:
+        """Send prompt to LLM and return response."""
+        ...
+
+
+@dataclass
+class ClassificationResult:
+    """Result of AI classification."""
+
+    classification: Classification
+    confidence: float  # 0.0-1.0
+    reasoning: str  # LLM's explanation
+
+
+class FindingClassifier(ABC):
+    """Abstract base class for finding classifiers.
+
+    Each specialized classifier analyzes a specific type of vulnerability
+    (e.g., SQL Injection, XSS) and determines if it's a true positive,
+    false positive, or needs investigation.
+    """
+
+    def __init__(self, llm_client: LLMClient | None = None):
+        """Initialize classifier with optional LLM client.
+
+        Args:
+            llm_client: LLM client for AI-powered classification.
+                       If None, uses heuristic-based classification.
+        """
+        self.llm = llm_client
+
+    @abstractmethod
+    def classify(self, finding: Finding) -> ClassificationResult:
+        """Classify finding as TP/FP/NI with confidence score.
+
+        Args:
+            finding: Security finding to classify.
+
+        Returns:
+            ClassificationResult with classification, confidence, and reasoning.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def supported_cwes(self) -> list[str]:
+        """Return list of CWE IDs this classifier handles."""
+        pass
+
+    def get_code_context(self, finding: Finding, context_lines: int = 5) -> str:
+        """Extract code context around finding.
+
+        Args:
+            finding: Finding to get context for.
+            context_lines: Number of lines before/after to include.
+
+        Returns:
+            Code snippet with surrounding context.
+        """
+        file_path = Path(finding.location.file)
+
+        if not file_path.exists():
+            return finding.location.code_snippet or ""
+
+        try:
+            with open(file_path) as f:
+                lines = f.readlines()
+
+            line_start = max(0, finding.location.line_start - context_lines - 1)
+            line_end = min(len(lines), finding.location.line_end + context_lines)
+
+            context = lines[line_start:line_end]
+            return "".join(context)
+        except OSError:
+            return finding.location.code_snippet or ""
+
+    def _parse_llm_response(self, response: str) -> ClassificationResult:
+        """Parse LLM JSON response into ClassificationResult.
+
+        Expected format:
+        {
+            "classification": "TP" | "FP" | "NI",
+            "confidence": 0.0-1.0,
+            "reasoning": "explanation"
+        }
+        """
+        import json
+
+        try:
+            # Try to extract JSON from response
+            response = response.strip()
+
+            # Handle markdown code blocks
+            if "```json" in response:
+                start = response.find("```json") + 7
+                end = response.find("```", start)
+                response = response[start:end].strip()
+            elif "```" in response:
+                start = response.find("```") + 3
+                end = response.find("```", start)
+                response = response[start:end].strip()
+
+            data = json.loads(response)
+
+            classification = Classification(data.get("classification", "NI"))
+            confidence = float(data.get("confidence", 0.5))
+            reasoning = data.get("reasoning", "No reasoning provided")
+
+            # Clamp confidence to valid range
+            confidence = max(0.0, min(1.0, confidence))
+
+            return ClassificationResult(
+                classification=classification,
+                confidence=confidence,
+                reasoning=reasoning,
+            )
+        except (json.JSONDecodeError, ValueError, KeyError):
+            # Default to needs investigation if parsing fails
+            return ClassificationResult(
+                classification=Classification.NEEDS_INVESTIGATION,
+                confidence=0.3,
+                reasoning=f"Failed to parse LLM response: {response[:200]}",
+            )

--- a/src/specify_cli/security/triage/classifiers/default.py
+++ b/src/specify_cli/security/triage/classifiers/default.py
@@ -1,0 +1,106 @@
+"""Default classifier for generic vulnerability types.
+
+This classifier handles vulnerabilities that don't have a specialized
+classifier. It uses generic prompts to analyze the finding.
+"""
+
+from specify_cli.security.models import Finding
+from specify_cli.security.triage.models import Classification
+from specify_cli.security.triage.classifiers.base import (
+    FindingClassifier,
+    ClassificationResult,
+)
+
+
+class DefaultClassifier(FindingClassifier):
+    """Generic classifier for unspecialized vulnerability types."""
+
+    @property
+    def supported_cwes(self) -> list[str]:
+        """Default classifier handles any CWE."""
+        return ["*"]  # Wildcard - handles any
+
+    def classify(self, finding: Finding) -> ClassificationResult:
+        """Classify finding using generic analysis."""
+        if self.llm is None:
+            return self._heuristic_classify(finding)
+
+        return self._ai_classify(finding)
+
+    def _heuristic_classify(self, finding: Finding) -> ClassificationResult:
+        """Heuristic-based classification when LLM is unavailable.
+
+        Uses severity and common patterns to estimate classification.
+        """
+        severity = finding.severity.value.lower()
+
+        # High/Critical severity are usually real issues
+        if severity in ("critical", "high"):
+            return ClassificationResult(
+                classification=Classification.NEEDS_INVESTIGATION,
+                confidence=0.6,
+                reasoning=(
+                    f"High severity ({severity}) finding requires investigation. "
+                    "No AI analysis available."
+                ),
+            )
+
+        # Low/Info often have high false positive rates
+        if severity in ("low", "info"):
+            return ClassificationResult(
+                classification=Classification.NEEDS_INVESTIGATION,
+                confidence=0.4,
+                reasoning=(
+                    f"Low severity ({severity}) finding. "
+                    "May be false positive but requires verification."
+                ),
+            )
+
+        # Medium severity - uncertain
+        return ClassificationResult(
+            classification=Classification.NEEDS_INVESTIGATION,
+            confidence=0.5,
+            reasoning="Medium severity finding requires human review.",
+        )
+
+    def _ai_classify(self, finding: Finding) -> ClassificationResult:
+        """AI-powered classification using LLM."""
+        context = self.get_code_context(finding)
+
+        prompt = f"""Analyze this security finding and classify it:
+
+**Finding:**
+- Title: {finding.title}
+- Severity: {finding.severity.value}
+- CWE: {finding.cwe_id or "Unknown"}
+- Description: {finding.description}
+
+**Location:**
+- File: {finding.location.file}
+- Line: {finding.location.line_start}
+
+**Code Context:**
+```
+{context}
+```
+
+**Classification Criteria:**
+- TRUE POSITIVE (TP): Real security vulnerability that should be fixed
+- FALSE POSITIVE (FP): Not a real vulnerability (scanner noise, sanitized input, test code)
+- NEEDS INVESTIGATION (NI): Uncertain, requires human review
+
+**Analysis Required:**
+1. Is there actually vulnerable code at this location?
+2. Is user input involved and unsanitized?
+3. Could an attacker exploit this?
+4. Are there mitigating factors (input validation, sandboxing)?
+
+Respond in JSON format:
+{{
+    "classification": "TP" | "FP" | "NI",
+    "confidence": 0.0-1.0,
+    "reasoning": "explanation of your decision"
+}}
+"""
+        response = self.llm.complete(prompt)
+        return self._parse_llm_response(response)

--- a/src/specify_cli/security/triage/classifiers/hardcoded_secrets.py
+++ b/src/specify_cli/security/triage/classifiers/hardcoded_secrets.py
@@ -1,0 +1,185 @@
+"""Hardcoded Secrets classifier (CWE-798).
+
+Specialized classifier for hardcoded credential vulnerabilities.
+Analyzes secret patterns and determines if they're real secrets.
+"""
+
+import re
+
+from specify_cli.security.models import Finding
+from specify_cli.security.triage.models import Classification
+from specify_cli.security.triage.classifiers.base import (
+    FindingClassifier,
+    ClassificationResult,
+)
+
+
+class HardcodedSecretsClassifier(FindingClassifier):
+    """Specialized classifier for hardcoded secret vulnerabilities."""
+
+    # Patterns that indicate dummy/test values
+    DUMMY_PATTERNS = [
+        r"^xxx+$",
+        r"^test",
+        r"^demo",
+        r"^example",
+        r"^placeholder",
+        r"^dummy",
+        r"^fake",
+        r"^changeme",
+        r"^password123?$",
+        r"^admin$",
+        r"^secret$",
+        r"^\*+$",
+        r"^your[-_]",
+        r"^<.*>$",  # Placeholder like <YOUR_API_KEY>
+        r"^\$\{.*\}$",  # Environment variable placeholder
+    ]
+
+    # High-entropy patterns that suggest real secrets
+    ENTROPY_THRESHOLD = 3.5  # Bits per character
+
+    @property
+    def supported_cwes(self) -> list[str]:
+        """CWEs related to hardcoded secrets."""
+        return ["CWE-798", "CWE-259", "CWE-321", "CWE-522"]
+
+    def classify(self, finding: Finding) -> ClassificationResult:
+        """Classify hardcoded secret finding."""
+        if self.llm is None:
+            return self._heuristic_classify(finding)
+
+        return self._ai_classify(finding)
+
+    def _heuristic_classify(self, finding: Finding) -> ClassificationResult:
+        """Heuristic-based secret classification."""
+        code = finding.location.code_snippet or ""
+
+        # Extract potential secret value
+        secret_value = self._extract_secret_value(code)
+
+        if not secret_value:
+            return ClassificationResult(
+                classification=Classification.NEEDS_INVESTIGATION,
+                confidence=0.5,
+                reasoning="Could not extract secret value from code.",
+            )
+
+        # Check for dummy patterns
+        for pattern in self.DUMMY_PATTERNS:
+            if re.match(pattern, secret_value.lower()):
+                return ClassificationResult(
+                    classification=Classification.FALSE_POSITIVE,
+                    confidence=0.85,
+                    reasoning=(
+                        f"Secret matches dummy pattern: {pattern}. "
+                        "This appears to be a placeholder or test value."
+                    ),
+                )
+
+        # Check entropy
+        entropy = self._calculate_entropy(secret_value)
+        if entropy < self.ENTROPY_THRESHOLD:
+            return ClassificationResult(
+                classification=Classification.FALSE_POSITIVE,
+                confidence=0.7,
+                reasoning=(
+                    f"Low entropy ({entropy:.2f} bits/char). Likely not a real secret."
+                ),
+            )
+
+        # Check file context
+        file_path = str(finding.location.file).lower()
+        if any(x in file_path for x in ["test", "mock", "fixture", "example"]):
+            return ClassificationResult(
+                classification=Classification.FALSE_POSITIVE,
+                confidence=0.8,
+                reasoning="Secret found in test/example file. Likely not production.",
+            )
+
+        # High entropy in production code = likely real
+        return ClassificationResult(
+            classification=Classification.TRUE_POSITIVE,
+            confidence=0.8,
+            reasoning=(
+                f"High entropy ({entropy:.2f} bits/char) secret in production code. "
+                "This appears to be a real hardcoded credential."
+            ),
+        )
+
+    def _extract_secret_value(self, code: str) -> str | None:
+        """Extract the secret value from code snippet."""
+        # Common patterns for secret assignment
+        patterns = [
+            r'["\']([^"\']+)["\']',  # Quoted string
+            r"=\s*([^\s;]+)",  # Assignment
+        ]
+
+        for pattern in patterns:
+            match = re.search(pattern, code)
+            if match:
+                return match.group(1)
+
+        return None
+
+    def _calculate_entropy(self, value: str) -> float:
+        """Calculate Shannon entropy of a string (bits per character)."""
+        import math
+        from collections import Counter
+
+        if not value:
+            return 0.0
+
+        counts = Counter(value)
+        length = len(value)
+        entropy = 0.0
+
+        for count in counts.values():
+            probability = count / length
+            entropy -= probability * math.log2(probability)
+
+        return entropy
+
+    def _ai_classify(self, finding: Finding) -> ClassificationResult:
+        """AI-powered secret classification."""
+        context = self.get_code_context(finding, context_lines=5)
+
+        prompt = f"""Analyze this potential hardcoded secret:
+
+**Finding:**
+- Title: {finding.title}
+- CWE: CWE-798 (Hardcoded Credentials)
+- File: {finding.location.file}:{finding.location.line_start}
+
+**Code Context:**
+```
+{context}
+```
+
+**Secret Analysis Checklist:**
+1. Is this a real secret or a placeholder/example?
+2. Is this in test code, fixtures, or documentation?
+3. Does the value have high entropy (looks random)?
+4. Is the secret used in production code paths?
+5. Could this be an environment variable default?
+
+**Common False Positives:**
+- Placeholder values: "your-api-key-here", "<SECRET>"
+- Test fixtures: "test_password", "dummy_token"
+- Documentation examples
+- Default/fallback values that are overridden
+
+**Classification:**
+- TP: Real secret that could be exploited
+- FP: Placeholder, test value, or documentation
+- NI: Cannot determine if real secret
+
+Respond in JSON format:
+{{
+    "classification": "TP" | "FP" | "NI",
+    "confidence": 0.0-1.0,
+    "reasoning": "explanation of why this is or isn't a real secret"
+}}
+"""
+        response = self.llm.complete(prompt)
+        return self._parse_llm_response(response)

--- a/src/specify_cli/security/triage/classifiers/path_traversal.py
+++ b/src/specify_cli/security/triage/classifiers/path_traversal.py
@@ -1,0 +1,136 @@
+"""Path Traversal classifier (CWE-22).
+
+Specialized classifier for path traversal vulnerabilities. Analyzes
+file path construction and validation patterns.
+"""
+
+from specify_cli.security.models import Finding
+from specify_cli.security.triage.models import Classification
+from specify_cli.security.triage.classifiers.base import (
+    FindingClassifier,
+    ClassificationResult,
+)
+
+
+class PathTraversalClassifier(FindingClassifier):
+    """Specialized classifier for path traversal vulnerabilities."""
+
+    @property
+    def supported_cwes(self) -> list[str]:
+        """CWEs related to path traversal."""
+        return ["CWE-22", "CWE-23", "CWE-36", "CWE-73"]
+
+    def classify(self, finding: Finding) -> ClassificationResult:
+        """Classify path traversal finding."""
+        if self.llm is None:
+            return self._heuristic_classify(finding)
+
+        return self._ai_classify(finding)
+
+    def _heuristic_classify(self, finding: Finding) -> ClassificationResult:
+        """Heuristic-based path traversal classification."""
+        code = finding.location.code_snippet or ""
+        code_lower = code.lower()
+
+        # Check for path validation (likely FP)
+        safe_patterns = [
+            "realpath",
+            "abspath",
+            "normpath",
+            "resolve()",
+            ".startswith(",
+            "is_relative_to",
+            "secure_filename",
+            "path.join",  # Often safe when combined with validation
+        ]
+
+        validation_found = False
+        for pattern in safe_patterns:
+            if pattern in code_lower:
+                validation_found = True
+                break
+
+        # Check for dangerous patterns
+        dangerous_patterns = [
+            "open(",
+            "read(",
+            "readfile",
+            "file_get_contents",
+            "include(",
+            "require(",
+            "send_file",
+            "sendfile",
+        ]
+
+        has_file_op = any(p in code_lower for p in dangerous_patterns)
+
+        if validation_found and has_file_op:
+            return ClassificationResult(
+                classification=Classification.NEEDS_INVESTIGATION,
+                confidence=0.6,
+                reasoning=(
+                    "Found file operation with some path validation. "
+                    "Verify validation is applied before file access."
+                ),
+            )
+
+        if validation_found:
+            return ClassificationResult(
+                classification=Classification.FALSE_POSITIVE,
+                confidence=0.7,
+                reasoning="Path validation detected. Likely safe.",
+            )
+
+        if has_file_op:
+            return ClassificationResult(
+                classification=Classification.TRUE_POSITIVE,
+                confidence=0.7,
+                reasoning=(
+                    "File operation without visible path validation. "
+                    "May be vulnerable to path traversal."
+                ),
+            )
+
+        return ClassificationResult(
+            classification=Classification.NEEDS_INVESTIGATION,
+            confidence=0.5,
+            reasoning="Could not determine path validation status.",
+        )
+
+    def _ai_classify(self, finding: Finding) -> ClassificationResult:
+        """AI-powered path traversal classification."""
+        context = self.get_code_context(finding, context_lines=10)
+
+        prompt = f"""Analyze this potential path traversal vulnerability:
+
+**Finding:**
+- Title: {finding.title}
+- CWE: CWE-22 (Path Traversal)
+- File: {finding.location.file}:{finding.location.line_start}
+
+**Code Context:**
+```
+{context}
+```
+
+**Path Traversal Analysis Checklist:**
+1. Is user input used to construct a file path?
+2. Is the path validated against a base directory?
+3. Are "../" sequences filtered or blocked?
+4. Is the path canonicalized (realpath, abspath) before use?
+5. Could an attacker access files outside the intended directory?
+
+**Classification:**
+- TP: User input in file path without proper validation
+- FP: Proper path validation, sandboxed directory, or no user input
+- NI: Cannot determine from context alone
+
+Respond in JSON format:
+{{
+    "classification": "TP" | "FP" | "NI",
+    "confidence": 0.0-1.0,
+    "reasoning": "explanation including what files could be accessed if TP"
+}}
+"""
+        response = self.llm.complete(prompt)
+        return self._parse_llm_response(response)

--- a/src/specify_cli/security/triage/classifiers/sql_injection.py
+++ b/src/specify_cli/security/triage/classifiers/sql_injection.py
@@ -1,0 +1,122 @@
+"""SQL Injection classifier (CWE-89).
+
+Specialized classifier for SQL injection vulnerabilities. Analyzes
+query construction patterns and input sanitization.
+"""
+
+from specify_cli.security.models import Finding
+from specify_cli.security.triage.models import Classification
+from specify_cli.security.triage.classifiers.base import (
+    FindingClassifier,
+    ClassificationResult,
+)
+
+
+class SQLInjectionClassifier(FindingClassifier):
+    """Specialized classifier for SQL injection vulnerabilities."""
+
+    @property
+    def supported_cwes(self) -> list[str]:
+        """CWEs related to SQL injection."""
+        return ["CWE-89", "CWE-564"]
+
+    def classify(self, finding: Finding) -> ClassificationResult:
+        """Classify SQL injection finding."""
+        if self.llm is None:
+            return self._heuristic_classify(finding)
+
+        return self._ai_classify(finding)
+
+    def _heuristic_classify(self, finding: Finding) -> ClassificationResult:
+        """Heuristic-based SQL injection classification."""
+        code = finding.location.code_snippet or ""
+        code_lower = code.lower()
+
+        # Check for parameterized queries (likely FP)
+        parameterized_patterns = [
+            "?",  # Placeholder
+            "$1",
+            "$2",  # PostgreSQL placeholders
+            ":param",  # Named parameters
+            "execute(",  # Usually parameterized
+            "prepared",
+        ]
+
+        for pattern in parameterized_patterns:
+            if pattern in code_lower:
+                return ClassificationResult(
+                    classification=Classification.FALSE_POSITIVE,
+                    confidence=0.7,
+                    reasoning=(
+                        f"Found parameterized query pattern: {pattern}. "
+                        "Likely using safe query construction."
+                    ),
+                )
+
+        # Check for string concatenation (likely TP)
+        concat_patterns = [
+            '+ "',
+            '" +',
+            "' +",
+            "+ '",
+            'f"',  # f-string
+            "f'",
+            ".format(",
+            "% (",  # % formatting
+            "%(",  # % formatting without space
+        ]
+
+        for pattern in concat_patterns:
+            if pattern in code:
+                return ClassificationResult(
+                    classification=Classification.TRUE_POSITIVE,
+                    confidence=0.8,
+                    reasoning=(
+                        f"Found string concatenation pattern: {pattern}. "
+                        "Likely vulnerable to SQL injection."
+                    ),
+                )
+
+        return ClassificationResult(
+            classification=Classification.NEEDS_INVESTIGATION,
+            confidence=0.5,
+            reasoning="Could not determine query construction method.",
+        )
+
+    def _ai_classify(self, finding: Finding) -> ClassificationResult:
+        """AI-powered SQL injection classification."""
+        context = self.get_code_context(finding, context_lines=10)
+
+        prompt = f"""Analyze this potential SQL injection vulnerability:
+
+**Finding:**
+- Title: {finding.title}
+- CWE: CWE-89 (SQL Injection)
+- File: {finding.location.file}:{finding.location.line_start}
+
+**Code Context (10 lines before and after):**
+```
+{context}
+```
+
+**SQL Injection Analysis Checklist:**
+1. Is the SQL query constructed using string concatenation with user input?
+2. Are parameterized queries or prepared statements used?
+3. Is there any input validation or sanitization before the query?
+4. Could an attacker inject SQL syntax (e.g., ' OR 1=1 --)?
+5. Is this ORM code that might auto-parameterize?
+
+**Classification:**
+- TP: String concatenation with user input, no sanitization
+- FP: Parameterized queries, ORM, or properly sanitized input
+- NI: Cannot determine from context alone
+
+Respond in JSON format:
+{{
+    "classification": "TP" | "FP" | "NI",
+    "confidence": 0.0-1.0,
+    "reasoning": "explanation including which checklist items apply"
+}}
+"""
+        response = self.llm.complete(prompt)
+        return self._parse_llm_response(response)

--- a/src/specify_cli/security/triage/classifiers/weak_crypto.py
+++ b/src/specify_cli/security/triage/classifiers/weak_crypto.py
@@ -1,0 +1,148 @@
+"""Weak Cryptography classifier (CWE-327).
+
+Specialized classifier for weak cryptography vulnerabilities.
+Analyzes cryptographic algorithm usage and key management.
+"""
+
+from specify_cli.security.models import Finding
+from specify_cli.security.triage.models import Classification
+from specify_cli.security.triage.classifiers.base import (
+    FindingClassifier,
+    ClassificationResult,
+)
+
+
+class WeakCryptoClassifier(FindingClassifier):
+    """Specialized classifier for weak cryptography vulnerabilities."""
+
+    # Known weak algorithms
+    WEAK_ALGORITHMS = {
+        "md5": "MD5 is cryptographically broken",
+        "sha1": "SHA-1 has known collision attacks",
+        "des": "DES uses insufficient key length (56-bit)",
+        "3des": "Triple DES is deprecated",
+        "rc2": "RC2 is considered weak",
+        "rc4": "RC4 has known biases",
+        "blowfish": "Blowfish has 64-bit block size vulnerability",
+    }
+
+    # Safe algorithms
+    SAFE_ALGORITHMS = {
+        "sha256",
+        "sha384",
+        "sha512",
+        "sha3",
+        "aes",
+        "aes-256",
+        "aes-128",
+        "chacha20",
+        "poly1305",
+        "argon2",
+        "bcrypt",
+        "scrypt",
+        "pbkdf2",
+    }
+
+    @property
+    def supported_cwes(self) -> list[str]:
+        """CWEs related to weak cryptography."""
+        return ["CWE-327", "CWE-328", "CWE-326", "CWE-916"]
+
+    def classify(self, finding: Finding) -> ClassificationResult:
+        """Classify weak crypto finding."""
+        if self.llm is None:
+            return self._heuristic_classify(finding)
+
+        return self._ai_classify(finding)
+
+    def _heuristic_classify(self, finding: Finding) -> ClassificationResult:
+        """Heuristic-based weak crypto classification."""
+        code = finding.location.code_snippet or ""
+        code_lower = code.lower()
+
+        # Check for weak algorithms
+        for algo, reason in self.WEAK_ALGORITHMS.items():
+            if algo in code_lower:
+                # Check context - is it for security or just checksums?
+                checksum_contexts = ["checksum", "hash file", "file hash", "etag"]
+                is_checksum = any(ctx in code_lower for ctx in checksum_contexts)
+
+                if is_checksum and algo in ("md5", "sha1"):
+                    return ClassificationResult(
+                        classification=Classification.FALSE_POSITIVE,
+                        confidence=0.75,
+                        reasoning=(
+                            f"{algo.upper()} used for checksums/integrity, not security. "
+                            "This is an acceptable use case."
+                        ),
+                    )
+
+                return ClassificationResult(
+                    classification=Classification.TRUE_POSITIVE,
+                    confidence=0.85,
+                    reasoning=f"Weak algorithm detected: {algo.upper()}. {reason}.",
+                )
+
+        # Check for safe algorithms (likely FP if present)
+        for algo in self.SAFE_ALGORITHMS:
+            if algo in code_lower:
+                return ClassificationResult(
+                    classification=Classification.FALSE_POSITIVE,
+                    confidence=0.7,
+                    reasoning=f"Safe algorithm detected: {algo}.",
+                )
+
+        return ClassificationResult(
+            classification=Classification.NEEDS_INVESTIGATION,
+            confidence=0.5,
+            reasoning="Could not identify cryptographic algorithm in use.",
+        )
+
+    def _ai_classify(self, finding: Finding) -> ClassificationResult:
+        """AI-powered weak crypto classification."""
+        context = self.get_code_context(finding, context_lines=10)
+
+        prompt = f"""Analyze this potential weak cryptography vulnerability:
+
+**Finding:**
+- Title: {finding.title}
+- CWE: CWE-327 (Weak Cryptography)
+- File: {finding.location.file}:{finding.location.line_start}
+
+**Code Context:**
+```
+{context}
+```
+
+**Cryptography Analysis Checklist:**
+1. What cryptographic algorithm is being used?
+2. Is it being used for security (passwords, encryption) or just checksums/hashing?
+3. Is the key/salt generation secure?
+4. What is the key length?
+
+**Known Weak Algorithms (for security purposes):**
+- MD5: Collision attacks, should not be used for passwords or signatures
+- SHA-1: Collision attacks demonstrated
+- DES: 56-bit key is too short
+- RC4: Known biases
+- ECB mode: Pattern leakage
+
+**Acceptable Uses of Weak Algorithms:**
+- MD5/SHA-1 for file checksums or cache keys (non-security)
+- Legacy system compatibility with migration plan
+- Test/example code
+
+**Classification:**
+- TP: Weak algorithm used for security-critical operation
+- FP: Weak algorithm used for non-security purpose, or strong algorithm
+- NI: Cannot determine usage context
+
+Respond in JSON format:
+{{
+    "classification": "TP" | "FP" | "NI",
+    "confidence": 0.0-1.0,
+    "reasoning": "explanation including what algorithm is used and for what purpose"
+}}
+"""
+        response = self.llm.complete(prompt)
+        return self._parse_llm_response(response)

--- a/src/specify_cli/security/triage/classifiers/xss.py
+++ b/src/specify_cli/security/triage/classifiers/xss.py
@@ -1,0 +1,123 @@
+"""Cross-Site Scripting (XSS) classifier (CWE-79).
+
+Specialized classifier for XSS vulnerabilities. Analyzes output encoding
+and input sanitization patterns.
+"""
+
+from specify_cli.security.models import Finding
+from specify_cli.security.triage.models import Classification
+from specify_cli.security.triage.classifiers.base import (
+    FindingClassifier,
+    ClassificationResult,
+)
+
+
+class XSSClassifier(FindingClassifier):
+    """Specialized classifier for XSS vulnerabilities."""
+
+    @property
+    def supported_cwes(self) -> list[str]:
+        """CWEs related to XSS."""
+        return ["CWE-79", "CWE-80"]
+
+    def classify(self, finding: Finding) -> ClassificationResult:
+        """Classify XSS finding."""
+        if self.llm is None:
+            return self._heuristic_classify(finding)
+
+        return self._ai_classify(finding)
+
+    def _heuristic_classify(self, finding: Finding) -> ClassificationResult:
+        """Heuristic-based XSS classification."""
+        code = finding.location.code_snippet or ""
+        code_lower = code.lower()
+
+        # Check for encoding/escaping (likely FP)
+        safe_patterns = [
+            "escape(",
+            "htmlescape",
+            "html.escape",
+            "sanitize",
+            "encode(",
+            "encodeuri",
+            "textcontent",  # Safe DOM assignment
+            "innertext",
+            "createtextnode",
+        ]
+
+        for pattern in safe_patterns:
+            if pattern in code_lower:
+                return ClassificationResult(
+                    classification=Classification.FALSE_POSITIVE,
+                    confidence=0.75,
+                    reasoning=(
+                        f"Found output encoding pattern: {pattern}. "
+                        "Input appears to be properly escaped."
+                    ),
+                )
+
+        # Check for dangerous sinks (likely TP)
+        dangerous_patterns = [
+            "innerhtml",
+            "outerhtml",
+            "document.write",
+            "eval(",
+            "v-html",  # Vue unescaped
+            "dangerouslysetinnerhtml",  # React
+            "[innerhtml]",  # Angular
+        ]
+
+        for pattern in dangerous_patterns:
+            if pattern in code_lower:
+                return ClassificationResult(
+                    classification=Classification.TRUE_POSITIVE,
+                    confidence=0.8,
+                    reasoning=(
+                        f"Found dangerous sink: {pattern}. "
+                        "This pattern is vulnerable to XSS if input is not sanitized."
+                    ),
+                )
+
+        return ClassificationResult(
+            classification=Classification.NEEDS_INVESTIGATION,
+            confidence=0.5,
+            reasoning="Could not determine if output is properly encoded.",
+        )
+
+    def _ai_classify(self, finding: Finding) -> ClassificationResult:
+        """AI-powered XSS classification."""
+        context = self.get_code_context(finding, context_lines=10)
+
+        prompt = f"""Analyze this potential Cross-Site Scripting (XSS) vulnerability:
+
+**Finding:**
+- Title: {finding.title}
+- CWE: CWE-79 (XSS)
+- File: {finding.location.file}:{finding.location.line_start}
+
+**Code Context:**
+```
+{context}
+```
+
+**XSS Analysis Checklist:**
+1. Is user input being rendered in HTML without encoding?
+2. Are dangerous sinks used (innerHTML, document.write, eval)?
+3. Is framework-provided escaping bypassed (dangerouslySetInnerHTML, v-html)?
+4. Is there input validation or output encoding present?
+5. Is this server-rendered HTML or client-side DOM manipulation?
+
+**Classification:**
+- TP: User input rendered in HTML without proper encoding
+- FP: Proper output encoding, Content Security Policy, or no user input
+- NI: Cannot determine from context alone
+
+Respond in JSON format:
+{{
+    "classification": "TP" | "FP" | "NI",
+    "confidence": 0.0-1.0,
+    "reasoning": "explanation including attack vector if TP"
+}}
+"""
+        response = self.llm.complete(prompt)
+        return self._parse_llm_response(response)

--- a/src/specify_cli/security/triage/engine.py
+++ b/src/specify_cli/security/triage/engine.py
@@ -1,0 +1,382 @@
+"""AI-powered vulnerability triage engine.
+
+This module provides the core TriageEngine that orchestrates:
+1. Classification (TP/FP/NI) using specialized classifiers
+2. Risk scoring using the Raptor formula
+3. Finding clustering by root cause
+4. Plain-English explanation generation
+
+See ADR-006 for architectural design.
+"""
+
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+from specify_cli.security.models import Finding
+from specify_cli.security.triage.models import (
+    Classification,
+    ClusterType,
+    Explanation,
+    TriageResult,
+)
+from specify_cli.security.triage.risk_scorer import RiskScorer
+from specify_cli.security.triage.classifiers.base import (
+    FindingClassifier,
+    ClassificationResult,
+    LLMClient,
+)
+from specify_cli.security.triage.classifiers.default import DefaultClassifier
+from specify_cli.security.triage.classifiers.sql_injection import (
+    SQLInjectionClassifier,
+)
+from specify_cli.security.triage.classifiers.xss import XSSClassifier
+from specify_cli.security.triage.classifiers.path_traversal import (
+    PathTraversalClassifier,
+)
+from specify_cli.security.triage.classifiers.hardcoded_secrets import (
+    HardcodedSecretsClassifier,
+)
+from specify_cli.security.triage.classifiers.weak_crypto import WeakCryptoClassifier
+
+
+@dataclass
+class TriageConfig:
+    """Configuration for the triage engine."""
+
+    min_cluster_size: int = 3  # Minimum findings to form a CWE cluster
+    min_file_cluster_size: int = 2  # Minimum findings to form a file cluster
+    explanation_max_length: int = 500  # Max chars for explanation sections
+
+
+class TriageEngine:
+    """AI-powered vulnerability triage engine.
+
+    Orchestrates classification, risk scoring, clustering, and explanation
+    generation for security findings.
+
+    Example:
+        >>> engine = TriageEngine(llm_client)
+        >>> results = engine.triage(findings)
+        >>> for result in results:
+        ...     print(f"{result.finding_id}: {result.classification.value}")
+    """
+
+    # CWE to classifier mapping
+    CWE_CLASSIFIER_MAP = {
+        "CWE-89": "sql_injection",
+        "CWE-564": "sql_injection",
+        "CWE-79": "xss",
+        "CWE-80": "xss",
+        "CWE-22": "path_traversal",
+        "CWE-23": "path_traversal",
+        "CWE-36": "path_traversal",
+        "CWE-73": "path_traversal",
+        "CWE-798": "hardcoded_secrets",
+        "CWE-259": "hardcoded_secrets",
+        "CWE-321": "hardcoded_secrets",
+        "CWE-522": "hardcoded_secrets",
+        "CWE-327": "weak_crypto",
+        "CWE-328": "weak_crypto",
+        "CWE-326": "weak_crypto",
+        "CWE-916": "weak_crypto",
+    }
+
+    def __init__(
+        self,
+        llm_client: LLMClient | None = None,
+        config: TriageConfig | None = None,
+    ):
+        """Initialize the triage engine.
+
+        Args:
+            llm_client: LLM client for AI-powered analysis. If None,
+                       uses heuristic-based classification.
+            config: Triage configuration options.
+        """
+        self.llm = llm_client
+        self.config = config or TriageConfig()
+        self.risk_scorer = RiskScorer()
+
+        # Initialize classifiers
+        self.classifiers: dict[str, FindingClassifier] = {
+            "sql_injection": SQLInjectionClassifier(llm_client),
+            "xss": XSSClassifier(llm_client),
+            "path_traversal": PathTraversalClassifier(llm_client),
+            "hardcoded_secrets": HardcodedSecretsClassifier(llm_client),
+            "weak_crypto": WeakCryptoClassifier(llm_client),
+            "default": DefaultClassifier(llm_client),
+        }
+
+    def triage(self, findings: list[Finding]) -> list[TriageResult]:
+        """Triage all findings with AI assistance.
+
+        Args:
+            findings: List of findings from scanner orchestrator.
+
+        Returns:
+            List of triage results, sorted by risk score (highest first).
+        """
+        results = []
+
+        for finding in findings:
+            result = self._triage_single(finding)
+            results.append(result)
+
+        # Cluster findings by root cause
+        results = self._cluster(results, findings)
+
+        # Sort by risk score (highest first)
+        results.sort(key=lambda r: r.risk_score, reverse=True)
+
+        return results
+
+    def _triage_single(self, finding: Finding) -> TriageResult:
+        """Triage a single finding.
+
+        Pipeline:
+        1. Classify (TP/FP/NI)
+        2. Score risk (Raptor formula)
+        3. Generate explanation
+
+        Args:
+            finding: Security finding to triage.
+
+        Returns:
+            TriageResult with classification, score, and explanation.
+        """
+        # 1. Classify
+        classification_result = self._classify(finding)
+
+        # 2. Score risk
+        risk_components = self.risk_scorer.score(finding, self.llm)
+
+        # 3. Generate explanation
+        explanation = self._generate_explanation(finding, classification_result)
+
+        return TriageResult(
+            finding_id=finding.id,
+            classification=classification_result.classification,
+            confidence=classification_result.confidence,
+            risk_score=risk_components.risk_score,
+            explanation=explanation,
+            ai_reasoning=classification_result.reasoning,
+            metadata={
+                "impact": risk_components.impact,
+                "exploitability": risk_components.exploitability,
+                "detection_time": risk_components.detection_time,
+            },
+        )
+
+    def _classify(self, finding: Finding) -> ClassificationResult:
+        """Classify finding using appropriate specialized classifier.
+
+        Uses Strategy Pattern: Select classifier based on CWE.
+        """
+        cwe_id = finding.cwe_id
+        classifier_key = self.CWE_CLASSIFIER_MAP.get(cwe_id, "default")
+        classifier = self.classifiers.get(classifier_key, self.classifiers["default"])
+
+        return classifier.classify(finding)
+
+    def _generate_explanation(
+        self,
+        finding: Finding,
+        classification: ClassificationResult,
+    ) -> Explanation:
+        """Generate plain-English explanation for a finding.
+
+        Follows the What/Why/How format:
+        - What: 1-sentence description
+        - Why It Matters: Security impact
+        - How to Exploit: Attack scenario (for TP only)
+        - How to Fix: Remediation approach
+        """
+        if self.llm is None:
+            return self._generate_heuristic_explanation(finding, classification)
+
+        return self._generate_ai_explanation(finding, classification)
+
+    def _generate_heuristic_explanation(
+        self,
+        finding: Finding,
+        classification: ClassificationResult,
+    ) -> Explanation:
+        """Generate explanation without AI."""
+        what = finding.description or finding.title
+
+        # Truncate if needed
+        max_len = self.config.explanation_max_length
+        if len(what) > max_len:
+            what = what[: max_len - 3] + "..."
+
+        why = self._get_cwe_impact(finding.cwe_id)
+        how_to_exploit = None
+
+        if classification.classification == Classification.TRUE_POSITIVE:
+            how_to_exploit = self._get_cwe_exploit_guidance(finding.cwe_id)
+
+        how_to_fix = self._get_cwe_fix_guidance(finding.cwe_id)
+
+        return Explanation(
+            what=what,
+            why_it_matters=why,
+            how_to_exploit=how_to_exploit,
+            how_to_fix=how_to_fix,
+        )
+
+    def _generate_ai_explanation(
+        self,
+        finding: Finding,
+        classification: ClassificationResult,
+    ) -> Explanation:
+        """Generate explanation using AI."""
+        prompt = f"""Generate a plain-English explanation for this security finding:
+
+**Finding:**
+- Title: {finding.title}
+- CWE: {finding.cwe_id or "Unknown"}
+- Classification: {classification.classification.value}
+- Confidence: {classification.confidence:.0%}
+
+**Description:**
+{finding.description}
+
+**Location:**
+{finding.location.file}:{finding.location.line_start}
+
+Generate a developer-friendly explanation in JSON format:
+{{
+    "what": "1-sentence description of the vulnerability",
+    "why_it_matters": "Security impact if exploited",
+    "how_to_exploit": "Attack scenario (only if TRUE_POSITIVE, else null)",
+    "how_to_fix": "Remediation approach"
+}}
+
+Keep each section under 200 characters. Use simple language.
+"""
+        try:
+            import json
+
+            response = self.llm.complete(prompt)
+
+            # Parse JSON response
+            response = response.strip()
+            if "```json" in response:
+                start = response.find("```json") + 7
+                end = response.find("```", start)
+                response = response[start:end].strip()
+            elif "```" in response:
+                start = response.find("```") + 3
+                end = response.find("```", start)
+                response = response[start:end].strip()
+
+            data = json.loads(response)
+
+            return Explanation(
+                what=data.get("what", finding.title),
+                why_it_matters=data.get("why_it_matters", "Security impact unknown"),
+                how_to_exploit=data.get("how_to_exploit"),
+                how_to_fix=data.get("how_to_fix", "Review and fix the vulnerability"),
+            )
+        except Exception:
+            # Fallback to heuristic
+            return self._generate_heuristic_explanation(finding, classification)
+
+    def _get_cwe_impact(self, cwe_id: str | None) -> str:
+        """Get standard impact description for a CWE."""
+        impacts = {
+            "CWE-89": "SQL injection can lead to data theft, modification, or deletion.",
+            "CWE-79": "XSS can steal session cookies or perform actions as the user.",
+            "CWE-22": "Path traversal can expose sensitive files on the server.",
+            "CWE-798": "Hardcoded secrets can be extracted and used by attackers.",
+            "CWE-327": "Weak cryptography can be broken, exposing protected data.",
+        }
+        return impacts.get(
+            cwe_id or "", "This vulnerability could compromise security."
+        )
+
+    def _get_cwe_exploit_guidance(self, cwe_id: str | None) -> str:
+        """Get example exploit scenario for a CWE."""
+        exploits = {
+            "CWE-89": "Attacker injects ' OR 1=1 -- to bypass authentication.",
+            "CWE-79": "Attacker injects <script>...</script> to steal cookies.",
+            "CWE-22": "Attacker uses ../../etc/passwd to read system files.",
+            "CWE-798": "Attacker extracts credentials from source code.",
+            "CWE-327": "Attacker uses rainbow tables to crack hashed passwords.",
+        }
+        return exploits.get(cwe_id or "", "Exploitation method depends on context.")
+
+    def _get_cwe_fix_guidance(self, cwe_id: str | None) -> str:
+        """Get remediation guidance for a CWE."""
+        fixes = {
+            "CWE-89": "Use parameterized queries or prepared statements.",
+            "CWE-79": "Escape output and use Content Security Policy.",
+            "CWE-22": "Validate paths against allowed directories.",
+            "CWE-798": "Use environment variables or secret management.",
+            "CWE-327": "Use modern algorithms (AES-256, bcrypt, Argon2).",
+        }
+        return fixes.get(
+            cwe_id or "", "Review and apply appropriate security controls."
+        )
+
+    def _cluster(
+        self,
+        results: list[TriageResult],
+        findings: list[Finding],
+    ) -> list[TriageResult]:
+        """Cluster findings by root cause for systemic fix recommendations.
+
+        Clustering strategies:
+        1. Same CWE category (e.g., all CWE-89 SQL injections)
+        2. Same file/function (e.g., all issues in auth.py)
+        """
+        # Build finding lookup
+        finding_map = {f.id: f for f in findings}
+
+        # 1. Cluster by CWE
+        by_cwe: dict[str, list[TriageResult]] = defaultdict(list)
+        for result in results:
+            finding = finding_map.get(result.finding_id)
+            if finding:
+                cwe = finding.cwe_id or "unknown"
+                by_cwe[cwe].append(result)
+
+        # Assign CWE cluster IDs
+        for cwe, cluster in by_cwe.items():
+            if len(cluster) >= self.config.min_cluster_size:
+                cluster_id = f"CLUSTER-CWE-{cwe}"
+                for result in cluster:
+                    result.cluster_id = cluster_id
+                    result.cluster_type = ClusterType.CWE
+
+        # 2. Cluster by file (if not already clustered)
+        by_file: dict[str, list[TriageResult]] = defaultdict(list)
+        unclustered = [r for r in results if r.cluster_id is None]
+
+        for result in unclustered:
+            finding = finding_map.get(result.finding_id)
+            if finding:
+                file_path = str(finding.location.file)
+                by_file[file_path].append(result)
+
+        for file_path, cluster in by_file.items():
+            if len(cluster) >= self.config.min_file_cluster_size:
+                cluster_id = f"CLUSTER-FILE-{Path(file_path).stem}"
+                for result in cluster:
+                    result.cluster_id = cluster_id
+                    result.cluster_type = ClusterType.FILE
+
+        return results
+
+    def get_classifier(self, cwe_id: str | None) -> FindingClassifier:
+        """Get the appropriate classifier for a CWE.
+
+        Args:
+            cwe_id: CWE identifier (e.g., "CWE-89").
+
+        Returns:
+            Specialized classifier or default classifier.
+        """
+        classifier_key = self.CWE_CLASSIFIER_MAP.get(cwe_id or "", "default")
+        return self.classifiers.get(classifier_key, self.classifiers["default"])

--- a/src/specify_cli/security/triage/models.py
+++ b/src/specify_cli/security/triage/models.py
@@ -1,0 +1,133 @@
+"""Data models for the AI triage engine.
+
+This module defines the core data structures for vulnerability triage:
+- Classification: TP/FP/NI categorization
+- TriageResult: Complete triage output for a finding
+- ClusterType: Root cause clustering strategies
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class Classification(Enum):
+    """Finding classification result from AI triage.
+
+    TRUE_POSITIVE: Real vulnerability that should be fixed
+    FALSE_POSITIVE: Not a real vulnerability (scanner noise)
+    NEEDS_INVESTIGATION: Uncertain, requires human review
+    """
+
+    TRUE_POSITIVE = "TP"
+    FALSE_POSITIVE = "FP"
+    NEEDS_INVESTIGATION = "NI"
+
+
+class ClusterType(Enum):
+    """Root cause clustering strategy."""
+
+    CWE = "cwe"  # Same CWE category
+    FILE = "file"  # Same file/function
+    PATTERN = "pattern"  # Same architectural pattern
+
+
+@dataclass
+class Explanation:
+    """Plain-English vulnerability explanation.
+
+    Follows the What/Why/How format for developer accessibility.
+    """
+
+    what: str  # 1-sentence description
+    why_it_matters: str  # Security impact
+    how_to_exploit: str | None  # Attack scenario (for TP only)
+    how_to_fix: str  # Remediation approach
+
+
+@dataclass
+class TriageResult:
+    """Result of AI triage for a single finding.
+
+    Contains classification, risk scoring, explanation, and clustering
+    information produced by the triage engine.
+    """
+
+    finding_id: str
+    classification: Classification
+    confidence: float  # 0.0-1.0
+    risk_score: float  # Raptor formula result
+    explanation: Explanation
+    cluster_id: str | None = None  # Root cause cluster
+    cluster_type: ClusterType | None = None
+    ai_reasoning: str = ""  # LLM's reasoning (for debugging)
+    metadata: dict = field(default_factory=dict)
+
+    @property
+    def is_actionable(self) -> bool:
+        """Returns True if finding requires developer action."""
+        return self.classification == Classification.TRUE_POSITIVE
+
+    @property
+    def requires_review(self) -> bool:
+        """Returns True if finding requires human review."""
+        return self.classification == Classification.NEEDS_INVESTIGATION
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for serialization."""
+        return {
+            "finding_id": self.finding_id,
+            "classification": self.classification.value,
+            "confidence": self.confidence,
+            "risk_score": self.risk_score,
+            "explanation": {
+                "what": self.explanation.what,
+                "why_it_matters": self.explanation.why_it_matters,
+                "how_to_exploit": self.explanation.how_to_exploit,
+                "how_to_fix": self.explanation.how_to_fix,
+            },
+            "cluster_id": self.cluster_id,
+            "cluster_type": self.cluster_type.value if self.cluster_type else None,
+            "ai_reasoning": self.ai_reasoning,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "TriageResult":
+        """Create from dictionary."""
+        return cls(
+            finding_id=data["finding_id"],
+            classification=Classification(data["classification"]),
+            confidence=data["confidence"],
+            risk_score=data["risk_score"],
+            explanation=Explanation(
+                what=data["explanation"]["what"],
+                why_it_matters=data["explanation"]["why_it_matters"],
+                how_to_exploit=data["explanation"].get("how_to_exploit"),
+                how_to_fix=data["explanation"]["how_to_fix"],
+            ),
+            cluster_id=data.get("cluster_id"),
+            cluster_type=(
+                ClusterType(data["cluster_type"]) if data.get("cluster_type") else None
+            ),
+            ai_reasoning=data.get("ai_reasoning", ""),
+            metadata=data.get("metadata", {}),
+        )
+
+
+@dataclass
+class RiskComponents:
+    """Components of the Raptor risk scoring formula.
+
+    Formula: risk_score = (impact × exploitability) / detection_time
+    """
+
+    impact: float  # 0-10 scale (CVSS or AI-estimated)
+    exploitability: float  # 0-10 scale (AI-estimated)
+    detection_time: int  # Days since code written (1-365+)
+
+    @property
+    def risk_score(self) -> float:
+        """Calculate risk score using Raptor formula."""
+        return round(
+            (self.impact * self.exploitability) / max(self.detection_time, 1), 2
+        )

--- a/tests/security/__init__.py
+++ b/tests/security/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for security module."""

--- a/tests/security/triage/__init__.py
+++ b/tests/security/triage/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the AI triage engine."""

--- a/tests/security/triage/test_classifiers.py
+++ b/tests/security/triage/test_classifiers.py
@@ -1,0 +1,325 @@
+"""Tests for triage classifiers."""
+
+from pathlib import Path
+from unittest.mock import Mock
+
+
+from specify_cli.security.models import Finding, Location, Severity
+from specify_cli.security.triage.models import Classification
+from specify_cli.security.triage.classifiers.default import DefaultClassifier
+from specify_cli.security.triage.classifiers.sql_injection import (
+    SQLInjectionClassifier,
+)
+from specify_cli.security.triage.classifiers.xss import XSSClassifier
+from specify_cli.security.triage.classifiers.path_traversal import (
+    PathTraversalClassifier,
+)
+from specify_cli.security.triage.classifiers.hardcoded_secrets import (
+    HardcodedSecretsClassifier,
+)
+from specify_cli.security.triage.classifiers.weak_crypto import WeakCryptoClassifier
+
+
+def make_finding(
+    title: str = "Test Finding",
+    severity: Severity = Severity.HIGH,
+    cwe_id: str | None = None,
+    code_snippet: str = "",
+    file_path: str = "test.py",
+) -> Finding:
+    """Create a test finding."""
+    return Finding(
+        id="TEST-001",
+        scanner="test",
+        severity=severity,
+        title=title,
+        description="Test description",
+        location=Location(
+            file=Path(file_path),
+            line_start=10,
+            line_end=12,
+            code_snippet=code_snippet,
+        ),
+        cwe_id=cwe_id,
+    )
+
+
+class TestDefaultClassifier:
+    """Tests for DefaultClassifier."""
+
+    def test_heuristic_high_severity(self):
+        """Test high severity gets needs investigation."""
+        classifier = DefaultClassifier()
+        finding = make_finding(severity=Severity.HIGH)
+
+        result = classifier.classify(finding)
+
+        assert result.classification == Classification.NEEDS_INVESTIGATION
+        assert result.confidence >= 0.5
+
+    def test_heuristic_low_severity(self):
+        """Test low severity gets needs investigation."""
+        classifier = DefaultClassifier()
+        finding = make_finding(severity=Severity.LOW)
+
+        result = classifier.classify(finding)
+
+        assert result.classification == Classification.NEEDS_INVESTIGATION
+
+    def test_with_mocked_llm(self):
+        """Test classification with mocked LLM."""
+        mock_llm = Mock()
+        mock_llm.complete.return_value = """
+        {
+            "classification": "TP",
+            "confidence": 0.9,
+            "reasoning": "Real vulnerability"
+        }
+        """
+        classifier = DefaultClassifier(mock_llm)
+        finding = make_finding()
+
+        result = classifier.classify(finding)
+
+        assert result.classification == Classification.TRUE_POSITIVE
+        assert result.confidence == 0.9
+
+
+class TestSQLInjectionClassifier:
+    """Tests for SQLInjectionClassifier."""
+
+    def test_supported_cwes(self):
+        """Test supported CWE list."""
+        classifier = SQLInjectionClassifier()
+        assert "CWE-89" in classifier.supported_cwes
+
+    def test_heuristic_parameterized_query(self):
+        """Test parameterized query detected as FP."""
+        classifier = SQLInjectionClassifier()
+        finding = make_finding(
+            cwe_id="CWE-89",
+            code_snippet='cursor.execute("SELECT * FROM users WHERE id = ?", (user_id,))',
+        )
+
+        result = classifier.classify(finding)
+
+        assert result.classification == Classification.FALSE_POSITIVE
+        assert result.confidence >= 0.7
+
+    def test_heuristic_string_concatenation(self):
+        """Test string concatenation detected as TP."""
+        classifier = SQLInjectionClassifier()
+        finding = make_finding(
+            cwe_id="CWE-89",
+            code_snippet='query = "SELECT * FROM users WHERE id = " + user_id',
+        )
+
+        result = classifier.classify(finding)
+
+        assert result.classification == Classification.TRUE_POSITIVE
+        assert result.confidence >= 0.7
+
+    def test_heuristic_fstring(self):
+        """Test f-string detected as TP."""
+        classifier = SQLInjectionClassifier()
+        finding = make_finding(
+            cwe_id="CWE-89",
+            code_snippet='query = f"SELECT * FROM users WHERE id = {user_id}"',
+        )
+
+        result = classifier.classify(finding)
+
+        assert result.classification == Classification.TRUE_POSITIVE
+
+
+class TestXSSClassifier:
+    """Tests for XSSClassifier."""
+
+    def test_supported_cwes(self):
+        """Test supported CWE list."""
+        classifier = XSSClassifier()
+        assert "CWE-79" in classifier.supported_cwes
+
+    def test_heuristic_innerhtml(self):
+        """Test innerHTML detected as TP."""
+        classifier = XSSClassifier()
+        finding = make_finding(
+            cwe_id="CWE-79",
+            code_snippet="element.innerHTML = userInput",
+        )
+
+        result = classifier.classify(finding)
+
+        assert result.classification == Classification.TRUE_POSITIVE
+
+    def test_heuristic_textcontent(self):
+        """Test textContent detected as FP."""
+        classifier = XSSClassifier()
+        finding = make_finding(
+            cwe_id="CWE-79",
+            code_snippet="element.textContent = userInput",
+        )
+
+        result = classifier.classify(finding)
+
+        assert result.classification == Classification.FALSE_POSITIVE
+
+    def test_heuristic_dangerouslysetinnerhtml(self):
+        """Test React dangerouslySetInnerHTML detected as TP."""
+        classifier = XSSClassifier()
+        finding = make_finding(
+            cwe_id="CWE-79",
+            code_snippet="<div dangerouslySetInnerHTML={{__html: userInput}} />",
+        )
+
+        result = classifier.classify(finding)
+
+        assert result.classification == Classification.TRUE_POSITIVE
+
+
+class TestPathTraversalClassifier:
+    """Tests for PathTraversalClassifier."""
+
+    def test_supported_cwes(self):
+        """Test supported CWE list."""
+        classifier = PathTraversalClassifier()
+        assert "CWE-22" in classifier.supported_cwes
+
+    def test_heuristic_realpath_validation(self):
+        """Test realpath validation detected as FP."""
+        classifier = PathTraversalClassifier()
+        finding = make_finding(
+            cwe_id="CWE-22",
+            code_snippet="path = os.path.realpath(user_path)\nif path.startswith(base_dir):",
+        )
+
+        result = classifier.classify(finding)
+
+        # Should detect validation
+        assert result.classification in (
+            Classification.FALSE_POSITIVE,
+            Classification.NEEDS_INVESTIGATION,
+        )
+
+    def test_heuristic_open_without_validation(self):
+        """Test open() without validation detected as TP."""
+        classifier = PathTraversalClassifier()
+        finding = make_finding(
+            cwe_id="CWE-22",
+            code_snippet="with open(user_path) as f:\n    data = f.read()",
+        )
+
+        result = classifier.classify(finding)
+
+        assert result.classification == Classification.TRUE_POSITIVE
+
+
+class TestHardcodedSecretsClassifier:
+    """Tests for HardcodedSecretsClassifier."""
+
+    def test_supported_cwes(self):
+        """Test supported CWE list."""
+        classifier = HardcodedSecretsClassifier()
+        assert "CWE-798" in classifier.supported_cwes
+
+    def test_heuristic_dummy_value(self):
+        """Test dummy/placeholder value detected as FP."""
+        classifier = HardcodedSecretsClassifier()
+        finding = make_finding(
+            cwe_id="CWE-798",
+            code_snippet='API_KEY = "your-api-key-here"',
+        )
+
+        result = classifier.classify(finding)
+
+        assert result.classification == Classification.FALSE_POSITIVE
+        assert (
+            "placeholder" in result.reasoning.lower()
+            or "dummy" in result.reasoning.lower()
+        )
+
+    def test_heuristic_test_file(self):
+        """Test secret in test file detected as FP."""
+        classifier = HardcodedSecretsClassifier()
+        finding = make_finding(
+            cwe_id="CWE-798",
+            code_snippet='SECRET_KEY = "a1b2c3d4e5f6g7h8i9j0"',
+            file_path="tests/test_auth.py",
+        )
+
+        result = classifier.classify(finding)
+
+        assert result.classification == Classification.FALSE_POSITIVE
+        assert "test" in result.reasoning.lower()
+
+    def test_heuristic_high_entropy_secret(self):
+        """Test high-entropy secret in prod detected as TP."""
+        classifier = HardcodedSecretsClassifier()
+        # High entropy string
+        finding = make_finding(
+            cwe_id="CWE-798",
+            code_snippet='API_KEY = "sk-aB3cD4eF5gH6iJ7kL8mN9oP0qR1sT2uV3wX4yZ5"',
+            file_path="src/config.py",
+        )
+
+        result = classifier.classify(finding)
+
+        assert result.classification == Classification.TRUE_POSITIVE
+
+
+class TestWeakCryptoClassifier:
+    """Tests for WeakCryptoClassifier."""
+
+    def test_supported_cwes(self):
+        """Test supported CWE list."""
+        classifier = WeakCryptoClassifier()
+        assert "CWE-327" in classifier.supported_cwes
+
+    def test_heuristic_md5_security(self):
+        """Test MD5 for security detected as TP."""
+        classifier = WeakCryptoClassifier()
+        finding = make_finding(
+            cwe_id="CWE-327",
+            code_snippet="password_hash = hashlib.md5(password.encode()).hexdigest()",
+        )
+
+        result = classifier.classify(finding)
+
+        assert result.classification == Classification.TRUE_POSITIVE
+
+    def test_heuristic_md5_checksum(self):
+        """Test MD5 for checksum detected as FP."""
+        classifier = WeakCryptoClassifier()
+        finding = make_finding(
+            cwe_id="CWE-327",
+            code_snippet="file_checksum = hashlib.md5(file_contents).hexdigest()",
+        )
+
+        result = classifier.classify(finding)
+
+        assert result.classification == Classification.FALSE_POSITIVE
+        assert "checksum" in result.reasoning.lower()
+
+    def test_heuristic_aes256(self):
+        """Test AES-256 detected as FP."""
+        classifier = WeakCryptoClassifier()
+        finding = make_finding(
+            cwe_id="CWE-327",
+            code_snippet="cipher = AES.new(key, AES.MODE_GCM)",
+        )
+
+        result = classifier.classify(finding)
+
+        assert result.classification == Classification.FALSE_POSITIVE
+
+    def test_heuristic_bcrypt(self):
+        """Test bcrypt detected as FP."""
+        classifier = WeakCryptoClassifier()
+        finding = make_finding(
+            cwe_id="CWE-327",
+            code_snippet="hashed = bcrypt.hashpw(password, bcrypt.gensalt())",
+        )
+
+        result = classifier.classify(finding)
+
+        assert result.classification == Classification.FALSE_POSITIVE

--- a/tests/security/triage/test_engine.py
+++ b/tests/security/triage/test_engine.py
@@ -1,0 +1,242 @@
+"""Tests for the TriageEngine."""
+
+from pathlib import Path
+from unittest.mock import Mock
+
+
+from specify_cli.security.models import Finding, Location, Severity
+from specify_cli.security.triage.models import Classification, ClusterType
+from specify_cli.security.triage.engine import TriageEngine, TriageConfig
+
+
+def make_finding(
+    id: str = "TEST-001",
+    title: str = "Test Finding",
+    severity: Severity = Severity.HIGH,
+    cwe_id: str | None = None,
+    code_snippet: str = "",
+    file_path: str = "test.py",
+    line_start: int = 10,
+) -> Finding:
+    """Create a test finding."""
+    return Finding(
+        id=id,
+        scanner="test",
+        severity=severity,
+        title=title,
+        description="Test description",
+        location=Location(
+            file=Path(file_path),
+            line_start=line_start,
+            line_end=line_start + 2,
+            code_snippet=code_snippet,
+        ),
+        cwe_id=cwe_id,
+    )
+
+
+class TestTriageEngine:
+    """Tests for TriageEngine."""
+
+    def test_initialization(self):
+        """Test engine initializes with default config."""
+        engine = TriageEngine()
+
+        assert engine.config.min_cluster_size == 3
+        assert "sql_injection" in engine.classifiers
+        assert "default" in engine.classifiers
+
+    def test_initialization_with_config(self):
+        """Test engine with custom config."""
+        config = TriageConfig(min_cluster_size=5)
+        engine = TriageEngine(config=config)
+
+        assert engine.config.min_cluster_size == 5
+
+    def test_get_classifier_sql_injection(self):
+        """Test correct classifier selected for SQL injection."""
+        engine = TriageEngine()
+        classifier = engine.get_classifier("CWE-89")
+
+        assert classifier == engine.classifiers["sql_injection"]
+
+    def test_get_classifier_xss(self):
+        """Test correct classifier selected for XSS."""
+        engine = TriageEngine()
+        classifier = engine.get_classifier("CWE-79")
+
+        assert classifier == engine.classifiers["xss"]
+
+    def test_get_classifier_unknown_cwe(self):
+        """Test default classifier for unknown CWE."""
+        engine = TriageEngine()
+        classifier = engine.get_classifier("CWE-999")
+
+        assert classifier == engine.classifiers["default"]
+
+    def test_triage_single_finding(self):
+        """Test triaging a single finding."""
+        engine = TriageEngine()
+        finding = make_finding(
+            cwe_id="CWE-89",
+            code_snippet='query = "SELECT * FROM users WHERE id = " + user_id',
+        )
+
+        results = engine.triage([finding])
+
+        assert len(results) == 1
+        assert results[0].finding_id == "TEST-001"
+        assert results[0].classification == Classification.TRUE_POSITIVE
+        assert results[0].risk_score > 0
+        assert results[0].explanation is not None
+
+    def test_triage_multiple_findings(self):
+        """Test triaging multiple findings."""
+        engine = TriageEngine()
+        findings = [
+            make_finding(id="F1", cwe_id="CWE-89"),
+            make_finding(id="F2", cwe_id="CWE-79"),
+            make_finding(id="F3", cwe_id="CWE-22"),
+        ]
+
+        results = engine.triage(findings)
+
+        assert len(results) == 3
+        finding_ids = {r.finding_id for r in results}
+        assert finding_ids == {"F1", "F2", "F3"}
+
+    def test_results_sorted_by_risk_score(self):
+        """Test results are sorted by risk score descending."""
+        engine = TriageEngine()
+        findings = [
+            make_finding(id="LOW", severity=Severity.LOW),
+            make_finding(id="HIGH", severity=Severity.HIGH),
+            make_finding(id="CRITICAL", severity=Severity.CRITICAL),
+        ]
+
+        results = engine.triage(findings)
+
+        # Results should be sorted highest risk first
+        assert results[0].finding_id == "CRITICAL"
+        assert results[-1].finding_id == "LOW"
+
+
+class TestClustering:
+    """Tests for finding clustering."""
+
+    def test_cluster_by_cwe(self):
+        """Test findings clustered by CWE."""
+        config = TriageConfig(min_cluster_size=2)  # Lower threshold for test
+        engine = TriageEngine(config=config)
+
+        # 3 SQL injection findings - should cluster
+        findings = [
+            make_finding(id="SQL1", cwe_id="CWE-89", file_path="file1.py"),
+            make_finding(id="SQL2", cwe_id="CWE-89", file_path="file2.py"),
+            make_finding(id="SQL3", cwe_id="CWE-89", file_path="file3.py"),
+        ]
+
+        results = engine.triage(findings)
+
+        # All should be in same cluster
+        cluster_ids = {r.cluster_id for r in results}
+        assert len(cluster_ids) == 1
+        assert "CWE-89" in list(cluster_ids)[0]
+
+        # All should have CWE cluster type
+        for result in results:
+            assert result.cluster_type == ClusterType.CWE
+
+    def test_cluster_by_file(self):
+        """Test findings clustered by file when not in CWE cluster."""
+        config = TriageConfig(min_cluster_size=5, min_file_cluster_size=2)
+        engine = TriageEngine(config=config)
+
+        # 2 findings in same file with different CWEs
+        findings = [
+            make_finding(id="F1", cwe_id="CWE-89", file_path="vulnerable.py"),
+            make_finding(id="F2", cwe_id="CWE-79", file_path="vulnerable.py"),
+        ]
+
+        results = engine.triage(findings)
+
+        # Should be in file cluster (not enough for CWE cluster)
+        cluster_ids = {r.cluster_id for r in results if r.cluster_id}
+        assert len(cluster_ids) == 1
+        assert "FILE" in list(cluster_ids)[0]
+
+    def test_no_cluster_single_finding(self):
+        """Test single finding doesn't form cluster."""
+        engine = TriageEngine()
+        findings = [make_finding(id="LONE", cwe_id="CWE-999")]
+
+        results = engine.triage(findings)
+
+        assert results[0].cluster_id is None
+        assert results[0].cluster_type is None
+
+
+class TestExplanation:
+    """Tests for explanation generation."""
+
+    def test_heuristic_explanation(self):
+        """Test explanation generated without LLM."""
+        engine = TriageEngine()
+        finding = make_finding(cwe_id="CWE-89", title="SQL Injection")
+
+        results = engine.triage([finding])
+        explanation = results[0].explanation
+
+        assert explanation.what is not None
+        assert explanation.why_it_matters is not None
+        assert explanation.how_to_fix is not None
+
+    def test_explanation_with_mocked_llm(self):
+        """Test explanation generation with mocked LLM."""
+        mock_llm = Mock()
+        mock_llm.complete.return_value = """
+        {
+            "what": "AI-generated description",
+            "why_it_matters": "AI-generated impact",
+            "how_to_exploit": "AI attack scenario",
+            "how_to_fix": "AI fix guidance"
+        }
+        """
+        engine = TriageEngine(llm_client=mock_llm)
+        finding = make_finding()
+
+        results = engine.triage([finding])
+
+        # LLM should be called for explanation
+        assert mock_llm.complete.called
+        # Verify explanation was generated
+        assert results[0].explanation is not None
+
+
+class TestRiskScoring:
+    """Tests for risk scoring integration."""
+
+    def test_risk_components_in_metadata(self):
+        """Test risk components stored in metadata."""
+        engine = TriageEngine()
+        finding = make_finding(severity=Severity.HIGH)
+
+        results = engine.triage([finding])
+        metadata = results[0].metadata
+
+        assert "impact" in metadata
+        assert "exploitability" in metadata
+        assert "detection_time" in metadata
+
+    def test_high_severity_high_risk(self):
+        """Test high severity gets high risk score."""
+        engine = TriageEngine()
+        high = make_finding(id="HIGH", severity=Severity.CRITICAL)
+        low = make_finding(id="LOW", severity=Severity.LOW)
+
+        results = engine.triage([high, low])
+
+        high_result = next(r for r in results if r.finding_id == "HIGH")
+        low_result = next(r for r in results if r.finding_id == "LOW")
+
+        assert high_result.risk_score > low_result.risk_score

--- a/tests/security/triage/test_models.py
+++ b/tests/security/triage/test_models.py
@@ -1,0 +1,136 @@
+"""Tests for triage data models."""
+
+import pytest
+
+from specify_cli.security.triage.models import (
+    Classification,
+    ClusterType,
+    Explanation,
+    RiskComponents,
+    TriageResult,
+)
+
+
+class TestClassification:
+    """Tests for Classification enum."""
+
+    def test_values(self):
+        """Test classification values."""
+        assert Classification.TRUE_POSITIVE.value == "TP"
+        assert Classification.FALSE_POSITIVE.value == "FP"
+        assert Classification.NEEDS_INVESTIGATION.value == "NI"
+
+    def test_from_value(self):
+        """Test creating classification from value."""
+        assert Classification("TP") == Classification.TRUE_POSITIVE
+        assert Classification("FP") == Classification.FALSE_POSITIVE
+        assert Classification("NI") == Classification.NEEDS_INVESTIGATION
+
+
+class TestRiskComponents:
+    """Tests for RiskComponents dataclass."""
+
+    def test_risk_score_calculation(self):
+        """Test Raptor formula calculation."""
+        # High impact, high exploitability, short detection time
+        components = RiskComponents(impact=9.0, exploitability=8.0, detection_time=1)
+        assert components.risk_score == 72.0
+
+    def test_risk_score_with_longer_detection(self):
+        """Test risk score decreases with longer detection time."""
+        components = RiskComponents(impact=9.0, exploitability=8.0, detection_time=10)
+        assert components.risk_score == 7.2
+
+    def test_risk_score_minimum_detection_time(self):
+        """Test detection time clamped to at least 1."""
+        components = RiskComponents(impact=9.0, exploitability=8.0, detection_time=0)
+        # Should use max(0, 1) = 1
+        assert components.risk_score == 72.0
+
+
+class TestExplanation:
+    """Tests for Explanation dataclass."""
+
+    def test_creation(self):
+        """Test creating an explanation."""
+        exp = Explanation(
+            what="SQL injection vulnerability",
+            why_it_matters="Data theft possible",
+            how_to_exploit="Use ' OR 1=1 --",
+            how_to_fix="Use parameterized queries",
+        )
+        assert exp.what == "SQL injection vulnerability"
+        assert exp.how_to_exploit == "Use ' OR 1=1 --"
+
+    def test_optional_exploit(self):
+        """Test explanation without exploit info (for FP)."""
+        exp = Explanation(
+            what="False positive",
+            why_it_matters="N/A",
+            how_to_exploit=None,
+            how_to_fix="No fix needed",
+        )
+        assert exp.how_to_exploit is None
+
+
+class TestTriageResult:
+    """Tests for TriageResult dataclass."""
+
+    @pytest.fixture
+    def sample_result(self):
+        """Create a sample triage result."""
+        return TriageResult(
+            finding_id="finding-001",
+            classification=Classification.TRUE_POSITIVE,
+            confidence=0.95,
+            risk_score=45.0,
+            explanation=Explanation(
+                what="SQL injection in login",
+                why_it_matters="Authentication bypass",
+                how_to_exploit="Inject SQL",
+                how_to_fix="Use prepared statements",
+            ),
+            cluster_id="CLUSTER-CWE-89",
+            cluster_type=ClusterType.CWE,
+            ai_reasoning="High confidence SQL injection",
+        )
+
+    def test_is_actionable_tp(self, sample_result):
+        """Test is_actionable for true positive."""
+        assert sample_result.is_actionable is True
+
+    def test_is_actionable_fp(self, sample_result):
+        """Test is_actionable for false positive."""
+        sample_result.classification = Classification.FALSE_POSITIVE
+        assert sample_result.is_actionable is False
+
+    def test_requires_review_ni(self, sample_result):
+        """Test requires_review for needs investigation."""
+        sample_result.classification = Classification.NEEDS_INVESTIGATION
+        assert sample_result.requires_review is True
+
+    def test_requires_review_tp(self, sample_result):
+        """Test requires_review for true positive."""
+        assert sample_result.requires_review is False
+
+    def test_to_dict(self, sample_result):
+        """Test serialization to dict."""
+        data = sample_result.to_dict()
+
+        assert data["finding_id"] == "finding-001"
+        assert data["classification"] == "TP"
+        assert data["confidence"] == 0.95
+        assert data["risk_score"] == 45.0
+        assert data["explanation"]["what"] == "SQL injection in login"
+        assert data["cluster_id"] == "CLUSTER-CWE-89"
+        assert data["cluster_type"] == "cwe"
+
+    def test_from_dict(self, sample_result):
+        """Test deserialization from dict."""
+        data = sample_result.to_dict()
+        restored = TriageResult.from_dict(data)
+
+        assert restored.finding_id == sample_result.finding_id
+        assert restored.classification == sample_result.classification
+        assert restored.confidence == sample_result.confidence
+        assert restored.explanation.what == sample_result.explanation.what


### PR DESCRIPTION
## Summary

Implements task-256: AI-Powered Vulnerability Triage Engine

### Features

- **Classification Pipeline**: TRUE_POSITIVE / FALSE_POSITIVE / NEEDS_INVESTIGATION
- **Specialized Classifiers**: 6 vulnerability-specific classifiers with heuristic + AI modes
- **Raptor Risk Formula**: `risk_score = (impact × exploitability) / detection_time`
- **Root Cause Clustering**: Group findings by CWE category or file location
- **Plain-English Explanations**: What/Why/How format for developers

### Architecture

```
TriageEngine
├── Classifiers (Strategy Pattern)
│   ├── SQLInjectionClassifier     (CWE-89, CWE-564)
│   ├── XSSClassifier              (CWE-79, CWE-80)
│   ├── PathTraversalClassifier    (CWE-22, CWE-23, CWE-36, CWE-73)
│   ├── HardcodedSecretsClassifier (CWE-798, CWE-259, CWE-321, CWE-522)
│   ├── WeakCryptoClassifier       (CWE-327, CWE-328, CWE-326, CWE-916)
│   └── DefaultClassifier          (fallback)
├── RiskScorer (Raptor formula)
└── Clusterer (CWE + file grouping)
```

### Key Components

| Component | Purpose |
|-----------|---------|
| `TriageEngine` | Main orchestrator with classifier dispatch |
| `*Classifier` | 6 specialized classifiers |
| `RiskScorer` | Raptor formula implementation |
| `TriageResult` | Rich result model with explanations |
| `Explanation` | What/Why/How format |

### Classification Results

| Classification | Code | Description |
|----------------|------|-------------|
| TRUE_POSITIVE | TP | Confirmed vulnerability |
| FALSE_POSITIVE | FP | Scanner noise |
| NEEDS_INVESTIGATION | NI | Requires manual review |

### Risk Score Formula

```
risk_score = (impact × exploitability) / detection_time

Where:
- impact: 0-10 (from CVSS or AI estimate)
- exploitability: 0-10 (AI estimated)
- detection_time: days since code written (1-365+)
```

## Test Plan

- [x] All 51 tests pass (`uv run pytest tests/security/triage/ -q`)
- [x] Ruff lint passes (`ruff check`)
- [x] Ruff format passes (`ruff format --check`)
- [x] DCO sign-off present

## Verification

```bash
cd /home/jpoley/ps/jp-spec-kit-galway-task-256
ruff check src/specify_cli/security/triage/ tests/security/triage/
ruff format --check src/specify_cli/security/triage/ tests/security/triage/
uv run pytest tests/security/triage/ -q
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)