### PR TITLE
feat(security): implement security configuration system

### DIFF
--- a/src/specify_cli/security/config/__init__.py
+++ b/src/specify_cli/security/config/__init__.py
@@ -1,0 +1,56 @@
+"""Security configuration module.
+
+This module provides configuration management for security scanning,
+supporting YAML-based configuration files with schema validation.
+
+Example:
+    >>> from specify_cli.security.config import load_config, SecurityConfig
+    >>> config = load_config()  # Loads from default location
+    >>> print(config.fail_on)
+    FailOnSeverity.HIGH
+"""
+
+from specify_cli.security.config.models import (
+    SecurityConfig,
+    ScannerType,
+    FailOnSeverity,
+    ScannerConfig,
+    SemgrepConfig,
+    CodeQLConfig,
+    BanditConfig,
+    TriageConfig,
+    ExclusionConfig,
+    ReportingConfig,
+)
+from specify_cli.security.config.loader import (
+    ConfigLoader,
+    ConfigLoadError,
+    load_config,
+)
+from specify_cli.security.config.schema import (
+    ConfigSchema,
+    SchemaError,
+    SchemaErrorType,
+)
+
+__all__ = [
+    # Models
+    "SecurityConfig",
+    "ScannerType",
+    "FailOnSeverity",
+    "ScannerConfig",
+    "SemgrepConfig",
+    "CodeQLConfig",
+    "BanditConfig",
+    "TriageConfig",
+    "ExclusionConfig",
+    "ReportingConfig",
+    # Loader
+    "ConfigLoader",
+    "ConfigLoadError",
+    "load_config",
+    # Schema
+    "ConfigSchema",
+    "SchemaError",
+    "SchemaErrorType",
+]

--- a/src/specify_cli/security/config/loader.py
+++ b/src/specify_cli/security/config/loader.py
@@ -1,0 +1,324 @@
+"""Security configuration loader.
+
+This module handles loading and parsing security-config.yml files,
+creating SecurityConfig instances from YAML configuration.
+"""
+
+from pathlib import Path
+
+import yaml
+
+from specify_cli.security.config.models import (
+    SecurityConfig,
+    SemgrepConfig,
+    CodeQLConfig,
+    BanditConfig,
+    TriageConfig,
+    ExclusionConfig,
+    ReportingConfig,
+    FailOnSeverity,
+)
+from specify_cli.security.config.schema import ConfigSchema, SchemaError
+
+
+class ConfigLoadError(Exception):
+    """Error loading security configuration."""
+
+    def __init__(self, message: str, errors: list[SchemaError] | None = None):
+        super().__init__(message)
+        self.errors = errors or []
+
+
+class ConfigLoader:
+    """Load security configuration from YAML files.
+
+    Example:
+        >>> loader = ConfigLoader()
+        >>> config = loader.load(Path(".jpspec/security-config.yml"))
+        >>> print(config.fail_on)
+    """
+
+    DEFAULT_CONFIG_PATHS = [
+        ".jpspec/security-config.yml",
+        ".jpspec/security-config.yaml",
+        ".security/config.yml",
+        ".security/config.yaml",
+        "security-config.yml",
+    ]
+
+    def __init__(self, validate: bool = True):
+        """Initialize config loader.
+
+        Args:
+            validate: Whether to validate config against schema.
+        """
+        self.validate = validate
+        self.schema = ConfigSchema()
+
+    def load(self, config_path: Path | None = None) -> SecurityConfig:
+        """Load configuration from file.
+
+        Args:
+            config_path: Path to config file. If None, searches default locations.
+
+        Returns:
+            SecurityConfig instance.
+
+        Raises:
+            ConfigLoadError: If config file not found or invalid.
+        """
+        if config_path is None:
+            config_path = self._find_config_file()
+
+        if config_path is None:
+            # Return default config if no file found
+            return SecurityConfig()
+
+        if not config_path.exists():
+            raise ConfigLoadError(f"Configuration file not found: {config_path}")
+
+        try:
+            with open(config_path) as f:
+                config_data = yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            raise ConfigLoadError(f"Invalid YAML in {config_path}: {e}") from e
+
+        if config_data is None:
+            # Empty file - return defaults
+            return SecurityConfig()
+
+        if self.validate:
+            errors = self.schema.validate(config_data)
+            if errors:
+                error_messages = [f"  - {e.path}: {e.message}" for e in errors]
+                raise ConfigLoadError(
+                    "Configuration validation failed:\n" + "\n".join(error_messages),
+                    errors=errors,
+                )
+
+        return self._parse_config(config_data)
+
+    def load_from_string(self, yaml_content: str) -> SecurityConfig:
+        """Load configuration from YAML string.
+
+        Args:
+            yaml_content: YAML content as string.
+
+        Returns:
+            SecurityConfig instance.
+        """
+        try:
+            config_data = yaml.safe_load(yaml_content)
+        except yaml.YAMLError as e:
+            raise ConfigLoadError(f"Invalid YAML: {e}") from e
+
+        if config_data is None:
+            return SecurityConfig()
+
+        if self.validate:
+            errors = self.schema.validate(config_data)
+            if errors:
+                error_messages = [f"  - {e.path}: {e.message}" for e in errors]
+                raise ConfigLoadError(
+                    "Configuration validation failed:\n" + "\n".join(error_messages),
+                    errors=errors,
+                )
+
+        return self._parse_config(config_data)
+
+    def _find_config_file(self) -> Path | None:
+        """Find configuration file in default locations.
+
+        Returns:
+            Path to config file, or None if not found.
+        """
+        for path_str in self.DEFAULT_CONFIG_PATHS:
+            path = Path(path_str)
+            if path.exists():
+                return path
+        return None
+
+    def _parse_config(self, data: dict) -> SecurityConfig:
+        """Parse configuration dictionary into SecurityConfig.
+
+        Args:
+            data: Parsed YAML data.
+
+        Returns:
+            SecurityConfig instance.
+        """
+        config = SecurityConfig()
+
+        # Parse scanners
+        if "scanners" in data:
+            scanners = data["scanners"]
+
+            if "semgrep" in scanners:
+                config.semgrep = self._parse_semgrep(scanners["semgrep"])
+
+            if "codeql" in scanners:
+                config.codeql = self._parse_codeql(scanners["codeql"])
+
+            if "bandit" in scanners:
+                config.bandit = self._parse_bandit(scanners["bandit"])
+
+        # Parse fail_on
+        if "fail_on" in data:
+            config.fail_on = FailOnSeverity(data["fail_on"].lower())
+
+        # Parse exclusions
+        if "exclusions" in data:
+            config.exclusions = self._parse_exclusions(data["exclusions"])
+
+        # Parse triage
+        if "triage" in data:
+            config.triage = self._parse_triage(data["triage"])
+
+        # Parse reporting
+        if "reporting" in data:
+            config.reporting = self._parse_reporting(data["reporting"])
+
+        # Parse top-level options
+        if "parallel_scans" in data:
+            config.parallel_scans = data["parallel_scans"]
+
+        if "max_findings" in data:
+            config.max_findings = data["max_findings"]
+
+        return config
+
+    def _parse_semgrep(self, data: dict) -> SemgrepConfig:
+        """Parse Semgrep configuration."""
+        config = SemgrepConfig()
+
+        if "enabled" in data:
+            config.enabled = data["enabled"]
+
+        if "rulesets" in data:
+            config.rulesets = data["rulesets"]
+
+        if "extra_args" in data:
+            config.extra_args = data["extra_args"]
+
+        if "custom_rules_dir" in data and data["custom_rules_dir"]:
+            config.custom_rules_dir = Path(data["custom_rules_dir"])
+
+        if "registry_rulesets" in data:
+            config.registry_rulesets = data["registry_rulesets"]
+
+        if "timeout" in data:
+            config.timeout = data["timeout"]
+
+        return config
+
+    def _parse_codeql(self, data: dict) -> CodeQLConfig:
+        """Parse CodeQL configuration."""
+        config = CodeQLConfig()
+
+        if "enabled" in data:
+            config.enabled = data["enabled"]
+
+        if "rulesets" in data:
+            config.rulesets = data["rulesets"]
+
+        if "extra_args" in data:
+            config.extra_args = data["extra_args"]
+
+        if "languages" in data:
+            config.languages = data["languages"]
+
+        if "query_suites" in data:
+            config.query_suites = data["query_suites"]
+
+        if "database_path" in data and data["database_path"]:
+            config.database_path = Path(data["database_path"])
+
+        return config
+
+    def _parse_bandit(self, data: dict) -> BanditConfig:
+        """Parse Bandit configuration."""
+        config = BanditConfig()
+
+        if "enabled" in data:
+            config.enabled = data["enabled"]
+
+        if "rulesets" in data:
+            config.rulesets = data["rulesets"]
+
+        if "extra_args" in data:
+            config.extra_args = data["extra_args"]
+
+        if "skips" in data:
+            config.skips = data["skips"]
+
+        if "confidence_level" in data:
+            config.confidence_level = data["confidence_level"]
+
+        return config
+
+    def _parse_exclusions(self, data: dict) -> ExclusionConfig:
+        """Parse exclusions configuration."""
+        config = ExclusionConfig()
+
+        if "paths" in data:
+            config.paths = data["paths"]
+
+        if "patterns" in data:
+            config.patterns = data["patterns"]
+
+        if "file_extensions" in data:
+            config.file_extensions = data["file_extensions"]
+
+        return config
+
+    def _parse_triage(self, data: dict) -> TriageConfig:
+        """Parse triage configuration."""
+        config = TriageConfig()
+
+        if "enabled" in data:
+            config.enabled = data["enabled"]
+
+        if "confidence_threshold" in data:
+            config.confidence_threshold = float(data["confidence_threshold"])
+
+        if "auto_dismiss_fp" in data:
+            config.auto_dismiss_fp = data["auto_dismiss_fp"]
+
+        if "cluster_similar" in data:
+            config.cluster_similar = data["cluster_similar"]
+
+        return config
+
+    def _parse_reporting(self, data: dict) -> ReportingConfig:
+        """Parse reporting configuration."""
+        config = ReportingConfig()
+
+        if "format" in data:
+            config.format = data["format"]
+
+        if "output_dir" in data and data["output_dir"]:
+            config.output_dir = Path(data["output_dir"])
+
+        if "include_false_positives" in data:
+            config.include_false_positives = data["include_false_positives"]
+
+        if "max_remediations" in data:
+            config.max_remediations = data["max_remediations"]
+
+        return config
+
+
+def load_config(
+    config_path: Path | None = None, validate: bool = True
+) -> SecurityConfig:
+    """Convenience function to load security configuration.
+
+    Args:
+        config_path: Path to config file. If None, searches default locations.
+        validate: Whether to validate config against schema.
+
+    Returns:
+        SecurityConfig instance.
+    """
+    loader = ConfigLoader(validate=validate)
+    return loader.load(config_path)

--- a/src/specify_cli/security/config/models.py
+++ b/src/specify_cli/security/config/models.py
@@ -1,0 +1,275 @@
+"""Security configuration models.
+
+This module defines the data models for security configuration,
+supporting scanner selection, severity thresholds, and AI settings.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+
+class ScannerType(Enum):
+    """Supported security scanners."""
+
+    SEMGREP = "semgrep"
+    CODEQL = "codeql"
+    BANDIT = "bandit"
+
+
+class FailOnSeverity(Enum):
+    """Severity threshold for failing scans."""
+
+    CRITICAL = "critical"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+    NONE = "none"  # Never fail
+
+
+@dataclass
+class ScannerConfig:
+    """Configuration for a specific scanner."""
+
+    enabled: bool = True
+    rulesets: list[str] = field(default_factory=list)
+    extra_args: list[str] = field(default_factory=list)
+
+
+@dataclass
+class SemgrepConfig(ScannerConfig):
+    """Semgrep-specific configuration."""
+
+    custom_rules_dir: Path | None = None
+    registry_rulesets: list[str] = field(default_factory=lambda: ["p/default"])
+    timeout: int = 300  # seconds
+
+
+@dataclass
+class CodeQLConfig(ScannerConfig):
+    """CodeQL-specific configuration."""
+
+    languages: list[str] = field(default_factory=list)
+    query_suites: list[str] = field(default_factory=lambda: ["security-extended"])
+    database_path: Path | None = None
+
+
+@dataclass
+class BanditConfig(ScannerConfig):
+    """Bandit-specific configuration."""
+
+    skips: list[str] = field(default_factory=list)  # e.g., ["B101", "B102"]
+    confidence_level: str = "medium"  # low, medium, high
+
+
+@dataclass
+class TriageConfig:
+    """AI triage configuration."""
+
+    enabled: bool = True
+    confidence_threshold: float = 0.7  # 0.0-1.0
+    auto_dismiss_fp: bool = False  # Auto-dismiss findings below threshold
+    cluster_similar: bool = True  # Group similar findings
+
+
+@dataclass
+class ExclusionConfig:
+    """Path and pattern exclusion configuration."""
+
+    paths: list[str] = field(default_factory=list)
+    patterns: list[str] = field(default_factory=list)
+    file_extensions: list[str] = field(default_factory=list)
+
+    def matches_path(self, path: Path | str) -> bool:
+        """Check if path should be excluded.
+
+        Args:
+            path: Path to check.
+
+        Returns:
+            True if path matches any exclusion.
+        """
+        import fnmatch
+
+        path_str = str(path)
+
+        # Check exact paths
+        for excl_path in self.paths:
+            if path_str.startswith(excl_path) or excl_path in path_str:
+                return True
+
+        # Check patterns
+        for pattern in self.patterns:
+            if fnmatch.fnmatch(path_str, pattern):
+                return True
+
+        # Check file extensions
+        if isinstance(path, str):
+            path = Path(path)
+        if path.suffix in self.file_extensions:
+            return True
+
+        return False
+
+
+@dataclass
+class ReportingConfig:
+    """Report generation configuration."""
+
+    format: str = "markdown"  # markdown, html, json, sarif
+    output_dir: Path | None = None
+    include_false_positives: bool = False
+    max_remediations: int = 10
+
+
+@dataclass
+class SecurityConfig:
+    """Complete security configuration.
+
+    This is the top-level configuration object that contains
+    all security scanning settings.
+
+    Example config file (.jpspec/security-config.yml):
+        scanners:
+          semgrep:
+            enabled: true
+            custom_rules_dir: .security/rules
+          codeql:
+            enabled: false
+
+        fail_on: high
+
+        exclusions:
+          paths:
+            - node_modules/
+            - .venv/
+          patterns:
+            - "*_test.py"
+
+        triage:
+          confidence_threshold: 0.8
+          auto_dismiss_fp: true
+
+        reporting:
+          format: markdown
+    """
+
+    # Scanners
+    semgrep: SemgrepConfig = field(default_factory=SemgrepConfig)
+    codeql: CodeQLConfig = field(default_factory=CodeQLConfig)
+    bandit: BanditConfig = field(default_factory=BanditConfig)
+
+    # Thresholds
+    fail_on: FailOnSeverity = FailOnSeverity.HIGH
+
+    # Exclusions
+    exclusions: ExclusionConfig = field(default_factory=ExclusionConfig)
+
+    # AI Triage
+    triage: TriageConfig = field(default_factory=TriageConfig)
+
+    # Reporting
+    reporting: ReportingConfig = field(default_factory=ReportingConfig)
+
+    # General
+    parallel_scans: bool = True
+    max_findings: int = 1000  # Limit findings to prevent overwhelming output
+
+    def get_enabled_scanners(self) -> list[ScannerType]:
+        """Get list of enabled scanners.
+
+        Returns:
+            List of enabled ScannerType values.
+        """
+        enabled = []
+        if self.semgrep.enabled:
+            enabled.append(ScannerType.SEMGREP)
+        if self.codeql.enabled:
+            enabled.append(ScannerType.CODEQL)
+        if self.bandit.enabled:
+            enabled.append(ScannerType.BANDIT)
+        return enabled
+
+    def should_fail(self, severity: str) -> bool:
+        """Check if scan should fail based on severity.
+
+        Args:
+            severity: Severity level to check.
+
+        Returns:
+            True if scan should fail for this severity.
+        """
+        if self.fail_on == FailOnSeverity.NONE:
+            return False
+
+        severity_order = {
+            "critical": 0,
+            "high": 1,
+            "medium": 2,
+            "low": 3,
+            "info": 4,
+        }
+
+        threshold_order = {
+            FailOnSeverity.CRITICAL: 0,
+            FailOnSeverity.HIGH: 1,
+            FailOnSeverity.MEDIUM: 2,
+            FailOnSeverity.LOW: 3,
+        }
+
+        finding_level = severity_order.get(severity.lower(), 4)
+        threshold_level = threshold_order.get(self.fail_on, 1)
+
+        return finding_level <= threshold_level
+
+    def to_dict(self) -> dict:
+        """Serialize configuration to dictionary.
+
+        Returns:
+            Dictionary representation of config.
+        """
+        return {
+            "scanners": {
+                "semgrep": {
+                    "enabled": self.semgrep.enabled,
+                    "rulesets": self.semgrep.rulesets,
+                    "custom_rules_dir": str(self.semgrep.custom_rules_dir)
+                    if self.semgrep.custom_rules_dir
+                    else None,
+                    "registry_rulesets": self.semgrep.registry_rulesets,
+                    "timeout": self.semgrep.timeout,
+                },
+                "codeql": {
+                    "enabled": self.codeql.enabled,
+                    "languages": self.codeql.languages,
+                    "query_suites": self.codeql.query_suites,
+                },
+                "bandit": {
+                    "enabled": self.bandit.enabled,
+                    "skips": self.bandit.skips,
+                    "confidence_level": self.bandit.confidence_level,
+                },
+            },
+            "fail_on": self.fail_on.value,
+            "exclusions": {
+                "paths": self.exclusions.paths,
+                "patterns": self.exclusions.patterns,
+                "file_extensions": self.exclusions.file_extensions,
+            },
+            "triage": {
+                "enabled": self.triage.enabled,
+                "confidence_threshold": self.triage.confidence_threshold,
+                "auto_dismiss_fp": self.triage.auto_dismiss_fp,
+                "cluster_similar": self.triage.cluster_similar,
+            },
+            "reporting": {
+                "format": self.reporting.format,
+                "output_dir": str(self.reporting.output_dir)
+                if self.reporting.output_dir
+                else None,
+                "include_false_positives": self.reporting.include_false_positives,
+                "max_remediations": self.reporting.max_remediations,
+            },
+            "parallel_scans": self.parallel_scans,
+            "max_findings": self.max_findings,
+        }

--- a/src/specify_cli/security/config/schema.py
+++ b/src/specify_cli/security/config/schema.py
@@ -1,0 +1,439 @@
+"""YAML schema validation for security configuration.
+
+This module provides schema validation for security-config.yml files,
+ensuring configuration files are well-formed and valid.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class SchemaErrorType(Enum):
+    """Types of schema validation errors."""
+
+    INVALID_TYPE = "invalid_type"
+    MISSING_FIELD = "missing_field"
+    UNKNOWN_FIELD = "unknown_field"
+    INVALID_VALUE = "invalid_value"
+    INVALID_RANGE = "invalid_range"
+
+
+@dataclass
+class SchemaError:
+    """Schema validation error."""
+
+    path: str  # e.g., "scanners.semgrep.enabled"
+    error_type: SchemaErrorType
+    message: str
+    expected: str | None = None
+    actual: str | None = None
+
+
+class ConfigSchema:
+    """Schema definition for security configuration.
+
+    Validates YAML configuration against expected structure.
+    """
+
+    VALID_SCANNERS = {"semgrep", "codeql", "bandit"}
+    VALID_FAIL_ON = {"critical", "high", "medium", "low", "none"}
+    VALID_FORMATS = {"markdown", "html", "json", "sarif"}
+    VALID_CONFIDENCE_LEVELS = {"low", "medium", "high"}
+
+    def validate(self, config_data: dict) -> list[SchemaError]:
+        """Validate configuration data against schema.
+
+        Args:
+            config_data: Parsed YAML configuration.
+
+        Returns:
+            List of validation errors (empty if valid).
+        """
+        errors: list[SchemaError] = []
+
+        if not isinstance(config_data, dict):
+            errors.append(
+                SchemaError(
+                    path="",
+                    error_type=SchemaErrorType.INVALID_TYPE,
+                    message="Configuration must be a dictionary",
+                    expected="dict",
+                    actual=type(config_data).__name__,
+                )
+            )
+            return errors
+
+        # Validate scanners section
+        if "scanners" in config_data:
+            errors.extend(self._validate_scanners(config_data["scanners"]))
+
+        # Validate fail_on
+        if "fail_on" in config_data:
+            errors.extend(self._validate_fail_on(config_data["fail_on"]))
+
+        # Validate exclusions
+        if "exclusions" in config_data:
+            errors.extend(self._validate_exclusions(config_data["exclusions"]))
+
+        # Validate triage
+        if "triage" in config_data:
+            errors.extend(self._validate_triage(config_data["triage"]))
+
+        # Validate reporting
+        if "reporting" in config_data:
+            errors.extend(self._validate_reporting(config_data["reporting"]))
+
+        # Validate top-level fields
+        errors.extend(self._validate_top_level(config_data))
+
+        return errors
+
+    def _validate_scanners(self, scanners: dict) -> list[SchemaError]:
+        """Validate scanners section."""
+        errors: list[SchemaError] = []
+
+        if not isinstance(scanners, dict):
+            errors.append(
+                SchemaError(
+                    path="scanners",
+                    error_type=SchemaErrorType.INVALID_TYPE,
+                    message="Scanners must be a dictionary",
+                    expected="dict",
+                    actual=type(scanners).__name__,
+                )
+            )
+            return errors
+
+        for scanner_name, scanner_config in scanners.items():
+            if scanner_name not in self.VALID_SCANNERS:
+                errors.append(
+                    SchemaError(
+                        path=f"scanners.{scanner_name}",
+                        error_type=SchemaErrorType.UNKNOWN_FIELD,
+                        message=f"Unknown scanner: {scanner_name}",
+                        expected=f"one of {self.VALID_SCANNERS}",
+                        actual=scanner_name,
+                    )
+                )
+                continue
+
+            if not isinstance(scanner_config, dict):
+                errors.append(
+                    SchemaError(
+                        path=f"scanners.{scanner_name}",
+                        error_type=SchemaErrorType.INVALID_TYPE,
+                        message="Scanner config must be a dictionary",
+                        expected="dict",
+                        actual=type(scanner_config).__name__,
+                    )
+                )
+                continue
+
+            # Validate enabled field
+            if "enabled" in scanner_config:
+                if not isinstance(scanner_config["enabled"], bool):
+                    errors.append(
+                        SchemaError(
+                            path=f"scanners.{scanner_name}.enabled",
+                            error_type=SchemaErrorType.INVALID_TYPE,
+                            message="enabled must be a boolean",
+                            expected="bool",
+                            actual=type(scanner_config["enabled"]).__name__,
+                        )
+                    )
+
+            # Validate scanner-specific fields
+            if scanner_name == "semgrep":
+                errors.extend(
+                    self._validate_semgrep(scanner_config, f"scanners.{scanner_name}")
+                )
+            elif scanner_name == "codeql":
+                errors.extend(
+                    self._validate_codeql(scanner_config, f"scanners.{scanner_name}")
+                )
+            elif scanner_name == "bandit":
+                errors.extend(
+                    self._validate_bandit(scanner_config, f"scanners.{scanner_name}")
+                )
+
+        return errors
+
+    def _validate_semgrep(self, config: dict, path: str) -> list[SchemaError]:
+        """Validate Semgrep-specific configuration."""
+        errors: list[SchemaError] = []
+
+        if "timeout" in config:
+            if not isinstance(config["timeout"], int) or config["timeout"] < 0:
+                errors.append(
+                    SchemaError(
+                        path=f"{path}.timeout",
+                        error_type=SchemaErrorType.INVALID_VALUE,
+                        message="timeout must be a positive integer",
+                    )
+                )
+
+        if "registry_rulesets" in config:
+            if not isinstance(config["registry_rulesets"], list):
+                errors.append(
+                    SchemaError(
+                        path=f"{path}.registry_rulesets",
+                        error_type=SchemaErrorType.INVALID_TYPE,
+                        message="registry_rulesets must be a list",
+                        expected="list",
+                        actual=type(config["registry_rulesets"]).__name__,
+                    )
+                )
+
+        return errors
+
+    def _validate_codeql(self, config: dict, path: str) -> list[SchemaError]:
+        """Validate CodeQL-specific configuration."""
+        errors: list[SchemaError] = []
+
+        if "languages" in config:
+            if not isinstance(config["languages"], list):
+                errors.append(
+                    SchemaError(
+                        path=f"{path}.languages",
+                        error_type=SchemaErrorType.INVALID_TYPE,
+                        message="languages must be a list",
+                        expected="list",
+                        actual=type(config["languages"]).__name__,
+                    )
+                )
+
+        if "query_suites" in config:
+            if not isinstance(config["query_suites"], list):
+                errors.append(
+                    SchemaError(
+                        path=f"{path}.query_suites",
+                        error_type=SchemaErrorType.INVALID_TYPE,
+                        message="query_suites must be a list",
+                        expected="list",
+                        actual=type(config["query_suites"]).__name__,
+                    )
+                )
+
+        return errors
+
+    def _validate_bandit(self, config: dict, path: str) -> list[SchemaError]:
+        """Validate Bandit-specific configuration."""
+        errors: list[SchemaError] = []
+
+        if "confidence_level" in config:
+            if config["confidence_level"] not in self.VALID_CONFIDENCE_LEVELS:
+                errors.append(
+                    SchemaError(
+                        path=f"{path}.confidence_level",
+                        error_type=SchemaErrorType.INVALID_VALUE,
+                        message=f"Invalid confidence level: {config['confidence_level']}",
+                        expected=f"one of {self.VALID_CONFIDENCE_LEVELS}",
+                        actual=config["confidence_level"],
+                    )
+                )
+
+        if "skips" in config:
+            if not isinstance(config["skips"], list):
+                errors.append(
+                    SchemaError(
+                        path=f"{path}.skips",
+                        error_type=SchemaErrorType.INVALID_TYPE,
+                        message="skips must be a list",
+                        expected="list",
+                        actual=type(config["skips"]).__name__,
+                    )
+                )
+
+        return errors
+
+    def _validate_fail_on(self, fail_on: str) -> list[SchemaError]:
+        """Validate fail_on field."""
+        errors: list[SchemaError] = []
+
+        if not isinstance(fail_on, str):
+            errors.append(
+                SchemaError(
+                    path="fail_on",
+                    error_type=SchemaErrorType.INVALID_TYPE,
+                    message="fail_on must be a string",
+                    expected="str",
+                    actual=type(fail_on).__name__,
+                )
+            )
+        elif fail_on.lower() not in self.VALID_FAIL_ON:
+            errors.append(
+                SchemaError(
+                    path="fail_on",
+                    error_type=SchemaErrorType.INVALID_VALUE,
+                    message=f"Invalid fail_on value: {fail_on}",
+                    expected=f"one of {self.VALID_FAIL_ON}",
+                    actual=fail_on,
+                )
+            )
+
+        return errors
+
+    def _validate_exclusions(self, exclusions: dict) -> list[SchemaError]:
+        """Validate exclusions section."""
+        errors: list[SchemaError] = []
+
+        if not isinstance(exclusions, dict):
+            errors.append(
+                SchemaError(
+                    path="exclusions",
+                    error_type=SchemaErrorType.INVALID_TYPE,
+                    message="exclusions must be a dictionary",
+                    expected="dict",
+                    actual=type(exclusions).__name__,
+                )
+            )
+            return errors
+
+        for field in ["paths", "patterns", "file_extensions"]:
+            if field in exclusions:
+                if not isinstance(exclusions[field], list):
+                    errors.append(
+                        SchemaError(
+                            path=f"exclusions.{field}",
+                            error_type=SchemaErrorType.INVALID_TYPE,
+                            message=f"{field} must be a list",
+                            expected="list",
+                            actual=type(exclusions[field]).__name__,
+                        )
+                    )
+
+        return errors
+
+    def _validate_triage(self, triage: dict) -> list[SchemaError]:
+        """Validate triage section."""
+        errors: list[SchemaError] = []
+
+        if not isinstance(triage, dict):
+            errors.append(
+                SchemaError(
+                    path="triage",
+                    error_type=SchemaErrorType.INVALID_TYPE,
+                    message="triage must be a dictionary",
+                    expected="dict",
+                    actual=type(triage).__name__,
+                )
+            )
+            return errors
+
+        if "enabled" in triage and not isinstance(triage["enabled"], bool):
+            errors.append(
+                SchemaError(
+                    path="triage.enabled",
+                    error_type=SchemaErrorType.INVALID_TYPE,
+                    message="enabled must be a boolean",
+                    expected="bool",
+                    actual=type(triage["enabled"]).__name__,
+                )
+            )
+
+        if "confidence_threshold" in triage:
+            threshold = triage["confidence_threshold"]
+            if not isinstance(threshold, (int, float)):
+                errors.append(
+                    SchemaError(
+                        path="triage.confidence_threshold",
+                        error_type=SchemaErrorType.INVALID_TYPE,
+                        message="confidence_threshold must be a number",
+                        expected="float",
+                        actual=type(threshold).__name__,
+                    )
+                )
+            elif not 0.0 <= threshold <= 1.0:
+                errors.append(
+                    SchemaError(
+                        path="triage.confidence_threshold",
+                        error_type=SchemaErrorType.INVALID_RANGE,
+                        message="confidence_threshold must be between 0.0 and 1.0",
+                        expected="0.0-1.0",
+                        actual=str(threshold),
+                    )
+                )
+
+        for bool_field in ["auto_dismiss_fp", "cluster_similar"]:
+            if bool_field in triage and not isinstance(triage[bool_field], bool):
+                errors.append(
+                    SchemaError(
+                        path=f"triage.{bool_field}",
+                        error_type=SchemaErrorType.INVALID_TYPE,
+                        message=f"{bool_field} must be a boolean",
+                        expected="bool",
+                        actual=type(triage[bool_field]).__name__,
+                    )
+                )
+
+        return errors
+
+    def _validate_reporting(self, reporting: dict) -> list[SchemaError]:
+        """Validate reporting section."""
+        errors: list[SchemaError] = []
+
+        if not isinstance(reporting, dict):
+            errors.append(
+                SchemaError(
+                    path="reporting",
+                    error_type=SchemaErrorType.INVALID_TYPE,
+                    message="reporting must be a dictionary",
+                    expected="dict",
+                    actual=type(reporting).__name__,
+                )
+            )
+            return errors
+
+        if "format" in reporting:
+            if reporting["format"] not in self.VALID_FORMATS:
+                errors.append(
+                    SchemaError(
+                        path="reporting.format",
+                        error_type=SchemaErrorType.INVALID_VALUE,
+                        message=f"Invalid format: {reporting['format']}",
+                        expected=f"one of {self.VALID_FORMATS}",
+                        actual=reporting["format"],
+                    )
+                )
+
+        if "max_remediations" in reporting:
+            max_rem = reporting["max_remediations"]
+            if not isinstance(max_rem, int) or max_rem < 0:
+                errors.append(
+                    SchemaError(
+                        path="reporting.max_remediations",
+                        error_type=SchemaErrorType.INVALID_VALUE,
+                        message="max_remediations must be a positive integer",
+                    )
+                )
+
+        return errors
+
+    def _validate_top_level(self, config: dict) -> list[SchemaError]:
+        """Validate top-level fields."""
+        errors: list[SchemaError] = []
+
+        if "parallel_scans" in config:
+            if not isinstance(config["parallel_scans"], bool):
+                errors.append(
+                    SchemaError(
+                        path="parallel_scans",
+                        error_type=SchemaErrorType.INVALID_TYPE,
+                        message="parallel_scans must be a boolean",
+                        expected="bool",
+                        actual=type(config["parallel_scans"]).__name__,
+                    )
+                )
+
+        if "max_findings" in config:
+            max_findings = config["max_findings"]
+            if not isinstance(max_findings, int) or max_findings < 0:
+                errors.append(
+                    SchemaError(
+                        path="max_findings",
+                        error_type=SchemaErrorType.INVALID_VALUE,
+                        message="max_findings must be a positive integer",
+                    )
+                )
+
+        return errors

--- a/tests/security/config/__init__.py
+++ b/tests/security/config/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for security configuration module."""

--- a/tests/security/config/test_loader.py
+++ b/tests/security/config/test_loader.py
@@ -1,0 +1,421 @@
+"""Tests for security configuration loader."""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from specify_cli.security.config.loader import (
+    ConfigLoader,
+    ConfigLoadError,
+    load_config,
+)
+from specify_cli.security.config.models import (
+    SecurityConfig,
+    FailOnSeverity,
+    ScannerType,
+)
+
+
+class TestConfigLoader:
+    """Tests for ConfigLoader."""
+
+    @pytest.fixture
+    def loader(self):
+        """Create a config loader."""
+        return ConfigLoader()
+
+    def test_load_default_when_no_file(self, loader):
+        """Test loading returns default config when no file found."""
+        with TemporaryDirectory() as tmpdir:
+            import os
+
+            old_cwd = os.getcwd()
+            os.chdir(tmpdir)
+            try:
+                config = loader.load()
+                assert isinstance(config, SecurityConfig)
+                assert config.fail_on == FailOnSeverity.HIGH
+            finally:
+                os.chdir(old_cwd)
+
+    def test_load_from_file(self, loader):
+        """Test loading configuration from file."""
+        with TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "security-config.yml"
+            config_path.write_text("""
+scanners:
+  semgrep:
+    enabled: true
+    timeout: 600
+  codeql:
+    enabled: false
+
+fail_on: medium
+
+exclusions:
+  paths:
+    - node_modules/
+    - .venv/
+
+triage:
+  confidence_threshold: 0.9
+""")
+
+            config = loader.load(config_path)
+
+            assert config.semgrep.enabled is True
+            assert config.semgrep.timeout == 600
+            assert config.codeql.enabled is False
+            assert config.fail_on == FailOnSeverity.MEDIUM
+            assert "node_modules/" in config.exclusions.paths
+            assert config.triage.confidence_threshold == 0.9
+
+    def test_load_nonexistent_file(self, loader):
+        """Test loading non-existent file raises error."""
+        with pytest.raises(ConfigLoadError, match="not found"):
+            loader.load(Path("/nonexistent/path/config.yml"))
+
+    def test_load_invalid_yaml(self, loader):
+        """Test loading invalid YAML raises error."""
+        with TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "security-config.yml"
+            config_path.write_text("invalid: yaml: content: [")
+
+            with pytest.raises(ConfigLoadError, match="Invalid YAML"):
+                loader.load(config_path)
+
+    def test_load_empty_file(self, loader):
+        """Test loading empty file returns defaults."""
+        with TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "security-config.yml"
+            config_path.write_text("")
+
+            config = loader.load(config_path)
+
+            assert isinstance(config, SecurityConfig)
+            assert config.fail_on == FailOnSeverity.HIGH
+
+    def test_load_with_validation_error(self, loader):
+        """Test loading with validation errors."""
+        with TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "security-config.yml"
+            config_path.write_text("""
+fail_on: invalid_severity
+""")
+
+            with pytest.raises(ConfigLoadError, match="validation failed"):
+                loader.load(config_path)
+
+    def test_load_without_validation(self):
+        """Test loading without validation."""
+        loader = ConfigLoader(validate=False)
+
+        with TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "security-config.yml"
+            config_path.write_text("""
+fail_on: high
+""")
+
+            config = loader.load(config_path)
+            assert config.fail_on == FailOnSeverity.HIGH
+
+
+class TestLoadFromString:
+    """Tests for loading configuration from string."""
+
+    @pytest.fixture
+    def loader(self):
+        return ConfigLoader()
+
+    def test_load_valid_string(self, loader):
+        """Test loading valid YAML string."""
+        yaml_content = """
+scanners:
+  semgrep:
+    enabled: true
+fail_on: critical
+"""
+        config = loader.load_from_string(yaml_content)
+
+        assert config.semgrep.enabled is True
+        assert config.fail_on == FailOnSeverity.CRITICAL
+
+    def test_load_empty_string(self, loader):
+        """Test loading empty string returns defaults."""
+        config = loader.load_from_string("")
+        assert isinstance(config, SecurityConfig)
+
+    def test_load_invalid_string(self, loader):
+        """Test loading invalid YAML string raises error."""
+        with pytest.raises(ConfigLoadError, match="Invalid YAML"):
+            loader.load_from_string("invalid: yaml: [")
+
+
+class TestScannerParsing:
+    """Tests for scanner configuration parsing."""
+
+    @pytest.fixture
+    def loader(self):
+        return ConfigLoader()
+
+    def test_parse_semgrep_config(self, loader):
+        """Test parsing Semgrep configuration."""
+        config = loader.load_from_string("""
+scanners:
+  semgrep:
+    enabled: true
+    custom_rules_dir: .security/rules
+    registry_rulesets:
+      - p/security-audit
+      - p/python
+    timeout: 600
+    extra_args:
+      - --verbose
+""")
+
+        assert config.semgrep.enabled is True
+        assert config.semgrep.custom_rules_dir == Path(".security/rules")
+        assert "p/security-audit" in config.semgrep.registry_rulesets
+        assert config.semgrep.timeout == 600
+        assert "--verbose" in config.semgrep.extra_args
+
+    def test_parse_codeql_config(self, loader):
+        """Test parsing CodeQL configuration."""
+        config = loader.load_from_string("""
+scanners:
+  codeql:
+    enabled: true
+    languages:
+      - python
+      - javascript
+    query_suites:
+      - security-and-quality
+    database_path: .codeql/db
+""")
+
+        assert config.codeql.enabled is True
+        assert "python" in config.codeql.languages
+        assert "javascript" in config.codeql.languages
+        assert config.codeql.database_path == Path(".codeql/db")
+
+    def test_parse_bandit_config(self, loader):
+        """Test parsing Bandit configuration."""
+        config = loader.load_from_string("""
+scanners:
+  bandit:
+    enabled: true
+    skips:
+      - B101
+      - B102
+    confidence_level: high
+""")
+
+        assert config.bandit.enabled is True
+        assert "B101" in config.bandit.skips
+        assert config.bandit.confidence_level == "high"
+
+
+class TestExclusionParsing:
+    """Tests for exclusion configuration parsing."""
+
+    @pytest.fixture
+    def loader(self):
+        return ConfigLoader()
+
+    def test_parse_exclusions(self, loader):
+        """Test parsing exclusions configuration."""
+        config = loader.load_from_string("""
+exclusions:
+  paths:
+    - node_modules/
+    - .venv/
+    - vendor/
+  patterns:
+    - "*_test.py"
+    - "*.min.js"
+  file_extensions:
+    - .pyc
+    - .pyo
+""")
+
+        assert "node_modules/" in config.exclusions.paths
+        assert ".venv/" in config.exclusions.paths
+        assert "*_test.py" in config.exclusions.patterns
+        assert ".pyc" in config.exclusions.file_extensions
+
+
+class TestTriageParsing:
+    """Tests for triage configuration parsing."""
+
+    @pytest.fixture
+    def loader(self):
+        return ConfigLoader()
+
+    def test_parse_triage(self, loader):
+        """Test parsing triage configuration."""
+        config = loader.load_from_string("""
+triage:
+  enabled: true
+  confidence_threshold: 0.85
+  auto_dismiss_fp: true
+  cluster_similar: false
+""")
+
+        assert config.triage.enabled is True
+        assert config.triage.confidence_threshold == 0.85
+        assert config.triage.auto_dismiss_fp is True
+        assert config.triage.cluster_similar is False
+
+
+class TestReportingParsing:
+    """Tests for reporting configuration parsing."""
+
+    @pytest.fixture
+    def loader(self):
+        return ConfigLoader()
+
+    def test_parse_reporting(self, loader):
+        """Test parsing reporting configuration."""
+        config = loader.load_from_string("""
+reporting:
+  format: html
+  output_dir: reports/security
+  include_false_positives: true
+  max_remediations: 5
+""")
+
+        assert config.reporting.format == "html"
+        assert config.reporting.output_dir == Path("reports/security")
+        assert config.reporting.include_false_positives is True
+        assert config.reporting.max_remediations == 5
+
+
+class TestTopLevelOptions:
+    """Tests for top-level option parsing."""
+
+    @pytest.fixture
+    def loader(self):
+        return ConfigLoader()
+
+    def test_parse_top_level(self, loader):
+        """Test parsing top-level options."""
+        config = loader.load_from_string("""
+parallel_scans: false
+max_findings: 500
+""")
+
+        assert config.parallel_scans is False
+        assert config.max_findings == 500
+
+
+class TestLoadConfigFunction:
+    """Tests for load_config convenience function."""
+
+    def test_load_config_returns_default(self):
+        """Test load_config returns default when no file."""
+        with TemporaryDirectory() as tmpdir:
+            import os
+
+            old_cwd = os.getcwd()
+            os.chdir(tmpdir)
+            try:
+                config = load_config()
+                assert isinstance(config, SecurityConfig)
+            finally:
+                os.chdir(old_cwd)
+
+    def test_load_config_from_path(self):
+        """Test load_config with explicit path."""
+        with TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.yml"
+            config_path.write_text("fail_on: critical")
+
+            config = load_config(config_path)
+
+            assert config.fail_on == FailOnSeverity.CRITICAL
+
+
+class TestCompleteConfig:
+    """Tests for complete configuration scenarios."""
+
+    @pytest.fixture
+    def loader(self):
+        return ConfigLoader()
+
+    def test_full_config(self, loader):
+        """Test loading a complete configuration."""
+        config = loader.load_from_string("""
+scanners:
+  semgrep:
+    enabled: true
+    custom_rules_dir: .security/semgrep-rules
+    registry_rulesets:
+      - p/security-audit
+      - p/owasp-top-ten
+    timeout: 600
+  codeql:
+    enabled: false
+  bandit:
+    enabled: true
+    skips:
+      - B101
+    confidence_level: high
+
+fail_on: high
+
+exclusions:
+  paths:
+    - node_modules/
+    - .venv/
+    - build/
+  patterns:
+    - "*_test.py"
+    - "test_*.py"
+  file_extensions:
+    - .pyc
+    - .min.js
+
+triage:
+  enabled: true
+  confidence_threshold: 0.8
+  auto_dismiss_fp: false
+  cluster_similar: true
+
+reporting:
+  format: markdown
+  output_dir: docs/security
+  include_false_positives: false
+  max_remediations: 10
+
+parallel_scans: true
+max_findings: 1000
+""")
+
+        # Verify scanners
+        assert config.semgrep.enabled is True
+        assert config.semgrep.custom_rules_dir == Path(".security/semgrep-rules")
+        assert config.codeql.enabled is False
+        assert config.bandit.enabled is True
+
+        # Verify enabled scanners
+        enabled = config.get_enabled_scanners()
+        assert ScannerType.SEMGREP in enabled
+        assert ScannerType.CODEQL not in enabled
+        assert ScannerType.BANDIT in enabled
+
+        # Verify fail_on behavior
+        assert config.should_fail("critical") is True
+        assert config.should_fail("high") is True
+        assert config.should_fail("medium") is False
+
+        # Verify exclusions
+        assert config.exclusions.matches_path("node_modules/pkg/index.js") is True
+        assert config.exclusions.matches_path("src/app.py") is False
+
+        # Verify triage
+        assert config.triage.confidence_threshold == 0.8
+
+        # Verify reporting
+        assert config.reporting.format == "markdown"
+        assert config.reporting.output_dir == Path("docs/security")

--- a/tests/security/config/test_models.py
+++ b/tests/security/config/test_models.py
@@ -1,0 +1,273 @@
+"""Tests for security configuration models."""
+
+from pathlib import Path
+
+
+from specify_cli.security.config.models import (
+    SecurityConfig,
+    ScannerType,
+    FailOnSeverity,
+    SemgrepConfig,
+    CodeQLConfig,
+    BanditConfig,
+    TriageConfig,
+    ExclusionConfig,
+    ReportingConfig,
+)
+
+
+class TestScannerType:
+    """Tests for ScannerType enum."""
+
+    def test_values(self):
+        """Test scanner type values."""
+        assert ScannerType.SEMGREP.value == "semgrep"
+        assert ScannerType.CODEQL.value == "codeql"
+        assert ScannerType.BANDIT.value == "bandit"
+
+
+class TestFailOnSeverity:
+    """Tests for FailOnSeverity enum."""
+
+    def test_values(self):
+        """Test fail_on severity values."""
+        assert FailOnSeverity.CRITICAL.value == "critical"
+        assert FailOnSeverity.HIGH.value == "high"
+        assert FailOnSeverity.MEDIUM.value == "medium"
+        assert FailOnSeverity.LOW.value == "low"
+        assert FailOnSeverity.NONE.value == "none"
+
+
+class TestSemgrepConfig:
+    """Tests for SemgrepConfig."""
+
+    def test_defaults(self):
+        """Test default values."""
+        config = SemgrepConfig()
+
+        assert config.enabled is True
+        assert config.custom_rules_dir is None
+        assert config.registry_rulesets == ["p/default"]
+        assert config.timeout == 300
+
+    def test_custom_config(self):
+        """Test custom configuration."""
+        config = SemgrepConfig(
+            enabled=False,
+            custom_rules_dir=Path(".security/rules"),
+            registry_rulesets=["p/security-audit", "p/python"],
+            timeout=600,
+        )
+
+        assert config.enabled is False
+        assert config.custom_rules_dir == Path(".security/rules")
+        assert "p/security-audit" in config.registry_rulesets
+
+
+class TestCodeQLConfig:
+    """Tests for CodeQLConfig."""
+
+    def test_defaults(self):
+        """Test default values."""
+        config = CodeQLConfig()
+
+        assert config.enabled is True
+        assert config.languages == []
+        assert config.query_suites == ["security-extended"]
+
+    def test_custom_config(self):
+        """Test custom configuration."""
+        config = CodeQLConfig(
+            enabled=True,
+            languages=["python", "javascript"],
+            query_suites=["security-and-quality"],
+        )
+
+        assert "python" in config.languages
+        assert "javascript" in config.languages
+
+
+class TestBanditConfig:
+    """Tests for BanditConfig."""
+
+    def test_defaults(self):
+        """Test default values."""
+        config = BanditConfig()
+
+        assert config.enabled is True
+        assert config.skips == []
+        assert config.confidence_level == "medium"
+
+    def test_custom_config(self):
+        """Test custom configuration."""
+        config = BanditConfig(
+            skips=["B101", "B102"],
+            confidence_level="high",
+        )
+
+        assert "B101" in config.skips
+        assert config.confidence_level == "high"
+
+
+class TestTriageConfig:
+    """Tests for TriageConfig."""
+
+    def test_defaults(self):
+        """Test default values."""
+        config = TriageConfig()
+
+        assert config.enabled is True
+        assert config.confidence_threshold == 0.7
+        assert config.auto_dismiss_fp is False
+        assert config.cluster_similar is True
+
+    def test_custom_config(self):
+        """Test custom configuration."""
+        config = TriageConfig(
+            enabled=True,
+            confidence_threshold=0.9,
+            auto_dismiss_fp=True,
+        )
+
+        assert config.confidence_threshold == 0.9
+        assert config.auto_dismiss_fp is True
+
+
+class TestExclusionConfig:
+    """Tests for ExclusionConfig."""
+
+    def test_defaults(self):
+        """Test default values."""
+        config = ExclusionConfig()
+
+        assert config.paths == []
+        assert config.patterns == []
+        assert config.file_extensions == []
+
+    def test_matches_path_exact(self):
+        """Test path matching with exact paths."""
+        config = ExclusionConfig(paths=["node_modules/", ".venv/"])
+
+        assert config.matches_path("node_modules/package/index.js") is True
+        assert config.matches_path(".venv/lib/python3.11/site.py") is True
+        assert config.matches_path("src/app.py") is False
+
+    def test_matches_path_patterns(self):
+        """Test path matching with glob patterns."""
+        config = ExclusionConfig(patterns=["*_test.py", "*.min.js"])
+
+        assert config.matches_path("test_app.py") is False  # Pattern is *_test.py
+        assert config.matches_path("app_test.py") is True
+        assert config.matches_path("bundle.min.js") is True
+        assert config.matches_path("bundle.js") is False
+
+    def test_matches_path_extensions(self):
+        """Test path matching with file extensions."""
+        config = ExclusionConfig(file_extensions=[".pyc", ".pyo"])
+
+        assert config.matches_path("app.pyc") is True
+        assert config.matches_path("app.pyo") is True
+        assert config.matches_path("app.py") is False
+
+
+class TestReportingConfig:
+    """Tests for ReportingConfig."""
+
+    def test_defaults(self):
+        """Test default values."""
+        config = ReportingConfig()
+
+        assert config.format == "markdown"
+        assert config.output_dir is None
+        assert config.include_false_positives is False
+        assert config.max_remediations == 10
+
+    def test_custom_config(self):
+        """Test custom configuration."""
+        config = ReportingConfig(
+            format="html",
+            output_dir=Path("reports/"),
+            include_false_positives=True,
+            max_remediations=5,
+        )
+
+        assert config.format == "html"
+        assert config.output_dir == Path("reports/")
+
+
+class TestSecurityConfig:
+    """Tests for SecurityConfig."""
+
+    def test_defaults(self):
+        """Test default configuration values."""
+        config = SecurityConfig()
+
+        assert config.semgrep.enabled is True
+        assert config.codeql.enabled is True
+        assert config.bandit.enabled is True
+        assert config.fail_on == FailOnSeverity.HIGH
+        assert config.parallel_scans is True
+        assert config.max_findings == 1000
+
+    def test_get_enabled_scanners(self):
+        """Test getting list of enabled scanners."""
+        config = SecurityConfig()
+
+        enabled = config.get_enabled_scanners()
+
+        assert ScannerType.SEMGREP in enabled
+        assert ScannerType.CODEQL in enabled
+        assert ScannerType.BANDIT in enabled
+
+    def test_get_enabled_scanners_partial(self):
+        """Test getting enabled scanners with some disabled."""
+        config = SecurityConfig()
+        config.codeql.enabled = False
+
+        enabled = config.get_enabled_scanners()
+
+        assert ScannerType.SEMGREP in enabled
+        assert ScannerType.CODEQL not in enabled
+        assert ScannerType.BANDIT in enabled
+
+    def test_should_fail_critical(self):
+        """Test should_fail with critical severity."""
+        config = SecurityConfig(fail_on=FailOnSeverity.HIGH)
+
+        assert config.should_fail("critical") is True
+        assert config.should_fail("high") is True
+        assert config.should_fail("medium") is False
+        assert config.should_fail("low") is False
+
+    def test_should_fail_medium(self):
+        """Test should_fail with medium threshold."""
+        config = SecurityConfig(fail_on=FailOnSeverity.MEDIUM)
+
+        assert config.should_fail("critical") is True
+        assert config.should_fail("high") is True
+        assert config.should_fail("medium") is True
+        assert config.should_fail("low") is False
+
+    def test_should_fail_none(self):
+        """Test should_fail with none (never fail)."""
+        config = SecurityConfig(fail_on=FailOnSeverity.NONE)
+
+        assert config.should_fail("critical") is False
+        assert config.should_fail("high") is False
+        assert config.should_fail("medium") is False
+        assert config.should_fail("low") is False
+
+    def test_to_dict(self):
+        """Test serialization to dictionary."""
+        config = SecurityConfig()
+
+        data = config.to_dict()
+
+        assert "scanners" in data
+        assert "semgrep" in data["scanners"]
+        assert data["scanners"]["semgrep"]["enabled"] is True
+        assert data["fail_on"] == "high"
+        assert data["parallel_scans"] is True
+        assert "triage" in data
+        assert "exclusions" in data
+        assert "reporting" in data

--- a/tests/security/config/test_schema.py
+++ b/tests/security/config/test_schema.py
@@ -1,0 +1,322 @@
+"""Tests for security configuration schema validation."""
+
+import pytest
+
+from specify_cli.security.config.schema import (
+    ConfigSchema,
+    SchemaErrorType,
+)
+
+
+class TestConfigSchema:
+    """Tests for ConfigSchema validation."""
+
+    @pytest.fixture
+    def schema(self):
+        """Create a schema instance."""
+        return ConfigSchema()
+
+    def test_validate_empty_config(self, schema):
+        """Test validating empty configuration."""
+        errors = schema.validate({})
+        assert len(errors) == 0
+
+    def test_validate_non_dict(self, schema):
+        """Test validating non-dict configuration."""
+        errors = schema.validate("invalid")
+
+        assert len(errors) == 1
+        assert errors[0].error_type == SchemaErrorType.INVALID_TYPE
+
+    def test_validate_valid_config(self, schema):
+        """Test validating a complete valid configuration."""
+        config = {
+            "scanners": {
+                "semgrep": {"enabled": True, "timeout": 300},
+                "codeql": {"enabled": False},
+                "bandit": {"enabled": True, "confidence_level": "high"},
+            },
+            "fail_on": "high",
+            "exclusions": {
+                "paths": ["node_modules/"],
+                "patterns": ["*_test.py"],
+            },
+            "triage": {
+                "enabled": True,
+                "confidence_threshold": 0.8,
+            },
+            "reporting": {
+                "format": "markdown",
+                "max_remediations": 5,
+            },
+            "parallel_scans": True,
+            "max_findings": 500,
+        }
+
+        errors = schema.validate(config)
+        assert len(errors) == 0
+
+
+class TestScannerValidation:
+    """Tests for scanner configuration validation."""
+
+    @pytest.fixture
+    def schema(self):
+        return ConfigSchema()
+
+    def test_unknown_scanner(self, schema):
+        """Test error for unknown scanner."""
+        config = {"scanners": {"unknown_scanner": {"enabled": True}}}
+
+        errors = schema.validate(config)
+
+        assert len(errors) == 1
+        assert errors[0].error_type == SchemaErrorType.UNKNOWN_FIELD
+        assert "unknown_scanner" in errors[0].message
+
+    def test_invalid_scanner_config_type(self, schema):
+        """Test error for non-dict scanner config."""
+        config = {"scanners": {"semgrep": "invalid"}}
+
+        errors = schema.validate(config)
+
+        assert len(errors) == 1
+        assert errors[0].error_type == SchemaErrorType.INVALID_TYPE
+
+    def test_invalid_enabled_type(self, schema):
+        """Test error for non-bool enabled field."""
+        config = {"scanners": {"semgrep": {"enabled": "yes"}}}
+
+        errors = schema.validate(config)
+
+        assert len(errors) == 1
+        assert errors[0].error_type == SchemaErrorType.INVALID_TYPE
+        assert "enabled" in errors[0].path
+
+    def test_semgrep_invalid_timeout(self, schema):
+        """Test error for invalid Semgrep timeout."""
+        config = {"scanners": {"semgrep": {"timeout": -1}}}
+
+        errors = schema.validate(config)
+
+        assert len(errors) == 1
+        assert errors[0].error_type == SchemaErrorType.INVALID_VALUE
+        assert "timeout" in errors[0].path
+
+    def test_semgrep_invalid_rulesets_type(self, schema):
+        """Test error for non-list rulesets."""
+        config = {"scanners": {"semgrep": {"registry_rulesets": "p/default"}}}
+
+        errors = schema.validate(config)
+
+        assert len(errors) == 1
+        assert errors[0].error_type == SchemaErrorType.INVALID_TYPE
+
+    def test_codeql_invalid_languages_type(self, schema):
+        """Test error for non-list languages."""
+        config = {"scanners": {"codeql": {"languages": "python"}}}
+
+        errors = schema.validate(config)
+
+        assert len(errors) == 1
+        assert errors[0].error_type == SchemaErrorType.INVALID_TYPE
+
+    def test_bandit_invalid_confidence_level(self, schema):
+        """Test error for invalid confidence level."""
+        config = {"scanners": {"bandit": {"confidence_level": "very_high"}}}
+
+        errors = schema.validate(config)
+
+        assert len(errors) == 1
+        assert errors[0].error_type == SchemaErrorType.INVALID_VALUE
+
+    def test_bandit_invalid_skips_type(self, schema):
+        """Test error for non-list skips."""
+        config = {"scanners": {"bandit": {"skips": "B101"}}}
+
+        errors = schema.validate(config)
+
+        assert len(errors) == 1
+        assert errors[0].error_type == SchemaErrorType.INVALID_TYPE
+
+
+class TestFailOnValidation:
+    """Tests for fail_on validation."""
+
+    @pytest.fixture
+    def schema(self):
+        return ConfigSchema()
+
+    def test_valid_fail_on_values(self, schema):
+        """Test all valid fail_on values."""
+        for value in ["critical", "high", "medium", "low", "none"]:
+            errors = schema.validate({"fail_on": value})
+            assert len(errors) == 0, f"Failed for: {value}"
+
+    def test_invalid_fail_on_value(self, schema):
+        """Test error for invalid fail_on value."""
+        errors = schema.validate({"fail_on": "severe"})
+
+        assert len(errors) == 1
+        assert errors[0].error_type == SchemaErrorType.INVALID_VALUE
+
+    def test_invalid_fail_on_type(self, schema):
+        """Test error for non-string fail_on."""
+        errors = schema.validate({"fail_on": 1})
+
+        assert len(errors) == 1
+        assert errors[0].error_type == SchemaErrorType.INVALID_TYPE
+
+
+class TestExclusionsValidation:
+    """Tests for exclusions validation."""
+
+    @pytest.fixture
+    def schema(self):
+        return ConfigSchema()
+
+    def test_valid_exclusions(self, schema):
+        """Test valid exclusions configuration."""
+        config = {
+            "exclusions": {
+                "paths": ["node_modules/", ".venv/"],
+                "patterns": ["*_test.py", "*.min.js"],
+                "file_extensions": [".pyc", ".pyo"],
+            }
+        }
+
+        errors = schema.validate(config)
+        assert len(errors) == 0
+
+    def test_invalid_exclusions_type(self, schema):
+        """Test error for non-dict exclusions."""
+        errors = schema.validate({"exclusions": "node_modules/"})
+
+        assert len(errors) == 1
+        assert errors[0].error_type == SchemaErrorType.INVALID_TYPE
+
+    def test_invalid_paths_type(self, schema):
+        """Test error for non-list paths."""
+        errors = schema.validate({"exclusions": {"paths": "node_modules/"}})
+
+        assert len(errors) == 1
+        assert errors[0].error_type == SchemaErrorType.INVALID_TYPE
+
+
+class TestTriageValidation:
+    """Tests for triage validation."""
+
+    @pytest.fixture
+    def schema(self):
+        return ConfigSchema()
+
+    def test_valid_triage(self, schema):
+        """Test valid triage configuration."""
+        config = {
+            "triage": {
+                "enabled": True,
+                "confidence_threshold": 0.8,
+                "auto_dismiss_fp": True,
+                "cluster_similar": False,
+            }
+        }
+
+        errors = schema.validate(config)
+        assert len(errors) == 0
+
+    def test_invalid_triage_type(self, schema):
+        """Test error for non-dict triage."""
+        errors = schema.validate({"triage": True})
+
+        assert len(errors) == 1
+        assert errors[0].error_type == SchemaErrorType.INVALID_TYPE
+
+    def test_invalid_confidence_threshold_type(self, schema):
+        """Test error for non-numeric confidence threshold."""
+        errors = schema.validate({"triage": {"confidence_threshold": "high"}})
+
+        assert len(errors) == 1
+        assert errors[0].error_type == SchemaErrorType.INVALID_TYPE
+
+    def test_confidence_threshold_too_high(self, schema):
+        """Test error for confidence threshold > 1.0."""
+        errors = schema.validate({"triage": {"confidence_threshold": 1.5}})
+
+        assert len(errors) == 1
+        assert errors[0].error_type == SchemaErrorType.INVALID_RANGE
+
+    def test_confidence_threshold_too_low(self, schema):
+        """Test error for confidence threshold < 0.0."""
+        errors = schema.validate({"triage": {"confidence_threshold": -0.1}})
+
+        assert len(errors) == 1
+        assert errors[0].error_type == SchemaErrorType.INVALID_RANGE
+
+    def test_invalid_auto_dismiss_type(self, schema):
+        """Test error for non-bool auto_dismiss_fp."""
+        errors = schema.validate({"triage": {"auto_dismiss_fp": "yes"}})
+
+        assert len(errors) == 1
+        assert errors[0].error_type == SchemaErrorType.INVALID_TYPE
+
+
+class TestReportingValidation:
+    """Tests for reporting validation."""
+
+    @pytest.fixture
+    def schema(self):
+        return ConfigSchema()
+
+    def test_valid_reporting(self, schema):
+        """Test valid reporting configuration."""
+        config = {
+            "reporting": {
+                "format": "markdown",
+                "max_remediations": 10,
+            }
+        }
+
+        errors = schema.validate(config)
+        assert len(errors) == 0
+
+    def test_valid_formats(self, schema):
+        """Test all valid format values."""
+        for fmt in ["markdown", "html", "json", "sarif"]:
+            errors = schema.validate({"reporting": {"format": fmt}})
+            assert len(errors) == 0, f"Failed for format: {fmt}"
+
+    def test_invalid_format(self, schema):
+        """Test error for invalid format."""
+        errors = schema.validate({"reporting": {"format": "pdf"}})
+
+        assert len(errors) == 1
+        assert errors[0].error_type == SchemaErrorType.INVALID_VALUE
+
+    def test_invalid_max_remediations(self, schema):
+        """Test error for invalid max_remediations."""
+        errors = schema.validate({"reporting": {"max_remediations": -1}})
+
+        assert len(errors) == 1
+        assert errors[0].error_type == SchemaErrorType.INVALID_VALUE
+
+
+class TestTopLevelValidation:
+    """Tests for top-level field validation."""
+
+    @pytest.fixture
+    def schema(self):
+        return ConfigSchema()
+
+    def test_invalid_parallel_scans_type(self, schema):
+        """Test error for non-bool parallel_scans."""
+        errors = schema.validate({"parallel_scans": "yes"})
+
+        assert len(errors) == 1
+        assert errors[0].error_type == SchemaErrorType.INVALID_TYPE
+
+    def test_invalid_max_findings(self, schema):
+        """Test error for invalid max_findings."""
+        errors = schema.validate({"max_findings": -100})
+
+        assert len(errors) == 1
+        assert errors[0].error_type == SchemaErrorType.INVALID_VALUE


### PR DESCRIPTION
## Summary

Implements task-217: Security Configuration System

### Features

- **YAML Configuration**: Schema-validated security settings
- **Scanner Configuration**: Semgrep, CodeQL, Bandit settings
- **Severity Thresholds**: Configurable fail-on levels for CI/CD
- **Exclusion Patterns**: Path and glob-based exclusions
- **Triage Settings**: AI confidence thresholds

### Architecture

```
SecurityConfig
├── SemgrepConfig     → rulesets, timeout, custom_rules_dir
├── CodeQLConfig      → languages, query_suites
├── BanditConfig      → skips, confidence_level
├── TriageConfig      → confidence_threshold, auto_dismiss_fp
├── ExclusionConfig   → paths, patterns, file_extensions
└── ReportingConfig   → format, output_dir, max_remediations
```

### Configuration Locations

1. `.jpspec/security-config.yml`
2. `.jpspec/security-config.yaml`
3. `.security/config.yml`
4. `.security/config.yaml`
5. `security-config.yml`

### Example Configuration

```yaml
scanners:
  semgrep:
    enabled: true
    timeout: 300
  codeql:
    enabled: false

fail_on: high

exclusions:
  paths:
    - node_modules/
    - .venv/

triage:
  confidence_threshold: 0.8

reporting:
  format: markdown
```

## Test Plan

- [x] All 72 tests pass (`uv run pytest tests/security/config/ -q`)
- [x] Ruff lint passes (`ruff check`)
- [x] Ruff format passes (`ruff format --check`)
- [x] DCO sign-off present

## Verification

```bash
cd /home/jpoley/ps/jp-spec-kit-galway-task-217
ruff check src/specify_cli/security/config/ tests/security/config/
ruff format --check src/specify_cli/security/config/ tests/security/config/
uv run pytest tests/security/config/ -q
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)