### PR TITLE
fix(agents): add missing definitions to frontend-engineer Button example

### DIFF
--- a/.claude/agents/frontend-engineer.md
+++ b/.claude/agents/frontend-engineer.md
@@ -20,10 +20,25 @@ You are an expert frontend engineer specializing in modern web development. You 
 ### Component Structure
 
 ```tsx
-// Good: Typed, accessible, performant
+// Good: Typed, accessible, performant - complete, runnable example
+import { cn } from "@/lib/utils"; // className merge utility (e.g., clsx + tailwind-merge)
+
+// Style variants as const objects for type safety
+const variants = {
+  primary: "bg-blue-600 text-white hover:bg-blue-700",
+  secondary: "bg-gray-200 text-gray-900 hover:bg-gray-300",
+  ghost: "bg-transparent hover:bg-gray-100",
+} as const;
+
+const sizes = {
+  sm: "px-3 py-1 text-sm",
+  md: "px-4 py-2",
+  lg: "px-6 py-3 text-lg",
+} as const;
+
 interface ButtonProps {
-  variant: 'primary' | 'secondary' | 'ghost';
-  size?: 'sm' | 'md' | 'lg';
+  variant: keyof typeof variants;
+  size?: keyof typeof sizes;
   disabled?: boolean;
   onClick?: () => void;
   children: React.ReactNode;
@@ -31,7 +46,7 @@ interface ButtonProps {
 
 export function Button({
   variant,
-  size = 'md',
+  size = "md",
   disabled = false,
   onClick,
   children,
@@ -42,7 +57,6 @@ export function Button({
       className={cn(variants[variant], sizes[size])}
       disabled={disabled}
       onClick={onClick}
-      aria-disabled={disabled}
     >
       {children}
     </button>

--- a/templates/agents/frontend-engineer.md
+++ b/templates/agents/frontend-engineer.md
@@ -20,10 +20,25 @@ You are an expert frontend engineer specializing in modern web development. You 
 ### Component Structure
 
 ```tsx
-// Good: Typed, accessible, performant
+// Good: Typed, accessible, performant - complete, runnable example
+import { cn } from "@/lib/utils"; // className merge utility (e.g., clsx + tailwind-merge)
+
+// Style variants as const objects for type safety
+const variants = {
+  primary: "bg-blue-600 text-white hover:bg-blue-700",
+  secondary: "bg-gray-200 text-gray-900 hover:bg-gray-300",
+  ghost: "bg-transparent hover:bg-gray-100",
+} as const;
+
+const sizes = {
+  sm: "px-3 py-1 text-sm",
+  md: "px-4 py-2",
+  lg: "px-6 py-3 text-lg",
+} as const;
+
 interface ButtonProps {
-  variant: 'primary' | 'secondary' | 'ghost';
-  size?: 'sm' | 'md' | 'lg';
+  variant: keyof typeof variants;
+  size?: keyof typeof sizes;
   disabled?: boolean;
   onClick?: () => void;
   children: React.ReactNode;
@@ -31,7 +46,7 @@ interface ButtonProps {
 
 export function Button({
   variant,
-  size = 'md',
+  size = "md",
   disabled = false,
   onClick,
   children,
@@ -42,7 +57,6 @@ export function Button({
       className={cn(variants[variant], sizes[size])}
       disabled={disabled}
       onClick={onClick}
-      aria-disabled={disabled}
     >
       {children}
     </button>

--- a/tests/test_agent_frontend_engineer.py
+++ b/tests/test_agent_frontend_engineer.py
@@ -36,6 +36,7 @@ def safe_read_file(file_path: Path) -> Optional[str]:
         if file_path.exists() and file_path.is_file():
             return file_path.read_text(encoding="utf-8")
     except (OSError, IOError, PermissionError):
+        # Suppress file read errors; function returns None if file can't be read
         pass
     return None
 


### PR DESCRIPTION
## Summary
Fix incomplete Button component example in frontend-engineer agent definition.

## Issues Fixed

### Button Component (Line 42)
| Issue | Fix |
|-------|-----|
| `variants[variant]` undefined | Added `variants` object with Tailwind classes |
| `sizes[size]` undefined | Added `sizes` object with Tailwind classes |
| `cn()` function undefined | Added import with explanatory comment |
| Redundant `aria-disabled` | Removed (native `disabled` handles accessibility) |
| Literal string types | Changed to `keyof typeof` for type safety |

### Test File (Line 38)
| Issue | Fix |
|-------|-----|
| Empty except clause | Added explanatory comment |

## Before (Would Fail)
```tsx
// variants and sizes are undefined!
// cn is not imported!
className={cn(variants[variant], sizes[size])}
```

## After (Complete, Runnable)
```tsx
import { cn } from "@/lib/utils"; // className merge utility

const variants = {
  primary: "bg-blue-600 text-white hover:bg-blue-700",
  secondary: "bg-gray-200 text-gray-900 hover:bg-gray-300",
  ghost: "bg-transparent hover:bg-gray-100",
} as const;

const sizes = {
  sm: "px-3 py-1 text-sm",
  md: "px-4 py-2",
  lg: "px-6 py-3 text-lg",
} as const;

interface ButtonProps {
  variant: keyof typeof variants;
  size?: keyof typeof sizes;
  // ...
}
```

## Test Plan
- [x] All 22 frontend-engineer tests pass
- [x] Full test suite passes (1747 tests)
- [x] Agent and template files are identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)