### PR TITLE
chore(backlog): mark hook/event tasks done and add jpspec prompt files

### DIFF
--- a/.github/prompts/jpspec._backlog-instructions.prompt.md
+++ b/.github/prompts/jpspec._backlog-instructions.prompt.md
@@ -1,0 +1,1 @@
+../../templates/commands/jpspec/_backlog-instructions.md

--- a/.github/prompts/jpspec._workflow-state.prompt.md
+++ b/.github/prompts/jpspec._workflow-state.prompt.md
@@ -1,0 +1,1 @@
+../../templates/commands/jpspec/_workflow-state.md

--- a/.github/prompts/jpspec.prune-branch.prompt.md
+++ b/.github/prompts/jpspec.prune-branch.prompt.md
@@ -1,0 +1,1 @@
+../../templates/commands/jpspec/prune-branch.md

--- a/backlog/tasks/task-189 - Create-Stop-Hook-for-Backlog-Task-Quality-Gate.md
+++ b/backlog/tasks/task-189 - Create-Stop-Hook-for-Backlog-Task-Quality-Gate.md
@@ -1,10 +1,10 @@
 ---
 id: task-189
 title: Create Stop Hook for Backlog Task Quality Gate
-status: To Do
+status: Done
 assignee: []
 created_date: '2025-12-01 05:04'
-updated_date: '2025-12-01 05:29'
+updated_date: '2025-12-03 22:27'
 labels:
   - claude-code
   - hooks

--- a/backlog/tasks/task-193 - Create-PermissionRequest-Hook-for-Auto-Approvals.md
+++ b/backlog/tasks/task-193 - Create-PermissionRequest-Hook-for-Auto-Approvals.md
@@ -1,10 +1,10 @@
 ---
 id: task-193
 title: Create PermissionRequest Hook for Auto-Approvals
-status: To Do
+status: Done
 assignee: []
 created_date: '2025-12-01 05:05'
-updated_date: '2025-12-01 05:31'
+updated_date: '2025-12-03 22:27'
 labels:
   - claude-code
   - hooks

--- a/backlog/tasks/task-203 - Integrate-Event-Emission-into-jpspec-Commands.md
+++ b/backlog/tasks/task-203 - Integrate-Event-Emission-into-jpspec-Commands.md
@@ -1,11 +1,11 @@
 ---
 id: task-203
 title: Integrate Event Emission into /jpspec Commands
-status: To Do
+status: Done
 assignee:
   - '@pm-planner'
 created_date: '2025-12-03 00:41'
-updated_date: '2025-12-03 01:41'
+updated_date: '2025-12-03 22:27'
 labels:
   - implement
   - integration

--- a/backlog/tasks/task-227 - Add-event-emission-instructions-to-jpspec-slash-commands.md
+++ b/backlog/tasks/task-227 - Add-event-emission-instructions-to-jpspec-slash-commands.md
@@ -1,9 +1,10 @@
 ---
 id: task-227
 title: Add event emission instructions to /jpspec slash commands
-status: To Do
+status: Done
 assignee: []
 created_date: '2025-12-03 02:10'
+updated_date: '2025-12-03 22:27'
 labels:
   - hooks
   - integration

--- a/backlog/tasks/task-228 - Create-Claude-Code-hook-to-auto-emit-events-on-jpspec-completion.md
+++ b/backlog/tasks/task-228 - Create-Claude-Code-hook-to-auto-emit-events-on-jpspec-completion.md
@@ -1,9 +1,10 @@
 ---
 id: task-228
 title: Create Claude Code hook to auto-emit events on /jpspec completion
-status: To Do
+status: Done
 assignee: []
 created_date: '2025-12-03 02:10'
+updated_date: '2025-12-03 22:27'
 labels:
   - hooks
   - claude-code

--- a/backlog/tasks/task-229 - Create-agent-progress-tracking-via-event-emission-(multi-machine-observability).md
+++ b/backlog/tasks/task-229 - Create-agent-progress-tracking-via-event-emission-(multi-machine-observability).md
@@ -3,9 +3,10 @@ id: task-229
 title: >-
   Create agent progress tracking via event emission (multi-machine
   observability)
-status: To Do
+status: Done
 assignee: []
 created_date: '2025-12-03 02:10'
+updated_date: '2025-12-03 22:27'
 labels:
   - hooks
   - observability


### PR DESCRIPTION
## Summary

- Mark 6 completed hook/event emission tasks as Done (task-189, task-193, task-203, task-227, task-228, task-229)
- Add 3 new prompt files for GitHub Copilot integration:
  - `jpspec._backlog-instructions.prompt.md`: Shared backlog CLI instructions for all jpspec agents
  - `jpspec._workflow-state.prompt.md`: Workflow state validation instructions
  - `jpspec.prune-branch.prompt.md`: New branch cleanup command

## Test plan

- [x] Verify task status changes are valid (To Do → Done)
- [x] Verify new prompt files are valid markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)