### PR TITLE
feat(hooks): robust code quality validation with all 8 Copilot fixes

### DIFF
--- a/scripts/bash/pre-commit-hook.sh
+++ b/scripts/bash/pre-commit-hook.sh
@@ -51,8 +51,115 @@ else
 fi
 echo ""
 
-# 3. Quick test run (only fast tests if marked)
-echo -e "${BLUE}3. Running quick tests...${NC}"
+# 3. Code quality validation (staged Python files only)
+# Addresses issues from PR #379 where encoding was fixed inconsistently
+# NOTE: Known limitations:
+#   - Multi-line function calls are not detected (grep is line-based)
+#   - Nested parentheses in arguments may confuse pattern matching
+#   - "encoding=" in comments may cause false negatives (rare)
+echo -e "${BLUE}3. Running code quality validation on staged files...${NC}"
+
+# Helper to safely print untrusted content (prevents terminal escape injection)
+safe_print() {
+    printf '%s\n' "$1" | tr -d '\000-\010\013\014\016-\037\177'
+}
+
+# Get staged Python files using null delimiter for spaces in filenames
+STAGED_FILES=()
+while IFS= read -r -d '' file; do
+    if [[ "$file" == *.py ]]; then
+        STAGED_FILES+=("$file")
+    fi
+done < <(git diff --cached --name-only --diff-filter=ACM -z 2>/dev/null)
+
+if [ "${#STAGED_FILES[@]}" -gt 0 ]; then
+    ENCODING_ISSUES=""
+    OPEN_ISSUES=""
+    SHADOW_WARNINGS=""
+
+    # Process each file only once (N ops instead of 3N)
+    for file in "${STAGED_FILES[@]}"; do
+        if [ -f "$file" ]; then
+            # Get staged content once per file
+            CONTENT=$(git show ":$file" 2>/dev/null || true)
+
+            if [ -n "$CONTENT" ]; then
+                # Check 1: write_text/read_text without encoding (require dot prefix)
+                # Pattern: .write_text( or .read_text( without encoding=
+                # Uses -E for extended regex (alternation with |)
+                ISSUES=$(echo "$CONTENT" | grep -nE '\.(write_text|read_text)\(' | grep -v 'encoding=' || true)
+                if [ -n "$ISSUES" ]; then
+                    ENCODING_ISSUES="${ENCODING_ISSUES}${file}:\n${ISSUES}\n"
+                fi
+
+                # Check 2: open() without encoding - comprehensive binary mode detection
+                # Uses word boundary \b to avoid matching .reopen(), file.open(), etc.
+                OPEN_LINES=$(echo "$CONTENT" | grep -nE '\bopen\(' | grep -v 'encoding=' || true)
+                while IFS= read -r line; do
+                    if [ -n "$line" ]; then
+                        # Extract the actual source content (after linenum:)
+                        LINE_CONTENT="${line#*:}"
+
+                        # Skip if mode argument contains 'b' for binary (handles rb, wb, r+b, rb+, br, etc.)
+                        # Matches both positional ('rb') and keyword (mode='rb') arguments
+                        # Note: [^)]* may not work with nested parens like open(get_file(), 'rb')
+                        if echo "$line" | grep -qE "['\"][rwax+]*b[rwax+]*['\"]|mode\s*=\s*['\"][rwax+]*b"; then
+                            continue
+                        fi
+                        # Skip if actual source line is a comment (starts with #)
+                        if echo "$LINE_CONTENT" | grep -qE '^\s*#'; then
+                            continue
+                        fi
+                        # Skip function definitions named exactly 'open'
+                        if echo "$line" | grep -qE 'def\s+open\s*\('; then
+                            continue
+                        fi
+                        OPEN_ISSUES="${OPEN_ISSUES}${file}:${line}\n"
+                    fi
+                done <<< "$OPEN_LINES"
+
+                # Check 3: Shadowed Python built-ins - match complete parameter names only
+                # Two-step approach: first find def lines, then check for parameter patterns
+                # Pattern matches builtins as standalone parameters preceded by ( or ,
+                # and followed by , : = ) - prevents matching 'user_id' for 'id'
+                SHADOW_LINES=$(echo "$CONTENT" | grep -nE '^\s*def\s+\w+\s*\(' | grep -E '[(,]\s*(id|type|list|dict|input|filter|map|hash|format|range|len|sum|min|max|open|file|dir|help|vars|iter|next|set|str|int|float|bool|bytes|tuple|object|super|property|classmethod|staticmethod)\s*[,:)=]' || true)
+                if [ -n "$SHADOW_LINES" ]; then
+                    SHADOW_WARNINGS="${SHADOW_WARNINGS}${file}:\n${SHADOW_LINES}\n"
+                fi
+            fi
+        fi
+    done
+
+    # Report encoding issues (blocking)
+    if [ -n "$ENCODING_ISSUES" ]; then
+        echo -e "${RED}✗ File I/O missing encoding=\"utf-8\":${NC}"
+        safe_print "$ENCODING_ISSUES"
+        STATUS=1
+    else
+        echo -e "${GREEN}✓ All write_text/read_text have encoding${NC}"
+    fi
+
+    # Report open() issues (blocking)
+    if [ -n "$OPEN_ISSUES" ]; then
+        echo -e "${RED}✗ open() calls missing encoding=\"utf-8\" (text mode):${NC}"
+        safe_print "$OPEN_ISSUES"
+        STATUS=1
+    else
+        echo -e "${GREEN}✓ All text-mode open() calls have encoding${NC}"
+    fi
+
+    # Report shadowing warnings (non-blocking)
+    if [ -n "$SHADOW_WARNINGS" ]; then
+        echo -e "${YELLOW}⚠ Possible shadowed Python built-ins (review manually):${NC}"
+        safe_print "$SHADOW_WARNINGS"
+    fi
+else
+    echo -e "${GREEN}✓ No Python files staged, skipping validation${NC}"
+fi
+echo ""
+
+# 4. Quick test run (only fast tests if marked)
+echo -e "${BLUE}4. Running quick tests...${NC}"
 if command -v pytest &> /dev/null; then
     # Run tests marked as 'quick' or all tests if no markers
     if pytest tests/ -m quick --tb=short > /dev/null 2>&1; then

--- a/src/specify_cli/security/fixer/generator.py
+++ b/src/specify_cli/security/fixer/generator.py
@@ -282,7 +282,9 @@ Respond in JSON format:
         # Find matching example
         for example in pattern.examples:
             if example["before"] in original_code:
-                fixed_code = original_code.replace(example["before"], example["after"], 1)
+                fixed_code = original_code.replace(
+                    example["before"], example["after"], 1
+                )
 
                 unified_diff = self._generate_diff(original_code, fixed_code)
 


### PR DESCRIPTION
## Summary

Adds comprehensive Python code quality validation to the pre-commit hook, addressing **all 8 Copilot review issues from PR #380**.

### Fixes Applied

| # | Issue | Fix |
|---|-------|-----|
| 1 | Inconsistent PR reference | Changed #376/#377 to #379 |
| 2 | Basic regex syntax | Added `-E` flag for extended regex |
| 3 | Incomplete binary mode detection | Pattern matches any mode containing 'b' (rb, r+b, br, etc.) |
| 4 | Comment detection on grep output | Extracts actual source content before checking for `#` |
| 5 | Broad function pattern | Matches exactly `def open(` not any `*open*` function |
| 6 | Missing word boundary | Added `\b` to prevent matching `.reopen()`, `file.open()` |
| 7 | Partial name matching | Two-step grep matches complete parameter names only |
| 8 | Dead code | Removed unused `check_pattern_in_content` function |

### Key Improvements

**Binary Mode Detection**: Now correctly handles all Python binary modes:
- `rb`, `wb`, `ab`, `xb` - basic modes
- `r+b`, `w+b`, `a+b` - with +
- `rb+`, `wb+` - + at end
- `br`, `bw` - b prefix (Python 3 style)

**Shadow Detection**: Two-step grep approach prevents false positives:
- `user_id` no longer matches `id`
- `mytype` no longer matches `type`
- Only catches actual parameter names: `(id,`, `(id)`, `(id:`, `(id=`

## Test Plan

- [x] `write_text()` without encoding - caught
- [x] `write_text(encoding="utf-8")` - passed
- [x] `read_text()` without encoding - caught
- [x] `open("f", "rb")` - skipped (binary)
- [x] `open("f", "r+b")` - skipped (binary with +)
- [x] `open("f", "br")` - skipped (Python 3 binary)
- [x] `open("f", "xb")` - skipped (exclusive binary)
- [x] `open("f", "r")` - caught (text without encoding)
- [x] `# open("f")` comment - skipped
- [x] `def open(filename)` - skipped
- [x] `def bad(id, name)` - warned (shadows id)
- [x] `def good(user_id)` - passed (not shadowing)
- [x] `def typed(id: int)` - warned (shadows id with type hint)
- [x] `def default(id=None)` - warned (shadows id with default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)