### PR TITLE
chore(backlog): rename dogfood tasks to dev-setup and set In Progress

### DIFF
--- a/backlog/tasks/task-259 - Create-dev-setup-validation-GitHub-Action.md
+++ b/backlog/tasks/task-259 - Create-dev-setup-validation-GitHub-Action.md
@@ -1,9 +1,10 @@
 ---
 id: task-259
-title: Create dogfood validation GitHub Action
-status: To Do
+title: Create dev-setup validation GitHub Action
+status: In Progress
 assignee: []
 created_date: '2025-12-03 13:54'
+updated_date: '2025-12-04 01:40'
 labels:
   - infrastructure
   - cicd

--- a/backlog/tasks/task-260 - Create-dev-setup-validation-test-suite.md
+++ b/backlog/tasks/task-260 - Create-dev-setup-validation-test-suite.md
@@ -1,9 +1,10 @@
 ---
 id: task-260
-title: Create dogfood validation test suite
-status: To Do
+title: Create dev-setup validation test suite
+status: In Progress
 assignee: []
 created_date: '2025-12-03 13:54'
+updated_date: '2025-12-04 01:40'
 labels:
   - testing
   - infrastructure

--- a/backlog/tasks/task-261 - Add-dev-setup-validation-pre-commit-hook.md
+++ b/backlog/tasks/task-261 - Add-dev-setup-validation-pre-commit-hook.md
@@ -1,9 +1,10 @@
 ---
 id: task-261
-title: Add dogfood validation pre-commit hook
-status: To Do
+title: Add dev-setup validation pre-commit hook
+status: In Progress
 assignee: []
 created_date: '2025-12-03 13:54'
+updated_date: '2025-12-04 01:40'
 labels:
   - infrastructure
   - hooks

--- a/backlog/tasks/task-262 - Add-dev-setup-management-Makefile-commands.md
+++ b/backlog/tasks/task-262 - Add-dev-setup-management-Makefile-commands.md
@@ -1,10 +1,10 @@
 ---
 id: task-262
-title: Add dogfood management Makefile commands
+title: Add dev-setup management Makefile commands
 status: Done
 assignee: []
 created_date: '2025-12-03 13:54'
-updated_date: '2025-12-04 01:25'
+updated_date: '2025-12-04 01:34'
 labels:
   - infrastructure
   - dx

--- a/backlog/tasks/task-263 - Document-dev-setup-workflow-for-contributors.md
+++ b/backlog/tasks/task-263 - Document-dev-setup-workflow-for-contributors.md
@@ -1,15 +1,15 @@
 ---
 id: task-263
-title: Document dogfood workflow for contributors
-status: To Do
+title: Document dev-setup workflow for contributors
+status: In Progress
 assignee: []
 created_date: '2025-12-03 13:54'
-updated_date: '2025-12-04 01:25'
+updated_date: '2025-12-04 01:39'
 labels:
   - documentation
   - dogfood
 dependencies: []
-priority: medium
+priority: high
 ---
 
 ## Description

--- a/backlog/tasks/task-266 - Create-dev-setup-operational-runbook.md
+++ b/backlog/tasks/task-266 - Create-dev-setup-operational-runbook.md
@@ -1,16 +1,16 @@
 ---
 id: task-266
-title: Create dogfood operational runbook
-status: To Do
+title: Create dev-setup operational runbook
+status: In Progress
 assignee: []
 created_date: '2025-12-03 13:55'
-updated_date: '2025-12-04 01:25'
+updated_date: '2025-12-04 01:39'
 labels:
   - documentation
   - operations
   - dogfood
 dependencies: []
-priority: low
+priority: high
 ---
 
 ## Description

--- a/backlog/tasks/task-273 - Update-dev-setup-command-for-jpspec-symlinks.md
+++ b/backlog/tasks/task-273 - Update-dev-setup-command-for-jpspec-symlinks.md
@@ -1,11 +1,11 @@
 ---
 id: task-273
-title: Update dogfood command for jpspec symlinks
+title: Update dev-setup command for jpspec symlinks
 status: Done
 assignee:
   - '@cli-engineer'
 created_date: '2025-12-03 14:01'
-updated_date: '2025-12-04 01:24'
+updated_date: '2025-12-04 01:34'
 labels:
   - cli
   - dogfood

--- a/backlog/tasks/task-277 - Create-dev-setup-init-equivalence-validation-tests.md
+++ b/backlog/tasks/task-277 - Create-dev-setup-init-equivalence-validation-tests.md
@@ -1,9 +1,10 @@
 ---
 id: task-277
-title: Create dogfood-init equivalence validation tests
-status: To Do
+title: Create dev-setup/init equivalence validation tests
+status: In Progress
 assignee: []
 created_date: '2025-12-03 14:01'
+updated_date: '2025-12-04 01:40'
 labels:
   - testing
   - validation


### PR DESCRIPTION
## Summary
- Renamed 8 tasks from "dogfood" to "dev-setup" terminology for consistency
- Set all non-Done tasks to "In Progress" with high priority
- Prepares tasks for parallel implementation across multiple agents

## Tasks Updated
| Task | New Title | Status |
|------|-----------|--------|
| task-259 | Create dev-setup validation GitHub Action | In Progress |
| task-260 | Create dev-setup validation test suite | In Progress |
| task-261 | Add dev-setup validation pre-commit hook | In Progress |
| task-262 | Add dev-setup management Makefile commands | Done (unchanged) |
| task-263 | Document dev-setup workflow for contributors | In Progress |
| task-266 | Create dev-setup operational runbook | In Progress |
| task-273 | Update dev-setup command for jpspec symlinks | Done (unchanged) |
| task-277 | Create dev-setup/init equivalence validation tests | In Progress |

## Test plan
- [x] Verify no "dogfood" tasks remain in backlog
- [x] Verify task files renamed correctly
- [x] Verify task statuses updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)