### PR TITLE
feat(hooks): add pre-commit framework config and integrate dev-setup validation (task-261)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,38 @@
+# Pre-commit hook configuration
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+
+repos:
+  # Local repository hooks
+  - repo: local
+    hooks:
+      # Dev-setup validation
+      # Validates that .claude/commands/ contains ONLY symlinks
+      # pointing to templates/commands/ (single-source-of-truth)
+      - id: dev-setup-validation
+        name: Dev-setup validation
+        entry: scripts/bash/pre-commit-dev-setup.sh
+        language: script
+        always_run: true
+        pass_filenames: false
+        description: Validate .claude/commands/ symlink structure
+
+  # Standard Python hooks
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.2
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+
+  # General file checks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+        args: [--fix=lf]

--- a/scripts/bash/pre-commit-hook.sh
+++ b/scripts/bash/pre-commit-hook.sh
@@ -159,8 +159,23 @@ else
 fi
 echo ""
 
-# 4. Quick test run (only fast tests if marked)
-echo -e "${BLUE}4. Running quick tests...${NC}"
+# 4. Dev-setup validation (fast)
+echo -e "${BLUE}4. Validating dev-setup structure...${NC}"
+if [ -f "scripts/bash/pre-commit-dev-setup.sh" ]; then
+    if ./scripts/bash/pre-commit-dev-setup.sh > /dev/null 2>&1; then
+        echo -e "${GREEN}✓ Dev-setup validation passed${NC}"
+    else
+        echo -e "${RED}✗ Dev-setup validation failed${NC}"
+        echo "Run: ./scripts/bash/pre-commit-dev-setup.sh"
+        STATUS=1
+    fi
+else
+    echo -e "${YELLOW}⚠ Dev-setup validation script not found, skipping${NC}"
+fi
+echo ""
+
+# 5. Quick test run (only fast tests if marked)
+echo -e "${BLUE}5. Running quick tests...${NC}"
 if command -v pytest &> /dev/null; then
     # Run tests marked as 'quick' or all tests if no markers
     if pytest tests/ -m quick --tb=short > /dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Completes task-261 by adding pre-commit framework configuration and integrating dev-setup validation into the existing pre-commit hook.

**This PR fixes all issues from the closed PR #398:**
- Uses existing ADR-010 (was incorrectly flagged as missing)
- Main already has complete `pre-commit-dev-setup.sh` with all R1-R7 validations
- Adds missing `.pre-commit-config.yaml` 
- Adds missing integration into `pre-commit-hook.sh`

## Changes

### .pre-commit-config.yaml (NEW)
- Adds pre-commit framework configuration
- Includes dev-setup-validation hook (calls `scripts/bash/pre-commit-dev-setup.sh`)
- Configures ruff for Python linting/formatting (v0.8.2)
- Adds standard file checks (trailing-whitespace, end-of-file, yaml, etc.)

### scripts/bash/pre-commit-hook.sh (MODIFIED)
- Integrated dev-setup validation as step 4
- Renumbered quick tests to step 5
- Calls `pre-commit-dev-setup.sh` for symlink structure validation
- Gracefully skips if script not found

## Validation Rules Enforced

| Rule | Description | Status |
|------|-------------|--------|
| R1 | All .md files in .claude/commands/ must be symlinks | ✅ |
| R2 | All symlinks must resolve to existing files | ✅ |
| R3 | All symlinks must point to templates/commands/ | ✅ |
| R7 | Expected subdirectories (jpspec/, speckit/) must exist | ✅ |

## Test Plan

- [x] `./scripts/bash/pre-commit-dev-setup.sh` passes
- [x] `pytest tests/test_dev_setup_validation.py` passes (11 tests)
- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] DCO sign-off included

## Related

- ADR: docs/adr/ADR-010-dev-setup-validation-architecture.md
- Documentation: scripts/CLAUDE.md
- Closes task-261

🤖 Generated with [Claude Code](https://claude.com/claude-code)