### PR TITLE
ci: add macOS to test matrix (task-168)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,12 @@ jobs:
         run: uv run ruff check .
 
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ['3.11']
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -39,7 +44,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -176,9 +176,9 @@ Run GitHub Actions workflows locally:
 ```
 
 ### Platform Support
-- **Primary platform**: Linux (Ubuntu 22.04/24.04) - fully tested and supported
-- **Portable design**: Script uses POSIX-compliant bash constructs and should work on macOS
-- **Future**: macOS CI matrix testing planned (separate task)
+- **Primary platforms**: Linux (Ubuntu 22.04/24.04) and macOS - both tested in CI
+- **CI Matrix**: GitHub Actions runs tests on ubuntu-latest and macos-latest
+- **Portable design**: Scripts use POSIX-compliant bash constructs
 
 **Script compatibility features**:
 - `#!/usr/bin/env bash` - finds bash via PATH (works on all platforms)


### PR DESCRIPTION
## Summary
- Adds macOS to CI test matrix for cross-platform verification
- Uses fail-fast: false to prevent one platform failure from blocking others
- Documents macOS CI support in scripts/CLAUDE.md

## Task
Closes task-168 - Add macOS CI Matrix Testing

## Acceptance Criteria
- [x] AC1: Add macos-latest to strategy.matrix.os in .github/workflows/ci.yml
- [ ] AC2: Verify run-local-ci.sh passes on macOS runner (pending CI run)
- [ ] AC3: Fix platform-specific issues if any (none expected)
- [x] AC4: Document macOS support in scripts/CLAUDE.md

## Test plan
- [ ] Wait for CI to complete on this PR
- [ ] Verify macOS job passes or investigate failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)