### PR TITLE
feat(security): add permissions.deny rules and tool dependency management

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,20 @@
     "Task",
     "TodoWrite"
   ],
+  "permissions": {
+    "deny": [
+      "Read(.env)",
+      "Read(.env.*)",
+      "Read(./secrets/**)",
+      "Edit(./CLAUDE.md)",
+      "Edit(./memory/constitution.md)",
+      "Edit(./uv.lock)",
+      "Edit(./package-lock.json)",
+      "Bash(sudo *)",
+      "Bash(rm -rf *)",
+      "Bash(sudo rm *)"
+    ]
+  },
   "preferences": {
     "codeStyle": "ruff",
     "testFramework": "pytest",

--- a/src/specify_cli/security/tools/__init__.py
+++ b/src/specify_cli/security/tools/__init__.py
@@ -1,0 +1,30 @@
+"""Tool dependency management for security scanners.
+
+This module provides installation, version management, and caching
+for security scanning tools like Semgrep and CodeQL.
+
+Features:
+- Auto-installation with version pinning
+- License compliance checking (CodeQL)
+- Dependency size monitoring
+- Offline mode for air-gapped environments
+- Cross-platform support (Linux, macOS, Windows)
+"""
+
+from specify_cli.security.tools.manager import ToolManager
+from specify_cli.security.tools.models import (
+    CacheInfo,
+    InstallResult,
+    ToolConfig,
+    ToolInfo,
+    ToolStatus,
+)
+
+__all__ = [
+    "ToolManager",
+    "ToolConfig",
+    "ToolInfo",
+    "ToolStatus",
+    "InstallResult",
+    "CacheInfo",
+]

--- a/src/specify_cli/security/tools/manager.py
+++ b/src/specify_cli/security/tools/manager.py
@@ -1,0 +1,573 @@
+"""Tool dependency manager for security scanners.
+
+This module provides the main ToolManager class for installing,
+managing, and monitoring security scanning tools.
+
+Features:
+- Auto-installation with version pinning
+- License compliance checking (CodeQL)
+- Dependency size monitoring (alert at 500MB)
+- Offline mode for air-gapped environments
+- Cross-platform support
+"""
+
+import logging
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from specify_cli.security.tools.models import (
+    DEFAULT_TOOL_CONFIGS,
+    CacheInfo,
+    InstallMethod,
+    InstallResult,
+    ToolConfig,
+    ToolInfo,
+    ToolStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ToolManager:
+    """Manager for security scanning tool dependencies.
+
+    This class handles:
+    - Tool discovery and installation
+    - Version pinning and updates
+    - License compliance checking
+    - Cache size monitoring
+    - Offline mode operation
+
+    Example:
+        >>> manager = ToolManager()
+        >>> result = manager.install("semgrep")
+        >>> if result.success:
+        ...     print(f"Installed at: {result.tool_info.path}")
+    """
+
+    # Cache size warning threshold in MB
+    CACHE_WARNING_THRESHOLD_MB = 500
+
+    def __init__(
+        self,
+        cache_dir: Path | None = None,
+        offline_mode: bool = False,
+        tool_configs: dict[str, ToolConfig] | None = None,
+    ):
+        """Initialize tool manager.
+
+        Args:
+            cache_dir: Directory to cache tools (default: ~/.specify/tools).
+            offline_mode: If True, only use cached tools, no network access.
+            tool_configs: Custom tool configurations (default: built-in configs).
+        """
+        self.cache_dir = cache_dir or Path.home() / ".specify" / "tools"
+        self.offline_mode = offline_mode
+        self.tool_configs = tool_configs or DEFAULT_TOOL_CONFIGS.copy()
+        self._ensure_cache_dir()
+
+    def _ensure_cache_dir(self) -> None:
+        """Create cache directory if it doesn't exist."""
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def get_tool_info(self, tool_name: str) -> ToolInfo | None:
+        """Get information about an installed tool.
+
+        Args:
+            tool_name: Name of the tool (e.g., "semgrep").
+
+        Returns:
+            ToolInfo if found, None otherwise.
+        """
+        tool_path = self._find_tool(tool_name)
+        if not tool_path:
+            return None
+
+        version = self._get_tool_version(tool_name, tool_path)
+        status = self._determine_status(tool_name, version)
+        install_method = self._detect_install_method(tool_path)
+        size_mb = self._get_size_mb(tool_path)
+
+        return ToolInfo(
+            name=tool_name,
+            version=version,
+            path=tool_path,
+            status=status,
+            install_method=install_method,
+            size_mb=size_mb,
+        )
+
+    def is_available(self, tool_name: str) -> bool:
+        """Check if tool is available for use.
+
+        Args:
+            tool_name: Name of the tool.
+
+        Returns:
+            True if tool is installed and ready.
+        """
+        return self._find_tool(tool_name) is not None
+
+    def install(
+        self,
+        tool_name: str,
+        accept_license: bool = False,
+        force: bool = False,
+    ) -> InstallResult:
+        """Install a security scanning tool.
+
+        Args:
+            tool_name: Name of the tool to install.
+            accept_license: If True, auto-accept license (for CodeQL etc).
+            force: If True, reinstall even if already installed.
+
+        Returns:
+            InstallResult with success status and tool info or error.
+
+        Raises:
+            ValueError: If tool_name is not in configurations.
+        """
+        if tool_name not in self.tool_configs:
+            return InstallResult(
+                success=False,
+                error_message=f"Unknown tool: {tool_name}. Available: {list(self.tool_configs.keys())}",
+            )
+
+        config = self.tool_configs[tool_name]
+
+        # Check if already installed (unless force)
+        if not force:
+            existing = self.get_tool_info(tool_name)
+            if existing and existing.status == ToolStatus.INSTALLED:
+                return InstallResult(success=True, tool_info=existing)
+
+        # Check offline mode
+        if self.offline_mode:
+            cached = self._find_in_cache(tool_name)
+            if cached:
+                return InstallResult(
+                    success=True,
+                    tool_info=ToolInfo(
+                        name=tool_name,
+                        version="cached",
+                        path=cached,
+                        status=ToolStatus.OFFLINE_ONLY,
+                        install_method=InstallMethod.BINARY,
+                    ),
+                )
+            return InstallResult(
+                success=False,
+                error_message=f"Offline mode: {tool_name} not found in cache",
+            )
+
+        # Check license requirement
+        if config.license_check and not accept_license:
+            return InstallResult(
+                success=False,
+                license_required=True,
+                error_message=f"License acceptance required. Review: {config.license_url}",
+            )
+
+        # Install based on method
+        if config.install_method == InstallMethod.PIP:
+            return self._install_pip(config)
+        elif config.install_method == InstallMethod.BINARY:
+            return self._install_binary(config)
+        else:
+            return InstallResult(
+                success=False,
+                error_message=f"Unsupported install method: {config.install_method}",
+            )
+
+    def _install_pip(self, config: ToolConfig) -> InstallResult:
+        """Install tool using pip.
+
+        Args:
+            config: Tool configuration.
+
+        Returns:
+            InstallResult with status.
+        """
+        package = config.pip_package or config.name
+        version_spec = f"=={config.version}" if config.version else ""
+
+        try:
+            cmd = [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                f"{package}{version_spec}",
+            ]
+            logger.info(f"Installing {package}{version_spec}")
+
+            subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=300,  # 5 minute timeout
+                check=True,
+            )
+
+            # Find the installed tool
+            tool_path = self._find_tool(config.name)
+            if not tool_path:
+                return InstallResult(
+                    success=False,
+                    error_message=f"Installed {package} but could not find {config.name} executable",
+                )
+
+            tool_info = self.get_tool_info(config.name)
+            return InstallResult(success=True, tool_info=tool_info)
+
+        except subprocess.CalledProcessError as e:
+            return InstallResult(
+                success=False,
+                error_message=f"pip install failed: {e.stderr}",
+            )
+        except subprocess.TimeoutExpired:
+            return InstallResult(
+                success=False,
+                error_message="Installation timed out after 5 minutes",
+            )
+
+    def _install_binary(self, config: ToolConfig) -> InstallResult:
+        """Install tool by downloading binary.
+
+        Args:
+            config: Tool configuration.
+
+        Returns:
+            InstallResult with status.
+        """
+        platform_key = self._get_platform_key()
+        if platform_key not in config.binary_urls:
+            return InstallResult(
+                success=False,
+                error_message=f"No binary available for platform: {platform_key}",
+            )
+
+        url = config.binary_urls[platform_key].format(version=config.version)
+        dest_dir = self.cache_dir / config.name / config.version
+
+        try:
+            # Download and extract
+            logger.info(f"Downloading {config.name} from {url}")
+            dest_dir.mkdir(parents=True, exist_ok=True)
+
+            # Use curl or wget for download
+            download_path = dest_dir / "download.zip"
+            self._download_file(url, download_path)
+
+            # Extract
+            shutil.unpack_archive(download_path, dest_dir)
+            download_path.unlink()
+
+            # Find executable
+            tool_path = self._find_in_directory(dest_dir, config.name)
+            if not tool_path:
+                return InstallResult(
+                    success=False,
+                    error_message=f"Downloaded but could not find {config.name} executable",
+                )
+
+            # Make executable
+            tool_path.chmod(tool_path.stat().st_mode | 0o755)
+
+            tool_info = ToolInfo(
+                name=config.name,
+                version=config.version or "unknown",
+                path=tool_path,
+                status=ToolStatus.INSTALLED,
+                install_method=InstallMethod.BINARY,
+                size_mb=self._get_size_mb(dest_dir),
+            )
+
+            return InstallResult(success=True, tool_info=tool_info)
+
+        except Exception as e:
+            logger.error(f"Binary install failed: {e}")
+            return InstallResult(
+                success=False,
+                error_message=f"Binary install failed: {e}",
+            )
+
+    def _download_file(self, url: str, dest: Path) -> None:
+        """Download a file from URL.
+
+        Args:
+            url: URL to download.
+            dest: Destination path.
+
+        Raises:
+            RuntimeError: If download fails.
+        """
+        import urllib.request
+
+        try:
+            urllib.request.urlretrieve(url, dest)
+        except Exception as e:
+            raise RuntimeError(f"Download failed: {e}") from e
+
+    def get_cache_info(self) -> CacheInfo:
+        """Get information about the tool cache.
+
+        Returns:
+            CacheInfo with size and tool details.
+        """
+        total_size = 0.0
+        tools = []
+
+        for item in self.cache_dir.iterdir():
+            if item.is_dir():
+                size_mb = self._get_size_mb(item)
+                total_size += size_mb
+                tools.append(
+                    ToolInfo(
+                        name=item.name,
+                        version="cached",
+                        path=item,
+                        status=ToolStatus.INSTALLED,
+                        install_method=InstallMethod.BINARY,
+                        size_mb=size_mb,
+                    )
+                )
+
+        return CacheInfo(
+            cache_dir=self.cache_dir,
+            total_size_mb=total_size,
+            tool_count=len(tools),
+            tools=tools,
+            size_warning=total_size > self.CACHE_WARNING_THRESHOLD_MB,
+            warning_threshold_mb=self.CACHE_WARNING_THRESHOLD_MB,
+        )
+
+    def check_for_updates(self, tool_name: str) -> tuple[bool, str | None]:
+        """Check if a tool has updates available.
+
+        Args:
+            tool_name: Name of the tool.
+
+        Returns:
+            Tuple of (update_available, latest_version).
+        """
+        if tool_name not in self.tool_configs:
+            return (False, None)
+
+        config = self.tool_configs[tool_name]
+        current = self.get_tool_info(tool_name)
+
+        if not current:
+            return (False, None)
+
+        # Compare with configured version
+        if config.version and current.version != config.version:
+            return (True, config.version)
+
+        return (False, None)
+
+    def update_tool(self, tool_name: str) -> InstallResult:
+        """Update a tool to the configured version.
+
+        Args:
+            tool_name: Name of the tool.
+
+        Returns:
+            InstallResult with status.
+        """
+        return self.install(tool_name, accept_license=True, force=True)
+
+    def _find_tool(self, tool_name: str) -> Path | None:
+        """Find tool in search paths.
+
+        Args:
+            tool_name: Name of the tool.
+
+        Returns:
+            Path to executable or None.
+        """
+        # 1. System PATH
+        system_path = shutil.which(tool_name)
+        if system_path:
+            return Path(system_path)
+
+        # 2. Current venv
+        venv_path = self._find_in_venv(tool_name)
+        if venv_path:
+            return venv_path
+
+        # 3. Cache directory
+        cached = self._find_in_cache(tool_name)
+        if cached:
+            return cached
+
+        return None
+
+    def _find_in_venv(self, tool_name: str) -> Path | None:
+        """Find tool in virtual environment.
+
+        Args:
+            tool_name: Name of the tool.
+
+        Returns:
+            Path if found, None otherwise.
+        """
+        venv_dirs = [
+            Path.cwd() / ".venv",
+            Path.cwd() / "venv",
+            Path(sys.prefix),
+        ]
+
+        for venv_dir in venv_dirs:
+            if not venv_dir.exists():
+                continue
+            for bin_dir in ["bin", "Scripts"]:
+                tool_path = venv_dir / bin_dir / tool_name
+                if tool_path.exists():
+                    return tool_path
+        return None
+
+    def _find_in_cache(self, tool_name: str) -> Path | None:
+        """Find tool in cache directory.
+
+        Args:
+            tool_name: Name of the tool.
+
+        Returns:
+            Path if found, None otherwise.
+        """
+        tool_dir = self.cache_dir / tool_name
+        if not tool_dir.exists():
+            return None
+
+        # Find most recent version
+        versions = sorted(tool_dir.iterdir(), reverse=True)
+        for version_dir in versions:
+            if version_dir.is_dir():
+                executable = self._find_in_directory(version_dir, tool_name)
+                if executable:
+                    return executable
+
+        return None
+
+    def _find_in_directory(self, directory: Path, tool_name: str) -> Path | None:
+        """Find executable in directory tree.
+
+        Args:
+            directory: Directory to search.
+            tool_name: Name of the tool.
+
+        Returns:
+            Path to executable or None.
+        """
+        for path in directory.rglob(tool_name):
+            if path.is_file() and os.access(path, os.X_OK):
+                return path
+        for path in directory.rglob(f"{tool_name}.exe"):
+            if path.is_file():
+                return path
+        return None
+
+    def _get_tool_version(self, tool_name: str, tool_path: Path) -> str:
+        """Get version of installed tool.
+
+        Args:
+            tool_name: Name of the tool.
+            tool_path: Path to executable.
+
+        Returns:
+            Version string or "unknown".
+        """
+        try:
+            result = subprocess.run(
+                [str(tool_path), "--version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            # Parse version from output
+            output = result.stdout.strip()
+            if output:
+                # Common patterns: "1.0.0", "tool version 1.0.0", "v1.0.0"
+                parts = output.split()
+                for part in parts:
+                    if part[0].isdigit() or (part.startswith("v") and len(part) > 1):
+                        return part.lstrip("v")
+            return "unknown"
+        except Exception:
+            return "unknown"
+
+    def _determine_status(self, tool_name: str, version: str) -> ToolStatus:
+        """Determine tool status based on version.
+
+        Args:
+            tool_name: Name of the tool.
+            version: Installed version.
+
+        Returns:
+            ToolStatus enum value.
+        """
+        if tool_name not in self.tool_configs:
+            return ToolStatus.INSTALLED
+
+        config = self.tool_configs[tool_name]
+        if config.version and version != config.version:
+            return ToolStatus.UPDATE_AVAILABLE
+
+        return ToolStatus.INSTALLED
+
+    def _detect_install_method(self, tool_path: Path) -> InstallMethod:
+        """Detect how tool was installed.
+
+        Args:
+            tool_path: Path to executable.
+
+        Returns:
+            InstallMethod enum value.
+        """
+        path_str = str(tool_path)
+
+        if self.cache_dir and str(self.cache_dir) in path_str:
+            return InstallMethod.BINARY
+        elif "site-packages" in path_str or ".venv" in path_str or "venv" in path_str:
+            return InstallMethod.PIP
+        else:
+            return InstallMethod.SYSTEM
+
+    def _get_size_mb(self, path: Path) -> float:
+        """Get size of file or directory in MB.
+
+        Args:
+            path: Path to measure.
+
+        Returns:
+            Size in megabytes.
+        """
+        if path.is_file():
+            return path.stat().st_size / (1024 * 1024)
+
+        total = 0
+        for item in path.rglob("*"):
+            if item.is_file():
+                total += item.stat().st_size
+
+        return total / (1024 * 1024)
+
+    def _get_platform_key(self) -> str:
+        """Get platform key for binary downloads.
+
+        Returns:
+            Platform identifier (linux, darwin, win32).
+        """
+        system = platform.system().lower()
+        if system == "linux":
+            return "linux"
+        elif system == "darwin":
+            return "darwin"
+        elif system == "windows":
+            return "win32"
+        return system

--- a/src/specify_cli/security/tools/models.py
+++ b/src/specify_cli/security/tools/models.py
@@ -1,0 +1,145 @@
+"""Data models for tool dependency management.
+
+This module defines the data structures used for managing security
+scanning tool dependencies, including configuration, status, and
+installation results.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+
+class ToolStatus(Enum):
+    """Status of a security scanning tool."""
+
+    NOT_INSTALLED = "not_installed"
+    INSTALLED = "installed"
+    UPDATE_AVAILABLE = "update_available"
+    LICENSE_REQUIRED = "license_required"
+    OFFLINE_ONLY = "offline_only"
+
+
+class InstallMethod(Enum):
+    """Method used to install a tool."""
+
+    PIP = "pip"
+    BINARY = "binary"
+    DOCKER = "docker"
+    SYSTEM = "system"  # Already installed via system package manager
+
+
+@dataclass
+class ToolConfig:
+    """Configuration for a security scanning tool.
+
+    Attributes:
+        name: Tool identifier (e.g., "semgrep", "codeql").
+        version: Pinned version (e.g., "1.45.0") or None for latest.
+        install_method: How to install the tool.
+        license_check: Whether tool requires license acceptance.
+        license_url: URL to license terms if license_check is True.
+        binary_urls: Platform-specific binary download URLs.
+        pip_package: Package name for pip installation.
+        size_estimate_mb: Estimated size in MB for download monitoring.
+    """
+
+    name: str
+    version: str | None = None
+    install_method: InstallMethod = InstallMethod.PIP
+    license_check: bool = False
+    license_url: str | None = None
+    binary_urls: dict[str, str] = field(default_factory=dict)
+    pip_package: str | None = None
+    size_estimate_mb: int = 50
+
+
+@dataclass
+class ToolInfo:
+    """Information about an installed tool.
+
+    Attributes:
+        name: Tool identifier.
+        version: Installed version string.
+        path: Path to executable.
+        status: Current tool status.
+        install_method: How the tool was installed.
+        size_mb: Size of installation in MB.
+    """
+
+    name: str
+    version: str
+    path: Path
+    status: ToolStatus
+    install_method: InstallMethod
+    size_mb: float = 0.0
+
+
+@dataclass
+class InstallResult:
+    """Result of a tool installation attempt.
+
+    Attributes:
+        success: Whether installation succeeded.
+        tool_info: Tool information if successful.
+        error_message: Error message if failed.
+        license_required: Whether user needs to accept license.
+    """
+
+    success: bool
+    tool_info: ToolInfo | None = None
+    error_message: str | None = None
+    license_required: bool = False
+
+
+@dataclass
+class CacheInfo:
+    """Information about the tool cache.
+
+    Attributes:
+        cache_dir: Path to cache directory.
+        total_size_mb: Total size of cached tools in MB.
+        tool_count: Number of cached tools.
+        tools: List of cached tool information.
+        size_warning: True if cache exceeds warning threshold.
+        warning_threshold_mb: Size threshold that triggers warning.
+    """
+
+    cache_dir: Path
+    total_size_mb: float
+    tool_count: int
+    tools: list[ToolInfo]
+    size_warning: bool = False
+    warning_threshold_mb: int = 500
+
+
+# Default tool configurations
+DEFAULT_TOOL_CONFIGS: dict[str, ToolConfig] = {
+    "semgrep": ToolConfig(
+        name="semgrep",
+        version="1.45.0",  # Pinned for reproducibility
+        install_method=InstallMethod.PIP,
+        pip_package="semgrep",
+        size_estimate_mb=100,
+    ),
+    "codeql": ToolConfig(
+        name="codeql",
+        version="2.15.0",
+        install_method=InstallMethod.BINARY,
+        license_check=True,
+        license_url="https://github.com/github/codeql-cli-binaries/blob/main/LICENSE.md",
+        binary_urls={
+            "linux": "https://github.com/github/codeql-cli-binaries/releases/download/v{version}/codeql-linux64.zip",
+            "darwin": "https://github.com/github/codeql-cli-binaries/releases/download/v{version}/codeql-osx64.zip",
+            "win32": "https://github.com/github/codeql-cli-binaries/releases/download/v{version}/codeql-win64.zip",
+        },
+        size_estimate_mb=400,
+    ),
+    "bandit": ToolConfig(
+        name="bandit",
+        version="1.7.7",
+        install_method=InstallMethod.PIP,
+        pip_package="bandit",
+        size_estimate_mb=10,
+    ),
+}

--- a/tests/security/tools/__init__.py
+++ b/tests/security/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for security tool dependency management."""

--- a/tests/security/tools/test_manager.py
+++ b/tests/security/tools/test_manager.py
@@ -1,0 +1,352 @@
+"""Tests for ToolManager class.
+
+Tests tool dependency management including:
+- Tool discovery
+- Auto-installation with version pinning
+- License compliance checking
+- Cache size monitoring
+- Offline mode
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from specify_cli.security.tools.manager import ToolManager
+from specify_cli.security.tools.models import (
+    InstallMethod,
+    ToolConfig,
+    ToolStatus,
+)
+
+
+class TestToolManagerInit:
+    """Test ToolManager initialization."""
+
+    def test_default_cache_dir(self):
+        """Default cache directory is ~/.specify/tools."""
+        manager = ToolManager()
+        assert manager.cache_dir == Path.home() / ".specify" / "tools"
+
+    def test_custom_cache_dir(self, tmp_path):
+        """Custom cache directory is respected."""
+        cache_dir = tmp_path / "custom_cache"
+        manager = ToolManager(cache_dir=cache_dir)
+        assert manager.cache_dir == cache_dir
+        assert cache_dir.exists()
+
+    def test_offline_mode_default(self):
+        """Offline mode is disabled by default."""
+        manager = ToolManager()
+        assert manager.offline_mode is False
+
+    def test_offline_mode_enabled(self, tmp_path):
+        """Offline mode can be enabled."""
+        manager = ToolManager(cache_dir=tmp_path, offline_mode=True)
+        assert manager.offline_mode is True
+
+    def test_default_tool_configs(self):
+        """Default tool configs include expected tools."""
+        manager = ToolManager()
+        assert "semgrep" in manager.tool_configs
+        assert "codeql" in manager.tool_configs
+        assert "bandit" in manager.tool_configs
+
+    def test_custom_tool_configs(self, tmp_path):
+        """Custom tool configs override defaults."""
+        custom_config = {
+            "mytool": ToolConfig(name="mytool", version="1.0.0"),
+        }
+        manager = ToolManager(cache_dir=tmp_path, tool_configs=custom_config)
+        assert "mytool" in manager.tool_configs
+        assert "semgrep" not in manager.tool_configs
+
+
+class TestToolDiscovery:
+    """Test tool discovery functionality."""
+
+    def test_find_tool_in_path(self, tmp_path):
+        """Find tool in system PATH."""
+        manager = ToolManager(cache_dir=tmp_path)
+
+        with patch("shutil.which") as mock_which:
+            mock_which.return_value = "/usr/bin/semgrep"
+            path = manager._find_tool("semgrep")
+            assert path == Path("/usr/bin/semgrep")
+
+    def test_find_tool_not_found(self, tmp_path):
+        """Return None when tool not found anywhere."""
+        manager = ToolManager(cache_dir=tmp_path)
+
+        with patch("shutil.which", return_value=None):
+            path = manager._find_tool("nonexistent")
+            assert path is None
+
+    def test_is_available_true(self, tmp_path):
+        """is_available returns True when tool exists."""
+        manager = ToolManager(cache_dir=tmp_path)
+
+        with patch.object(manager, "_find_tool", return_value=Path("/usr/bin/tool")):
+            assert manager.is_available("tool") is True
+
+    def test_is_available_false(self, tmp_path):
+        """is_available returns False when tool missing."""
+        manager = ToolManager(cache_dir=tmp_path)
+
+        with patch.object(manager, "_find_tool", return_value=None):
+            assert manager.is_available("tool") is False
+
+
+class TestGetToolInfo:
+    """Test getting tool information."""
+
+    def test_get_info_not_installed(self, tmp_path):
+        """Return None for non-installed tool."""
+        manager = ToolManager(cache_dir=tmp_path)
+
+        with patch.object(manager, "_find_tool", return_value=None):
+            info = manager.get_tool_info("nonexistent")
+            assert info is None
+
+    def test_get_info_installed(self, tmp_path):
+        """Return ToolInfo for installed tool."""
+        manager = ToolManager(cache_dir=tmp_path)
+        tool_path = Path("/usr/bin/semgrep")
+
+        with (
+            patch.object(manager, "_find_tool", return_value=tool_path),
+            patch.object(manager, "_get_tool_version", return_value="1.45.0"),
+        ):
+            info = manager.get_tool_info("semgrep")
+            assert info is not None
+            assert info.name == "semgrep"
+            assert info.version == "1.45.0"
+            assert info.path == tool_path
+
+
+class TestInstallation:
+    """Test tool installation."""
+
+    def test_install_unknown_tool(self, tmp_path):
+        """Fail gracefully for unknown tool."""
+        manager = ToolManager(cache_dir=tmp_path)
+        result = manager.install("unknown_tool")
+
+        assert result.success is False
+        assert "Unknown tool" in result.error_message
+
+    def test_install_already_installed(self, tmp_path):
+        """Skip installation if already installed."""
+        manager = ToolManager(cache_dir=tmp_path)
+
+        mock_info = MagicMock()
+        mock_info.status = ToolStatus.INSTALLED
+
+        with patch.object(manager, "get_tool_info", return_value=mock_info):
+            result = manager.install("semgrep")
+            assert result.success is True
+
+    def test_install_offline_mode_not_cached(self, tmp_path):
+        """Fail in offline mode when tool not cached."""
+        manager = ToolManager(cache_dir=tmp_path, offline_mode=True)
+
+        with patch.object(manager, "get_tool_info", return_value=None):
+            result = manager.install("semgrep")
+            assert result.success is False
+            assert "Offline mode" in result.error_message
+
+    def test_install_license_required(self, tmp_path):
+        """Require license acceptance for licensed tools."""
+        manager = ToolManager(cache_dir=tmp_path)
+
+        with patch.object(manager, "get_tool_info", return_value=None):
+            result = manager.install("codeql", accept_license=False)
+            assert result.success is False
+            assert result.license_required is True
+
+    def test_install_license_accepted(self, tmp_path):
+        """Proceed with installation when license accepted."""
+        manager = ToolManager(cache_dir=tmp_path)
+
+        with (
+            patch.object(manager, "get_tool_info", return_value=None),
+            patch.object(
+                manager,
+                "_install_binary",
+                return_value=MagicMock(success=True),
+            ),
+        ):
+            result = manager.install("codeql", accept_license=True)
+            assert result.success is True
+
+
+class TestPipInstallation:
+    """Test pip-based installation."""
+
+    def test_pip_install_success(self, tmp_path):
+        """Successfully install via pip."""
+        manager = ToolManager(cache_dir=tmp_path)
+        config = ToolConfig(
+            name="testtool",
+            version="1.0.0",
+            install_method=InstallMethod.PIP,
+            pip_package="testtool",
+        )
+
+        mock_info = MagicMock()
+        mock_info.name = "testtool"
+
+        with (
+            patch("subprocess.run") as mock_run,
+            patch.object(manager, "_find_tool", return_value=Path("/usr/bin/testtool")),
+            patch.object(manager, "get_tool_info", return_value=mock_info),
+        ):
+            mock_run.return_value = MagicMock(returncode=0)
+            result = manager._install_pip(config)
+            assert result.success is True
+
+    def test_pip_install_failure(self, tmp_path):
+        """Handle pip install failure."""
+        manager = ToolManager(cache_dir=tmp_path)
+        config = ToolConfig(name="testtool", pip_package="testtool")
+
+        import subprocess
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.CalledProcessError(
+                1, "pip", stderr=b"Error"
+            )
+            result = manager._install_pip(config)
+            assert result.success is False
+            assert "pip install failed" in result.error_message
+
+
+class TestCacheManagement:
+    """Test cache management functionality."""
+
+    def test_get_cache_info_empty(self, tmp_path):
+        """Get info for empty cache."""
+        manager = ToolManager(cache_dir=tmp_path)
+        info = manager.get_cache_info()
+
+        assert info.cache_dir == tmp_path
+        assert info.total_size_mb == 0.0
+        assert info.tool_count == 0
+        assert info.size_warning is False
+
+    def test_get_cache_info_with_tools(self, tmp_path):
+        """Get info with cached tools."""
+        manager = ToolManager(cache_dir=tmp_path)
+
+        # Create fake cached tool
+        tool_dir = tmp_path / "semgrep"
+        tool_dir.mkdir()
+        (tool_dir / "binary").write_bytes(b"x" * 1024 * 1024)  # 1MB
+
+        info = manager.get_cache_info()
+        assert info.tool_count == 1
+        assert info.total_size_mb > 0
+
+    def test_cache_size_warning(self, tmp_path):
+        """Warn when cache exceeds threshold."""
+        manager = ToolManager(cache_dir=tmp_path)
+        manager.CACHE_WARNING_THRESHOLD_MB = 1  # Set low for testing
+
+        # Create large cached content
+        tool_dir = tmp_path / "large_tool"
+        tool_dir.mkdir()
+        (tool_dir / "binary").write_bytes(b"x" * 2 * 1024 * 1024)  # 2MB
+
+        info = manager.get_cache_info()
+        assert info.size_warning is True
+
+
+class TestUpdateChecking:
+    """Test tool update checking."""
+
+    def test_check_updates_not_installed(self, tmp_path):
+        """No updates for non-installed tool."""
+        manager = ToolManager(cache_dir=tmp_path)
+
+        with patch.object(manager, "get_tool_info", return_value=None):
+            has_update, version = manager.check_for_updates("semgrep")
+            assert has_update is False
+
+    def test_check_updates_up_to_date(self, tmp_path):
+        """No updates when version matches."""
+        manager = ToolManager(cache_dir=tmp_path)
+
+        mock_info = MagicMock()
+        mock_info.version = "1.45.0"  # Matches default config
+
+        with patch.object(manager, "get_tool_info", return_value=mock_info):
+            has_update, version = manager.check_for_updates("semgrep")
+            assert has_update is False
+
+    def test_check_updates_available(self, tmp_path):
+        """Detect when update is available."""
+        manager = ToolManager(cache_dir=tmp_path)
+
+        mock_info = MagicMock()
+        mock_info.version = "1.40.0"  # Older than config
+
+        with patch.object(manager, "get_tool_info", return_value=mock_info):
+            has_update, version = manager.check_for_updates("semgrep")
+            assert has_update is True
+            assert version == "1.45.0"
+
+
+class TestOfflineMode:
+    """Test offline mode functionality."""
+
+    def test_offline_uses_cache_only(self, tmp_path):
+        """Offline mode only uses cached tools."""
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+
+        # Create cached tool
+        tool_dir = cache_dir / "semgrep" / "1.0.0"
+        tool_dir.mkdir(parents=True)
+        tool_exe = tool_dir / "semgrep"
+        tool_exe.write_text("#!/bin/bash\necho 'semgrep'")
+        tool_exe.chmod(0o755)
+
+        manager = ToolManager(cache_dir=cache_dir, offline_mode=True)
+
+        # Should find in cache even though not in PATH
+        with patch("shutil.which", return_value=None):
+            result = manager.install("semgrep")
+            assert result.success is True
+            assert result.tool_info.status == ToolStatus.OFFLINE_ONLY
+
+    def test_offline_fails_if_not_cached(self, tmp_path):
+        """Offline mode fails for uncached tools."""
+        manager = ToolManager(cache_dir=tmp_path, offline_mode=True)
+
+        result = manager.install("semgrep")
+        assert result.success is False
+        assert "Offline mode" in result.error_message
+
+
+class TestPlatformDetection:
+    """Test cross-platform support."""
+
+    def test_linux_platform(self, tmp_path):
+        """Detect Linux platform."""
+        manager = ToolManager(cache_dir=tmp_path)
+
+        with patch("platform.system", return_value="Linux"):
+            assert manager._get_platform_key() == "linux"
+
+    def test_macos_platform(self, tmp_path):
+        """Detect macOS platform."""
+        manager = ToolManager(cache_dir=tmp_path)
+
+        with patch("platform.system", return_value="Darwin"):
+            assert manager._get_platform_key() == "darwin"
+
+    def test_windows_platform(self, tmp_path):
+        """Detect Windows platform."""
+        manager = ToolManager(cache_dir=tmp_path)
+
+        with patch("platform.system", return_value="Windows"):
+            assert manager._get_platform_key() == "win32"

--- a/tests/security/tools/test_models.py
+++ b/tests/security/tools/test_models.py
@@ -1,0 +1,184 @@
+"""Tests for tool dependency management models."""
+
+from pathlib import Path
+
+from specify_cli.security.tools.models import (
+    DEFAULT_TOOL_CONFIGS,
+    CacheInfo,
+    InstallMethod,
+    InstallResult,
+    ToolConfig,
+    ToolInfo,
+    ToolStatus,
+)
+
+
+class TestToolStatus:
+    """Test ToolStatus enum."""
+
+    def test_all_statuses_defined(self):
+        """All expected statuses are defined."""
+        statuses = [s.value for s in ToolStatus]
+        assert "not_installed" in statuses
+        assert "installed" in statuses
+        assert "update_available" in statuses
+        assert "license_required" in statuses
+        assert "offline_only" in statuses
+
+
+class TestInstallMethod:
+    """Test InstallMethod enum."""
+
+    def test_all_methods_defined(self):
+        """All expected install methods are defined."""
+        methods = [m.value for m in InstallMethod]
+        assert "pip" in methods
+        assert "binary" in methods
+        assert "docker" in methods
+        assert "system" in methods
+
+
+class TestToolConfig:
+    """Test ToolConfig dataclass."""
+
+    def test_minimal_config(self):
+        """Create config with minimal required fields."""
+        config = ToolConfig(name="test")
+        assert config.name == "test"
+        assert config.version is None
+        assert config.install_method == InstallMethod.PIP
+        assert config.license_check is False
+
+    def test_full_config(self):
+        """Create config with all fields."""
+        config = ToolConfig(
+            name="codeql",
+            version="2.15.0",
+            install_method=InstallMethod.BINARY,
+            license_check=True,
+            license_url="https://example.com/license",
+            binary_urls={"linux": "https://example.com/linux.zip"},
+            pip_package="codeql-cli",
+            size_estimate_mb=400,
+        )
+        assert config.name == "codeql"
+        assert config.version == "2.15.0"
+        assert config.install_method == InstallMethod.BINARY
+        assert config.license_check is True
+        assert config.size_estimate_mb == 400
+
+
+class TestToolInfo:
+    """Test ToolInfo dataclass."""
+
+    def test_create_tool_info(self):
+        """Create ToolInfo with all fields."""
+        info = ToolInfo(
+            name="semgrep",
+            version="1.45.0",
+            path=Path("/usr/bin/semgrep"),
+            status=ToolStatus.INSTALLED,
+            install_method=InstallMethod.SYSTEM,
+            size_mb=50.5,
+        )
+        assert info.name == "semgrep"
+        assert info.version == "1.45.0"
+        assert info.path == Path("/usr/bin/semgrep")
+        assert info.status == ToolStatus.INSTALLED
+        assert info.size_mb == 50.5
+
+
+class TestInstallResult:
+    """Test InstallResult dataclass."""
+
+    def test_successful_result(self):
+        """Create successful install result."""
+        info = ToolInfo(
+            name="test",
+            version="1.0",
+            path=Path("/bin/test"),
+            status=ToolStatus.INSTALLED,
+            install_method=InstallMethod.PIP,
+        )
+        result = InstallResult(success=True, tool_info=info)
+        assert result.success is True
+        assert result.tool_info is not None
+        assert result.error_message is None
+
+    def test_failed_result(self):
+        """Create failed install result."""
+        result = InstallResult(
+            success=False,
+            error_message="Installation failed: network error",
+        )
+        assert result.success is False
+        assert result.tool_info is None
+        assert "network error" in result.error_message
+
+    def test_license_required_result(self):
+        """Create license required result."""
+        result = InstallResult(
+            success=False,
+            license_required=True,
+            error_message="License acceptance required",
+        )
+        assert result.success is False
+        assert result.license_required is True
+
+
+class TestCacheInfo:
+    """Test CacheInfo dataclass."""
+
+    def test_empty_cache_info(self):
+        """Create info for empty cache."""
+        info = CacheInfo(
+            cache_dir=Path("/tmp/cache"),
+            total_size_mb=0.0,
+            tool_count=0,
+            tools=[],
+        )
+        assert info.total_size_mb == 0.0
+        assert info.tool_count == 0
+        assert info.size_warning is False
+
+    def test_cache_with_warning(self):
+        """Create info with size warning."""
+        info = CacheInfo(
+            cache_dir=Path("/tmp/cache"),
+            total_size_mb=600.0,
+            tool_count=2,
+            tools=[],
+            size_warning=True,
+            warning_threshold_mb=500,
+        )
+        assert info.size_warning is True
+        assert info.warning_threshold_mb == 500
+
+
+class TestDefaultToolConfigs:
+    """Test default tool configurations."""
+
+    def test_semgrep_config(self):
+        """Semgrep has correct default config."""
+        config = DEFAULT_TOOL_CONFIGS["semgrep"]
+        assert config.name == "semgrep"
+        assert config.install_method == InstallMethod.PIP
+        assert config.pip_package == "semgrep"
+        assert config.version is not None
+
+    def test_codeql_config(self):
+        """CodeQL has correct default config."""
+        config = DEFAULT_TOOL_CONFIGS["codeql"]
+        assert config.name == "codeql"
+        assert config.install_method == InstallMethod.BINARY
+        assert config.license_check is True
+        assert "linux" in config.binary_urls
+        assert "darwin" in config.binary_urls
+        assert "win32" in config.binary_urls
+
+    def test_bandit_config(self):
+        """Bandit has correct default config."""
+        config = DEFAULT_TOOL_CONFIGS["bandit"]
+        assert config.name == "bandit"
+        assert config.install_method == InstallMethod.PIP
+        assert config.pip_package == "bandit"


### PR DESCRIPTION
## Summary

This PR completes three kinsale-assigned tasks in a single wave:

### Task-184: Add permissions.deny Security Rules to settings.json
- Added deny rules for `.env` and `.env.*` files (Read blocked)
- Added deny rules for `secrets/` directory (Read blocked)
- Protected `CLAUDE.md` and `memory/constitution.md` from edits
- Protected lock files (`uv.lock`, `package-lock.json`) from edits
- Blocked dangerous bash commands (`sudo`, `rm -rf`)
- Documented permission rules in `memory/claude-hooks.md`

### Task-249: Implement Tool Dependency Management Module
- Created `src/specify_cli/security/tools/` module with:
  - `models.py`: ToolConfig, ToolInfo, ToolStatus, InstallResult, CacheInfo
  - `manager.py`: ToolManager with full dependency management
- Features:
  - Semgrep auto-installation with version pinning (1.45.0)
  - CodeQL license check and conditional binary download
  - Dependency size monitoring (alert at 500MB threshold)
  - Tool version update mechanism
  - Offline mode for air-gapped environments
  - Cross-platform support (Linux, macOS, Windows)
- 43 unit tests covering all functionality

### Task-085: Local CI Simulation Script
- Verified all ACs already implemented in `scripts/bash/run-local-ci.sh`
- Script supports both direct execution (no Docker) and act mode

## Test plan

- [x] Run `uv run ruff format --check .` - 200 files already formatted
- [x] Run `uv run ruff check .` - All checks passed
- [x] Run `uv run pytest tests/security/tools/ -v` - 43 tests pass
- [x] Run full test suite `uv run pytest tests/ -x -q` - 2342 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)