### PR TITLE
feat(security): Web Security Testing with Playwright DAST (task-222) [v2]

### DIFF
--- a/.claude/commands/jpspec/security_web.md
+++ b/.claude/commands/jpspec/security_web.md
@@ -1,0 +1,1 @@
+../../../templates/commands/jpspec/security_web.md

--- a/.claude/skills/security-dast.md
+++ b/.claude/skills/security-dast.md
@@ -1,0 +1,506 @@
+# Security DAST Skill
+
+## Purpose
+
+This skill enables Claude Code to perform Dynamic Application Security Testing (DAST) on web applications using Playwright. You will crawl web applications, test for OWASP Top 10 vulnerabilities, analyze security headers, and detect common web security issues.
+
+## When to Use This Skill
+
+- When invoked by `/jpspec:security_web` command
+- When user asks to test web application security
+- When analyzing running web applications for vulnerabilities
+
+## Prerequisites
+
+- Target web application is running and accessible
+- Playwright browser automation configured
+- Optional: Authentication credentials for protected areas
+- Optional: Seed URLs for deep crawling
+
+## Input
+
+Target application specified by:
+1. URL from command line: `--url https://example.com`
+2. Configuration file: `.jpspec/security-config.yml` under `dast.target_url`
+3. User prompt when neither is provided
+
+Expected configuration:
+```yaml
+dast:
+  target_url: "https://example.com"
+  max_depth: 3
+  max_pages: 100
+  timeout: 30000
+  auth:
+    type: "form"  # or "bearer", "basic"
+    login_url: "/login"
+    username: "${DAST_USERNAME}"  # Read from env
+    password: "${DAST_PASSWORD}"  # Read from env
+  exclusions:
+    - "/logout"
+    - "/admin/delete"
+    - "*.pdf"
+```
+
+## Web Security Tests
+
+For EACH page discovered during crawling, perform these security checks:
+
+### 1. Security Headers Analysis
+
+Check for essential security headers:
+
+**Required Headers:**
+- `Content-Security-Policy` - Prevents XSS and data injection
+- `X-Frame-Options` - Prevents clickjacking (or frame-ancestors in CSP)
+- `X-Content-Type-Options: nosniff` - Prevents MIME sniffing
+- `Strict-Transport-Security` - Enforces HTTPS
+- `Referrer-Policy` - Controls referrer information
+
+**Report missing or misconfigured headers as findings.**
+
+Example check:
+```python
+response = await page.goto(url)
+headers = response.headers
+
+# Missing CSP
+if "content-security-policy" not in headers:
+    create_finding(
+        title="Missing Content-Security-Policy header",
+        severity="high",
+        cwe_id="CWE-693",
+        description="No CSP header found. Application vulnerable to XSS attacks.",
+        location={"url": url, "header": "Content-Security-Policy"},
+        remediation="Add CSP header: Content-Security-Policy: default-src 'self'"
+    )
+```
+
+### 2. Cookie Security Flags
+
+Inspect all cookies set by the application:
+
+**Required Flags:**
+- `Secure` - Cookie only sent over HTTPS
+- `HttpOnly` - Cookie not accessible via JavaScript (prevents XSS cookie theft)
+- `SameSite` - Protection against CSRF (Strict or Lax)
+
+Example check:
+```python
+cookies = await context.cookies()
+
+for cookie in cookies:
+    if not cookie.get("secure"):
+        create_finding(
+            title=f"Cookie '{cookie['name']}' missing Secure flag",
+            severity="medium",
+            cwe_id="CWE-614",
+            description="Cookie transmitted over unencrypted connections",
+            remediation="Set Secure flag on cookie"
+        )
+
+    if not cookie.get("httpOnly") and "session" in cookie["name"].lower():
+        create_finding(
+            title=f"Session cookie '{cookie['name']}' missing HttpOnly flag",
+            severity="high",
+            cwe_id="CWE-1004",
+            description="Session cookie accessible via JavaScript, vulnerable to XSS theft",
+            remediation="Set HttpOnly flag on session cookies"
+        )
+```
+
+### 3. XSS (Cross-Site Scripting) Detection
+
+Test input fields for reflected and stored XSS:
+
+**Test Payloads:**
+```python
+xss_payloads = [
+    "<script>alert('XSS')</script>",
+    "<img src=x onerror=alert('XSS')>",
+    "javascript:alert('XSS')",
+    "<svg/onload=alert('XSS')>",
+    "'-alert('XSS')-'",
+]
+```
+
+**Test Process:**
+1. Identify all input fields (text inputs, textareas, search boxes)
+2. Submit each payload to each field
+3. Check if payload appears unescaped in response
+4. Check if JavaScript executes (using Playwright event listeners)
+
+Example:
+```python
+# Find all forms
+forms = await page.locator("form").all()
+
+for form in forms:
+    inputs = await form.locator("input[type=text], input[type=search], textarea").all()
+
+    for input_elem in inputs:
+        name = await input_elem.get_attribute("name")
+
+        for payload in xss_payloads:
+            # Fill and submit
+            await input_elem.fill(payload)
+            await form.evaluate("form => form.submit()")
+
+            # Wait for navigation
+            await page.wait_for_load_state()
+
+            # Check if payload appears unescaped
+            content = await page.content()
+            if payload in content:
+                create_finding(
+                    title=f"Reflected XSS in form field '{name}'",
+                    severity="high",
+                    cwe_id="CWE-79",
+                    description=f"Input field '{name}' reflects user input without encoding",
+                    location={"url": page.url, "field": name},
+                    remediation="HTML-encode all user input before rendering"
+                )
+```
+
+### 4. SQL Injection Detection
+
+Test input fields for SQL injection vulnerabilities:
+
+**Test Payloads:**
+```python
+sqli_payloads = [
+    "' OR '1'='1",
+    "admin'--",
+    "' UNION SELECT NULL--",
+    "1' AND '1'='2",
+    "'; DROP TABLE users--",
+]
+```
+
+**Error Signatures:**
+```python
+sql_errors = [
+    "SQL syntax",
+    "mysql_fetch",
+    "ORA-",
+    "PostgreSQL",
+    "ODBC",
+    "Microsoft SQL Server",
+    "SQLite",
+]
+```
+
+**Test Process:**
+1. Submit payloads to input fields
+2. Check response for SQL error messages
+3. Check for behavioral changes (authentication bypass, different responses)
+
+Example:
+```python
+for payload in sqli_payloads:
+    await input_elem.fill(payload)
+    await form.evaluate("form => form.submit()")
+    await page.wait_for_load_state()
+
+    content = await page.content()
+
+    # Check for SQL errors
+    for error_sig in sql_errors:
+        if error_sig.lower() in content.lower():
+            create_finding(
+                title=f"SQL Injection in form field '{name}'",
+                severity="critical",
+                cwe_id="CWE-89",
+                description=f"SQL error message detected after injecting payload",
+                location={"url": page.url, "field": name, "payload": payload},
+                remediation="Use parameterized queries or prepared statements"
+            )
+```
+
+### 5. CSRF (Cross-Site Request Forgery) Detection
+
+Check for CSRF protection on state-changing operations:
+
+**Test Process:**
+1. Identify forms that modify state (POST, PUT, DELETE)
+2. Check for CSRF tokens in forms
+3. Check for CSRF tokens in headers
+4. Verify SameSite cookie attribute
+
+Example:
+```python
+forms = await page.locator("form[method=post], form[method=put]").all()
+
+for form in forms:
+    action = await form.get_attribute("action")
+
+    # Look for CSRF token field
+    csrf_field = await form.locator("input[name*=csrf], input[name*=token]").count()
+
+    if csrf_field == 0:
+        # Check for CSRF token in meta tags
+        csrf_meta = await page.locator("meta[name=csrf-token]").count()
+
+        if csrf_meta == 0:
+            create_finding(
+                title=f"Missing CSRF protection on form",
+                severity="high",
+                cwe_id="CWE-352",
+                description=f"State-changing form lacks CSRF token",
+                location={"url": page.url, "form_action": action},
+                remediation="Add CSRF token to all state-changing forms"
+            )
+```
+
+### 6. Sensitive Data Exposure
+
+Check for sensitive information in responses:
+
+**Sensitive Patterns:**
+```python
+sensitive_patterns = [
+    (r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b', "email addresses"),
+    (r'\b\d{3}-\d{2}-\d{4}\b', "SSN"),
+    (r'\b(?:\d{4}[-\s]?){3}\d{4}\b', "credit card numbers"),
+    (r'password\s*[:=]\s*["\']?[\w@#$%]+', "hardcoded passwords"),
+    (r'api[_-]?key\s*[:=]\s*["\']?[\w-]+', "API keys"),
+    (r'secret\s*[:=]\s*["\']?[\w-]+', "secrets"),
+]
+```
+
+Example:
+```python
+import re
+
+content = await page.content()
+
+for pattern, description in sensitive_patterns:
+    matches = re.findall(pattern, content, re.IGNORECASE)
+
+    if matches:
+        create_finding(
+            title=f"Sensitive data exposure: {description}",
+            severity="medium",
+            cwe_id="CWE-200",
+            description=f"Found {len(matches)} instance(s) of {description} in page content",
+            location={"url": page.url},
+            remediation=f"Remove {description} from client-side code"
+        )
+```
+
+### 7. TLS/SSL Configuration
+
+Test HTTPS configuration:
+
+**Checks:**
+- Redirects HTTP to HTTPS
+- Valid SSL certificate
+- Strong cipher suites
+- TLS 1.2+ (no TLS 1.0/1.1)
+
+Example:
+```python
+# Test HTTP -> HTTPS redirect
+http_url = url.replace("https://", "http://")
+response = await page.goto(http_url)
+
+if response.url.startswith("http://"):
+    create_finding(
+        title="No HTTPS redirect",
+        severity="medium",
+        cwe_id="CWE-319",
+        description="HTTP requests not redirected to HTTPS",
+        location={"url": http_url},
+        remediation="Configure server to redirect all HTTP traffic to HTTPS"
+    )
+```
+
+## Crawling Strategy
+
+Use Playwright to discover pages:
+
+### Breadth-First Crawling
+
+```python
+from collections import deque
+
+visited = set()
+queue = deque([base_url])
+
+while queue and len(visited) < max_pages:
+    url = queue.popleft()
+
+    if url in visited:
+        continue
+
+    visited.add(url)
+
+    # Run security tests on this page
+    await test_page_security(page, url)
+
+    # Extract links
+    links = await page.locator("a[href]").all()
+
+    for link in links:
+        href = await link.get_attribute("href")
+
+        # Resolve relative URLs
+        absolute_url = urljoin(url, href)
+
+        # Skip excluded URLs
+        if should_exclude(absolute_url):
+            continue
+
+        # Stay within domain
+        if urlparse(absolute_url).netloc == urlparse(base_url).netloc:
+            queue.append(absolute_url)
+```
+
+### Authentication Handling
+
+Support multiple authentication methods:
+
+**Form-based:**
+```python
+# Navigate to login page
+await page.goto(login_url)
+
+# Fill credentials
+await page.locator("input[name=username]").fill(username)
+await page.locator("input[name=password]").fill(password)
+
+# Submit form
+await page.locator("button[type=submit]").click()
+await page.wait_for_load_state()
+
+# Save authenticated context
+context_state = await context.storage_state()
+```
+
+**Bearer Token:**
+```python
+# Add Authorization header to all requests
+await context.set_extra_http_headers({
+    "Authorization": f"Bearer {token}"
+})
+```
+
+**Basic Auth:**
+```python
+# Set credentials in browser context
+context = await browser.new_context(
+    http_credentials={"username": username, "password": password}
+)
+```
+
+## Output Format
+
+Write findings to `docs/security/web-findings.json` in Unified Finding Format:
+
+```json
+[
+  {
+    "id": "DAST-XSS-001",
+    "scanner": "playwright-dast",
+    "severity": "high",
+    "title": "Reflected XSS in search parameter",
+    "description": "Search input reflects user data without HTML encoding",
+    "location": {
+      "url": "https://example.com/search",
+      "parameter": "q",
+      "method": "GET"
+    },
+    "cwe_id": "CWE-79",
+    "cvss_score": 7.3,
+    "confidence": "high",
+    "remediation": "HTML-encode all user input before rendering in responses",
+    "references": [
+      "https://owasp.org/www-community/attacks/xss/",
+      "https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html"
+    ],
+    "metadata": {
+      "test_type": "xss",
+      "payload": "<script>alert('XSS')</script>",
+      "timestamp": "2025-12-04T18:30:00Z"
+    }
+  }
+]
+```
+
+Sort findings by severity (critical first), then by URL.
+
+## Rate Limiting and Politeness
+
+- Respect robots.txt (optional, configurable)
+- Add delay between requests: `await page.wait_for_timeout(100)`
+- Limit concurrent requests: max 5 parallel pages
+- Stop on repeated errors (3 consecutive failures)
+
+## Error Handling
+
+**Connection Errors:**
+- Retry up to 3 times with exponential backoff
+- Skip page and continue crawling if timeout
+
+**Authentication Errors:**
+- Fail fast if login fails (don't crawl as unauthenticated)
+- Report authentication failure clearly
+
+**JavaScript Errors:**
+- Log but don't stop (some pages have intentional JS errors)
+
+## Success Criteria
+
+- Crawl all pages within depth limit
+- Test all discovered forms and inputs
+- Check security headers on all pages
+- Generate findings in Unified Finding Format
+- Report summary with vulnerability counts
+- Exit code 0 if no critical findings, 1 if critical vulnerabilities found
+
+## Example Workflow
+
+```bash
+# User runs web security test
+/jpspec:security_web --url https://example.com --crawl
+
+# You execute:
+1. Load configuration from .jpspec/security-config.yml
+2. Launch Playwright browser (headless mode)
+3. Authenticate if credentials provided
+4. Start crawling from base URL
+5. For each page:
+   - Check security headers
+   - Check cookie flags
+   - Test XSS in all inputs
+   - Test SQL injection in all inputs
+   - Check CSRF protection
+   - Scan for sensitive data
+6. Generate findings in UFFormat
+7. Write to docs/security/web-findings.json
+8. Report summary to user
+9. Exit with appropriate code
+```
+
+## Notes
+
+- This is a SKILL, not Python code. You (Claude Code) execute the logic natively.
+- No LLM API calls from Python. All AI reasoning happens in this skill.
+- Python code handles Playwright automation and data structures.
+- Use Playwright Browser tool for web interactions.
+- Apply domain knowledge from `memory/security/web-security-patterns.md`.
+- False positives are common in DAST - use conservative classification.
+
+## Integration with Triage
+
+After web scan, findings can be triaged:
+
+```bash
+# Run web scan
+/jpspec:security_web --url https://example.com
+
+# Triage findings
+/jpspec:security_triage --input docs/security/web-findings.json
+```
+
+The triage skill will classify DAST findings as TP/FP/NI and generate remediation guidance.

--- a/memory/security/web-security-patterns.md
+++ b/memory/security/web-security-patterns.md
@@ -1,0 +1,644 @@
+# Web Security Patterns
+
+This document contains web security knowledge for AI tools performing DAST (Dynamic Application Security Testing) using Playwright.
+
+## OWASP Top 10 Web Vulnerabilities
+
+### 1. Cross-Site Scripting (XSS) - CWE-79
+
+**Description:** Untrusted data sent to web browser without validation/escaping, allowing attackers to execute malicious scripts.
+
+**Types:**
+- **Reflected XSS:** Payload in URL/form echoed back immediately
+- **Stored XSS:** Payload saved in database, rendered later
+- **DOM-based XSS:** Vulnerability in client-side JavaScript
+
+**Test Payloads:**
+```javascript
+// Basic script tag
+<script>alert('XSS')</script>
+
+// Image with error handler
+<img src=x onerror=alert('XSS')>
+
+// SVG with onload
+<svg/onload=alert('XSS')>
+
+// JavaScript protocol
+javascript:alert('XSS')
+
+// Event handler in attribute
+<input onfocus=alert('XSS') autofocus>
+
+// String breaking
+'-alert('XSS')-'
+"-alert('XSS')-"
+
+// HTML entity encoding bypass
+&lt;script&gt;alert('XSS')&lt;/script&gt;
+
+// Template literal
+${alert('XSS')}
+
+// Polyglot payload
+jaVasCript:/*-/*`/*\`/*'/*"/**/(/* */onerror=alert('XSS') )//%0D%0A%0d%0a//</stYle/</titLe/</teXtarEa/</scRipt/--!>\x3csVg/<sVg/oNloAd=alert('XSS')//>\x3e
+```
+
+**Detection:**
+- Submit payload to input field
+- Check if payload appears unescaped in response HTML
+- Check if JavaScript executes (dialog appears, DOM mutation)
+- Look for reflected user input in `<script>` tags, event handlers, URLs
+
+**Remediation:**
+- HTML-encode output: `&lt;` for `<`, `&gt;` for `>`, `&quot;` for `"`
+- Use Content-Security-Policy header
+- Use framework auto-escaping (React, Vue, Angular)
+- Validate input against allowlist
+
+**References:**
+- [OWASP XSS Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+- [PortSwigger XSS](https://portswigger.net/web-security/cross-site-scripting)
+
+---
+
+### 2. SQL Injection (SQLi) - CWE-89
+
+**Description:** Attacker inserts malicious SQL code into queries, potentially reading/modifying database data.
+
+**Test Payloads:**
+```sql
+-- Authentication bypass
+' OR '1'='1
+' OR 1=1--
+admin'--
+admin' #
+
+-- UNION-based extraction
+' UNION SELECT NULL--
+' UNION SELECT NULL, NULL--
+' UNION SELECT username, password FROM users--
+
+-- Boolean-based blind
+' AND '1'='1
+' AND '1'='2
+
+-- Time-based blind
+'; WAITFOR DELAY '00:00:05'--
+'; SELECT SLEEP(5)--
+'; pg_sleep(5)--
+
+-- Stacked queries
+'; DROP TABLE users--
+'; INSERT INTO users VALUES ('hacker', 'password')--
+
+-- Error-based
+' AND 1=CONVERT(int, (SELECT @@version))--
+```
+
+**Detection:**
+- Submit payload to input field
+- Look for SQL error messages in response
+- Check for behavioral changes (authentication bypass, different data)
+- Monitor response time (time-based blind SQLi)
+
+**SQL Error Signatures:**
+```
+SQL syntax error
+mysql_fetch_array()
+mysql_num_rows()
+ORA-01756: quoted string not properly terminated
+PostgreSQL query failed
+ODBC SQL Server Driver
+Microsoft OLE DB Provider for SQL Server
+Unclosed quotation mark
+SQLite3::SQLException
+```
+
+**Remediation:**
+- Use parameterized queries (prepared statements)
+- Never concatenate user input into SQL
+- Use ORM with parameterization (SQLAlchemy, Hibernate)
+- Escape special characters if parameterization not possible
+- Principle of least privilege (limited DB permissions)
+
+**References:**
+- [OWASP SQL Injection Prevention](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html)
+- [PortSwigger SQL Injection](https://portswigger.net/web-security/sql-injection)
+
+---
+
+### 3. Cross-Site Request Forgery (CSRF) - CWE-352
+
+**Description:** Attacker tricks victim into submitting state-changing request using victim's authentication.
+
+**Detection:**
+- Find forms that modify state (POST, PUT, DELETE)
+- Check for CSRF token in hidden input field
+- Check for CSRF token in request headers
+- Verify SameSite cookie attribute
+
+**CSRF Token Patterns:**
+```html
+<!-- Hidden input field -->
+<input type="hidden" name="csrf_token" value="...">
+<input type="hidden" name="_token" value="...">
+<input type="hidden" name="authenticity_token" value="...">
+
+<!-- Meta tag -->
+<meta name="csrf-token" content="...">
+
+<!-- Header -->
+X-CSRF-Token: ...
+X-XSRF-Token: ...
+```
+
+**Remediation:**
+- Use anti-CSRF tokens (synchronizer token pattern)
+- Set SameSite cookie attribute (Strict or Lax)
+- Verify Origin/Referer headers
+- Require re-authentication for sensitive actions
+- Use custom headers (AJAX requests)
+
+**References:**
+- [OWASP CSRF Prevention](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html)
+
+---
+
+### 4. Security Headers - CWE-693
+
+**Description:** Missing HTTP security headers expose application to attacks.
+
+**Required Headers:**
+
+#### Content-Security-Policy (CSP)
+Prevents XSS by restricting resource sources.
+
+**Good Examples:**
+```
+Content-Security-Policy: default-src 'self'; script-src 'self' https://trusted.cdn.com; object-src 'none'
+```
+
+**Bad Examples:**
+```
+Content-Security-Policy: default-src *  # Too permissive
+Content-Security-Policy: script-src 'unsafe-inline'  # Allows inline scripts
+```
+
+**Detection:** Header missing or contains `'unsafe-inline'`, `'unsafe-eval'`, or `*`
+
+---
+
+#### X-Frame-Options / frame-ancestors
+Prevents clickjacking attacks.
+
+**Good Examples:**
+```
+X-Frame-Options: DENY
+X-Frame-Options: SAMEORIGIN
+Content-Security-Policy: frame-ancestors 'none'
+Content-Security-Policy: frame-ancestors 'self'
+```
+
+**Detection:** Both headers missing
+
+---
+
+#### X-Content-Type-Options
+Prevents MIME-sniffing attacks.
+
+**Good Example:**
+```
+X-Content-Type-Options: nosniff
+```
+
+**Detection:** Header missing
+
+---
+
+#### Strict-Transport-Security (HSTS)
+Forces HTTPS connections.
+
+**Good Example:**
+```
+Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+```
+
+**Detection:** Header missing on HTTPS responses
+
+---
+
+#### Referrer-Policy
+Controls referrer information leakage.
+
+**Good Examples:**
+```
+Referrer-Policy: no-referrer
+Referrer-Policy: strict-origin-when-cross-origin
+```
+
+**Bad Example:**
+```
+Referrer-Policy: unsafe-url  # Leaks full URL
+```
+
+**Detection:** Header missing or set to `unsafe-url`
+
+---
+
+#### X-XSS-Protection
+Legacy XSS filter (deprecated, CSP preferred).
+
+**Good Example:**
+```
+X-XSS-Protection: 0  # Disable (use CSP instead)
+```
+
+**Note:** Can cause security issues in older browsers. Use CSP instead.
+
+---
+
+### 5. Cookie Security - CWE-614, CWE-1004
+
+**Description:** Insecure cookie configuration allows theft or tampering.
+
+**Required Flags:**
+
+#### Secure Flag
+Ensures cookie only sent over HTTPS.
+
+**Detection:** Cookie without `Secure` flag on HTTPS site
+
+---
+
+#### HttpOnly Flag
+Prevents JavaScript access to cookie (XSS mitigation).
+
+**Detection:** Session/auth cookie without `HttpOnly` flag
+
+---
+
+#### SameSite Flag
+Protects against CSRF attacks.
+
+**Values:**
+- `Strict` - Cookie never sent in cross-site requests (strongest)
+- `Lax` - Cookie sent on top-level navigation (GET only)
+- `None` - Cookie sent in all cross-site requests (requires `Secure`)
+
+**Detection:** Session/auth cookie without `SameSite` attribute
+
+---
+
+**Example Secure Cookie:**
+```
+Set-Cookie: session_id=abc123; Secure; HttpOnly; SameSite=Strict; Path=/; Max-Age=3600
+```
+
+**References:**
+- [OWASP Session Management](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html)
+
+---
+
+### 6. Sensitive Data Exposure - CWE-200
+
+**Description:** Application exposes sensitive information in client-side code, URLs, or error messages.
+
+**Sensitive Data Patterns:**
+
+```python
+# Email addresses
+r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b'
+
+# Social Security Numbers
+r'\b\d{3}-\d{2}-\d{4}\b'
+
+# Credit card numbers
+r'\b(?:\d{4}[-\s]?){3}\d{4}\b'
+
+# Phone numbers
+r'\b\d{3}[-.]?\d{3}[-.]?\d{4}\b'
+
+# API keys
+r'api[_-]?key\s*[:=]\s*["\']?[\w-]{20,}["\']?'
+
+# AWS keys
+r'AKIA[0-9A-Z]{16}'
+
+# GitHub tokens
+r'gh[pousr]_[0-9a-zA-Z]{36}'
+
+# Private keys
+r'-----BEGIN (RSA|DSA|EC|OPENSSH) PRIVATE KEY-----'
+
+# Hardcoded passwords
+r'password\s*[:=]\s*["\']?[\w@#$%^&*!]{8,}["\']?'
+
+# JWT tokens
+r'eyJ[A-Za-z0-9-_=]+\.eyJ[A-Za-z0-9-_=]+\.[A-Za-z0-9-_.+/=]*'
+
+# Internal IPs
+r'\b10\.\d{1,3}\.\d{1,3}\.\d{1,3}\b'
+r'\b172\.(1[6-9]|2[0-9]|3[01])\.\d{1,3}\.\d{1,3}\b'
+r'\b192\.168\.\d{1,3}\.\d{1,3}\b'
+
+# Database connection strings
+r'(mongodb|mysql|postgresql|postgres)://[^\s<>"{}|\\^`\[\]]*'
+```
+
+**Detection:**
+- Search response body for sensitive patterns
+- Check JavaScript files for hardcoded secrets
+- Check HTML comments for sensitive info
+- Check error messages for stack traces, paths
+
+**Remediation:**
+- Remove sensitive data from client-side code
+- Use server-side sessions, not client-side tokens
+- Redact sensitive data in logs and errors
+- Use environment variables for secrets
+
+---
+
+### 7. TLS/SSL Configuration - CWE-319
+
+**Description:** Weak HTTPS configuration allows downgrade or interception attacks.
+
+**Security Checks:**
+
+#### HTTP to HTTPS Redirect
+**Test:** Visit `http://` version of site
+**Expected:** Redirect to `https://` (301/302)
+**Finding if:** No redirect (stays on HTTP)
+
+---
+
+#### Valid Certificate
+**Test:** Check SSL certificate
+**Expected:** Valid, trusted CA, not expired, correct hostname
+**Finding if:** Self-signed, expired, hostname mismatch
+
+---
+
+#### Strong Cipher Suites
+**Test:** SSL/TLS scan (requires external tool)
+**Expected:** TLS 1.2+, strong ciphers only
+**Finding if:** TLS 1.0/1.1 enabled, weak ciphers (RC4, DES, MD5)
+
+---
+
+#### HSTS Header
+**Test:** Check HTTPS response headers
+**Expected:** `Strict-Transport-Security` header present
+**Finding if:** Header missing
+
+---
+
+**Remediation:**
+- Force HTTPS redirect (server configuration)
+- Obtain valid certificate (Let's Encrypt)
+- Disable TLS 1.0/1.1, enable TLS 1.2+
+- Use strong cipher suites only
+- Add HSTS header with long max-age
+
+**References:**
+- [Mozilla SSL Configuration Generator](https://ssl-config.mozilla.org/)
+- [Qualys SSL Labs Test](https://www.ssllabs.com/ssltest/)
+
+---
+
+## Playwright Security Testing Patterns
+
+### Authentication State Management
+
+**Save authenticated session:**
+```python
+# After successful login
+await context.storage_state(path=".jpspec/.dast-session.json")
+
+# Reuse session in new context
+context = await browser.new_context(storage_state=".jpspec/.dast-session.json")
+```
+
+---
+
+### XSS Detection with Playwright
+
+**Method 1: Dialog Detection**
+```python
+# Listen for alert() dialogs
+dialog_triggered = False
+
+async def handle_dialog(dialog):
+    global dialog_triggered
+    dialog_triggered = True
+    await dialog.dismiss()
+
+page.on("dialog", handle_dialog)
+
+# Submit XSS payload
+await input_elem.fill("<script>alert('XSS')</script>")
+await form.evaluate("form => form.submit()")
+await page.wait_for_load_state()
+
+if dialog_triggered:
+    # XSS confirmed
+    pass
+```
+
+**Method 2: Response Content Inspection**
+```python
+# Check if payload appears unescaped
+payload = "<script>alert('XSS')</script>"
+await input_elem.fill(payload)
+await form.evaluate("form => form.submit()")
+await page.wait_for_load_state()
+
+content = await page.content()
+
+# Check for unescaped payload (bad)
+if payload in content:
+    # Likely XSS
+    pass
+
+# Check for escaped payload (good)
+if "&lt;script&gt;" in content:
+    # Properly escaped
+    pass
+```
+
+---
+
+### SQL Injection Detection
+
+**Method 1: Error Message Detection**
+```python
+payload = "' OR '1'='1"
+await input_elem.fill(payload)
+await form.evaluate("form => form.submit()")
+await page.wait_for_load_state()
+
+content = await page.content().lower()
+
+# SQL error signatures
+sql_errors = [
+    "sql syntax",
+    "mysql_fetch",
+    "ora-",
+    "postgresql",
+    "sqlite3",
+    "odbc",
+    "unclosed quotation",
+]
+
+for error in sql_errors:
+    if error in content:
+        # SQL injection confirmed
+        pass
+```
+
+**Method 2: Behavioral Analysis**
+```python
+# Test authentication bypass
+await page.locator("input[name=username]").fill("admin' OR '1'='1'--")
+await page.locator("input[name=password]").fill("anything")
+await page.locator("button[type=submit]").click()
+await page.wait_for_load_state()
+
+# Check if login succeeded
+if "logout" in await page.content().lower():
+    # Authentication bypass (SQL injection)
+    pass
+```
+
+---
+
+### Form Discovery and Testing
+
+**Find all forms:**
+```python
+forms = await page.locator("form").all()
+
+for form in forms:
+    # Get form details
+    action = await form.get_attribute("action")
+    method = await form.get_attribute("method") or "GET"
+
+    # Find inputs
+    inputs = await form.locator("input:not([type=hidden]):not([type=submit]), textarea").all()
+
+    for input_elem in inputs:
+        input_type = await input_elem.get_attribute("type") or "text"
+        name = await input_elem.get_attribute("name")
+
+        # Test input with payloads
+        await test_input(input_elem, name, payloads)
+```
+
+---
+
+### Rate Limiting and Politeness
+
+```python
+import asyncio
+
+# Add delay between requests
+await asyncio.sleep(0.1)  # 100ms delay
+
+# Limit concurrent pages
+semaphore = asyncio.Semaphore(5)  # Max 5 concurrent
+
+async def test_page(url):
+    async with semaphore:
+        page = await context.new_page()
+        # Test page
+        await page.close()
+```
+
+---
+
+## CVSS Scoring for Web Vulnerabilities
+
+### XSS - Reflected
+- **CVSS:** 6.1-7.3 (Medium-High)
+- **Vector:** CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+- **Severity:** High
+
+### XSS - Stored
+- **CVSS:** 7.3-9.0 (High-Critical)
+- **Vector:** CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
+- **Severity:** High to Critical
+
+### SQL Injection
+- **CVSS:** 9.8 (Critical)
+- **Vector:** CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+- **Severity:** Critical
+
+### CSRF
+- **CVSS:** 6.5-8.1 (Medium-High)
+- **Vector:** CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N
+- **Severity:** High
+
+### Missing CSP
+- **CVSS:** 5.3 (Medium)
+- **Severity:** Medium
+
+### Insecure Cookie
+- **CVSS:** 4.3-6.5 (Medium)
+- **Severity:** Medium
+
+---
+
+## False Positive Patterns
+
+**Common False Positives in DAST:**
+
+1. **XSS in non-HTML contexts:**
+   - JSON responses (Content-Type: application/json)
+   - PDF downloads
+   - Images, CSS, JavaScript files
+
+2. **SQL errors in non-user input:**
+   - Admin panels with intentional SQL interfaces
+   - Database management tools
+   - Error pages showing SQL for debugging
+
+3. **CSRF on read-only operations:**
+   - GET requests that don't modify state
+   - Public APIs without authentication
+
+4. **Missing headers on static assets:**
+   - CSP on images, CSS, JS files
+   - HSTS on HTTP-only assets
+
+**Validation Before Reporting:**
+- Check Content-Type header (only test HTML responses)
+- Verify input actually flows to dangerous sink
+- Confirm state change occurs (for CSRF)
+- Check if finding is in scope (not third-party CDN)
+
+---
+
+## References
+
+### OWASP Resources
+- [OWASP Top 10 2021](https://owasp.org/Top10/)
+- [OWASP Testing Guide](https://owasp.org/www-project-web-security-testing-guide/)
+- [OWASP Cheat Sheet Series](https://cheatsheetseries.owasp.org/)
+
+### CWE References
+- [CWE-79: Cross-site Scripting](https://cwe.mitre.org/data/definitions/79.html)
+- [CWE-89: SQL Injection](https://cwe.mitre.org/data/definitions/89.html)
+- [CWE-352: CSRF](https://cwe.mitre.org/data/definitions/352.html)
+- [CWE-693: Protection Mechanism Failure](https://cwe.mitre.org/data/definitions/693.html)
+
+### Tools
+- [Playwright](https://playwright.dev/) - Browser automation
+- [OWASP ZAP](https://www.zaproxy.org/) - Web app scanner
+- [Burp Suite](https://portswigger.net/burp) - Security testing platform
+
+---
+
+## Version History
+
+- v0.0.251: Initial web security patterns document

--- a/templates/commands/jpspec/security_web.md
+++ b/templates/commands/jpspec/security_web.md
@@ -1,0 +1,420 @@
+# /jpspec:security_web
+
+Test web applications for security vulnerabilities using dynamic analysis with Playwright.
+
+## Purpose
+
+This command performs Dynamic Application Security Testing (DAST) on running web applications:
+- Automated crawling of web pages
+- OWASP Top 10 vulnerability detection
+- Security header and cookie analysis
+- Authenticated crawling support
+- Findings in Unified Finding Format
+
+## Prerequisites
+
+- Target web application is running and accessible
+- Playwright browser automation available
+- Network access to target URL
+- Optional: Authentication credentials for protected areas
+
+## Workflow
+
+### 1. Load Configuration
+
+Read security configuration for DAST settings:
+
+```bash
+# Check if config exists
+if [ -f .jpspec/security-config.yml ]; then
+    echo "Using DAST configuration from .jpspec/security-config.yml"
+else
+    echo "No DAST configuration found. Using defaults."
+fi
+```
+
+**Configuration Parameters:**
+- `dast.target_url` - Base URL to test
+- `dast.max_depth` - Maximum crawl depth (default: 3)
+- `dast.max_pages` - Maximum pages to crawl (default: 100)
+- `dast.timeout` - Page load timeout in ms (default: 30000)
+- `dast.auth.type` - Authentication method: `form`, `bearer`, `basic`
+- `dast.auth.login_url` - Login page URL (for form auth)
+- `dast.auth.username` - Username (read from env: `${DAST_USERNAME}`)
+- `dast.auth.password` - Password (read from env: `${DAST_PASSWORD}`)
+- `dast.exclusions` - URLs to skip (e.g., logout, delete endpoints)
+
+### 2. Validate Target URL
+
+Ensure target is accessible before scanning:
+
+```bash
+# Get target URL from CLI arg or config
+TARGET_URL="${1:-$(yq '.dast.target_url' .jpspec/security-config.yml 2>/dev/null)}"
+
+if [ -z "$TARGET_URL" ]; then
+    echo "ERROR: No target URL specified. Use --url or set dast.target_url in config."
+    exit 1
+fi
+
+# Validate URL format
+if ! [[ "$TARGET_URL" =~ ^https?:// ]]; then
+    echo "ERROR: Invalid URL format. Must start with http:// or https://"
+    exit 1
+fi
+
+# Test connectivity
+if ! curl -s --head --max-time 10 "$TARGET_URL" > /dev/null 2>&1; then
+    echo "ERROR: Cannot reach target URL: $TARGET_URL"
+    exit 1
+fi
+
+echo "Target URL: $TARGET_URL"
+```
+
+### 3. Initialize Playwright
+
+Set up browser automation for testing:
+
+```python
+from playwright.async_api import async_playwright
+
+# Launch browser (headless for CI/CD)
+playwright = await async_playwright().start()
+browser = await playwright.chromium.launch(headless=True)
+
+# Create browser context
+context = await browser.new_context(
+    viewport={"width": 1920, "height": 1080},
+    user_agent="JpSpecKit-DAST-Scanner/1.0",
+    ignore_https_errors=False,  # Fail on invalid certs
+)
+
+# Create page
+page = await context.new_page()
+```
+
+### 4. Authenticate (If Configured)
+
+Handle authentication before crawling:
+
+**Form-based Authentication:**
+```python
+if auth_type == "form":
+    # Navigate to login page
+    await page.goto(f"{base_url}{login_url}")
+
+    # Fill credentials
+    await page.locator("input[name=username], input[name=email]").fill(username)
+    await page.locator("input[name=password]").fill(password)
+
+    # Submit form
+    await page.locator("button[type=submit], input[type=submit]").click()
+    await page.wait_for_load_state("networkidle")
+
+    # Verify authentication succeeded
+    if "login" in page.url.lower():
+        raise ValueError("Authentication failed - still on login page")
+
+    # Save authenticated session
+    await context.storage_state(path=".jpspec/.dast-session.json")
+    print("Authentication successful")
+```
+
+**Bearer Token Authentication:**
+```python
+elif auth_type == "bearer":
+    # Add Authorization header to all requests
+    await context.set_extra_http_headers({
+        "Authorization": f"Bearer {token}"
+    })
+```
+
+**Basic Authentication:**
+```python
+elif auth_type == "basic":
+    # Recreate context with credentials
+    context = await browser.new_context(
+        http_credentials={"username": username, "password": password}
+    )
+    page = await context.new_page()
+```
+
+### 5. Invoke Security DAST Skill
+
+Use the `security-dast` skill to crawl and test the application:
+
+**Crawling Process:**
+
+For each page discovered:
+
+1. **Navigate to page:**
+   ```python
+   response = await page.goto(url, wait_until="networkidle")
+   ```
+
+2. **Run security checks:**
+   - Check security headers (CSP, X-Frame-Options, HSTS, etc.)
+   - Analyze cookies (Secure, HttpOnly, SameSite flags)
+   - Test XSS in all input fields
+   - Test SQL injection in all input fields
+   - Check CSRF protection on forms
+   - Scan for sensitive data exposure
+
+3. **Extract links:**
+   ```python
+   links = await page.locator("a[href]").evaluate_all(
+       "elements => elements.map(el => el.href)"
+   )
+
+   # Filter to same domain
+   internal_links = [
+       link for link in links
+       if urlparse(link).netloc == urlparse(base_url).netloc
+   ]
+   ```
+
+4. **Add to crawl queue:**
+   ```python
+   for link in internal_links:
+       if link not in visited and link not in queue:
+           if not should_exclude(link, exclusions):
+               queue.append(link)
+   ```
+
+**Progress Reporting:**
+```bash
+echo "Crawling $TARGET_URL..."
+echo "Max depth: $MAX_DEPTH, Max pages: $MAX_PAGES"
+echo ""
+
+# Show progress during crawl
+# Pages crawled: 42/100 | Findings: 8 (3 critical, 2 high, 3 medium)
+```
+
+### 6. Generate Security Findings
+
+Create findings in Unified Finding Format for each vulnerability:
+
+**Finding Structure:**
+```python
+finding = {
+    "id": f"DAST-{test_type.upper()}-{counter:03d}",
+    "scanner": "playwright-dast",
+    "severity": severity,  # critical, high, medium, low
+    "title": title,
+    "description": description,
+    "location": {
+        "url": url,
+        "parameter": parameter,  # if applicable
+        "method": method,  # GET, POST, etc.
+    },
+    "cwe_id": cwe_id,
+    "cvss_score": cvss_score,
+    "confidence": "high",  # DAST findings are high confidence
+    "remediation": remediation,
+    "references": references,
+    "metadata": {
+        "test_type": test_type,
+        "payload": payload,  # if applicable
+        "timestamp": datetime.now().isoformat(),
+    }
+}
+```
+
+**CWE Mapping:**
+- XSS: CWE-79
+- SQL Injection: CWE-89
+- CSRF: CWE-352
+- Missing CSP: CWE-693
+- Insecure Cookies: CWE-614, CWE-1004
+- Sensitive Data Exposure: CWE-200
+- Missing HTTPS: CWE-319
+
+### 7. Save Findings
+
+Write findings to `docs/security/web-findings.json`:
+
+```bash
+# Create output directory if needed
+mkdir -p docs/security
+
+# Save findings
+echo "Saving findings to docs/security/web-findings.json"
+# Python code writes findings to file
+```
+
+### 8. Generate Report
+
+Create summary report and display to user:
+
+```bash
+# Generate report
+TOTAL=$(jq 'length' docs/security/web-findings.json)
+CRITICAL=$(jq '[.[] | select(.severity=="critical")] | length' docs/security/web-findings.json)
+HIGH=$(jq '[.[] | select(.severity=="high")] | length' docs/security/web-findings.json)
+MEDIUM=$(jq '[.[] | select(.severity=="medium")] | length' docs/security/web-findings.json)
+LOW=$(jq '[.[] | select(.severity=="low")] | length' docs/security/web-findings.json)
+
+echo "
+Web Security Scan Complete
+===========================
+Target: $TARGET_URL
+Pages Crawled: $PAGES_CRAWLED
+Total Findings: $TOTAL
+
+Severity Breakdown:
+  Critical: $CRITICAL
+  High: $HIGH
+  Medium: $MEDIUM
+  Low: $LOW
+
+Findings saved to: docs/security/web-findings.json
+
+Next Steps:
+1. Review findings: cat docs/security/web-findings.json | jq
+2. Triage findings: /jpspec:security_triage --input docs/security/web-findings.json
+3. Generate report: /jpspec:security_report
+"
+
+# Exit with failure if critical findings
+if [ "$CRITICAL" -gt 0 ]; then
+    echo "ERROR: Critical vulnerabilities found!"
+    exit 1
+fi
+```
+
+### 9. Cleanup
+
+Close browser and cleanup temporary files:
+
+```python
+# Close browser
+await browser.close()
+await playwright.stop()
+
+# Remove session file (contains credentials)
+if os.path.exists(".jpspec/.dast-session.json"):
+    os.remove(".jpspec/.dast-session.json")
+```
+
+## Command Options
+
+```bash
+/jpspec:security_web [OPTIONS]
+
+Options:
+  --url URL                  Target URL to scan (required if not in config)
+  --crawl                    Enable crawling (default: single page only)
+  --max-depth N              Maximum crawl depth (default: 3)
+  --max-pages N              Maximum pages to crawl (default: 100)
+  --auth-type TYPE           Authentication: form, bearer, basic
+  --username USER            Username for authentication
+  --password PASS            Password for authentication
+  --login-url URL            Login page URL (for form auth)
+  --output FILE              Output file (default: docs/security/web-findings.json)
+  --timeout MS               Page load timeout in milliseconds (default: 30000)
+  --exclude PATTERN          URL patterns to exclude (can be repeated)
+  --headful                  Show browser window (for debugging)
+```
+
+## Example Usage
+
+```bash
+# Scan single page
+/jpspec:security_web --url https://example.com
+
+# Crawl entire site
+/jpspec:security_web --url https://example.com --crawl --max-pages 200
+
+# Authenticated scan
+/jpspec:security_web \
+  --url https://example.com \
+  --crawl \
+  --auth-type form \
+  --login-url /login \
+  --username admin \
+  --password $ADMIN_PASSWORD
+
+# Scan with exclusions
+/jpspec:security_web \
+  --url https://example.com \
+  --crawl \
+  --exclude "/logout" \
+  --exclude "/admin/delete*" \
+  --exclude "*.pdf"
+```
+
+## Integration with Backlog
+
+After web scan, findings can be converted to backlog tasks:
+
+```bash
+# For each critical/high finding:
+backlog task create "Fix [finding title]" \
+  -d "[finding description]" \
+  --ac "Implement remediation per web scan report" \
+  --ac "Verify fix with re-scan" \
+  --ac "Update security tests if needed" \
+  -l security,web,bug \
+  --priority high
+
+# Add web scan report reference
+backlog task edit [task-id] --notes "See web scan: docs/security/web-findings.json"
+```
+
+## Security Considerations
+
+**Rate Limiting:**
+- Add delays between requests to avoid overwhelming target
+- Respect robots.txt (configurable)
+- Limit concurrent requests (max 5 parallel pages)
+
+**Scope Boundaries:**
+- Only crawl within target domain (no external links)
+- Respect exclusion patterns (don't crawl /logout, delete endpoints)
+- Stop on repeated errors (don't hammer broken endpoints)
+
+**Credential Safety:**
+- Never log credentials (username, password, tokens)
+- Use environment variables for sensitive data
+- Delete session files after scan
+- Don't commit credentials to git
+
+## Error Handling
+
+- **Target unreachable:** Fail fast with clear error message
+- **Authentication failure:** Abort scan (don't proceed unauthenticated)
+- **Page load timeout:** Skip page, continue crawling
+- **JavaScript errors:** Log but don't stop (some errors are intentional)
+- **Connection errors:** Retry 3 times with exponential backoff
+
+## Performance Considerations
+
+- **Parallel crawling:** Test up to 5 pages concurrently
+- **Headless mode:** Faster than headful (use for CI/CD)
+- **Caching:** Skip re-testing identical pages (same URL)
+- **Progress indicators:** Show progress for long scans (>50 pages)
+
+## Success Criteria
+
+- All pages within depth limit crawled
+- All forms and inputs tested for XSS and SQLi
+- Security headers checked on all pages
+- Findings saved in Unified Finding Format
+- Exit code 0 if no critical findings, 1 if critical vulnerabilities found
+
+## Related Commands
+
+- `/jpspec:security scan` - Run SAST scanners (Semgrep, CodeQL, Bandit)
+- `/jpspec:security_triage` - Triage web security findings
+- `/jpspec:security_report` - Generate comprehensive security report
+- `/jpspec:security_fix` - Apply automated fixes to findings
+
+## References
+
+- [OWASP Top 10](https://owasp.org/www-project-top-ten/)
+- [Web Security Patterns](../../../memory/security/web-security-patterns.md)
+- [Security DAST Skill](../../../.claude/skills/security-dast.md)
+- [ADR-007: Unified Security Finding Format](../../../docs/adr/ADR-007-unified-security-finding-format.md)
+- [Playwright Documentation](https://playwright.dev/)


### PR DESCRIPTION
## Summary

This PR adds comprehensive web application security testing capabilities using Playwright for Dynamic Application Security Testing (DAST).

**Replaces:** PR #481 (closed due to Copilot review issues - all issues now fixed)

## Changes

### New Files Added
- `.claude/skills/security-dast.md` - Security DAST skill for automated vulnerability scanning
- `templates/commands/jpspec/security_web.md` - `/jpspec:security_web` command implementation
- `.claude/commands/jpspec/security_web.md` - Symlink to command template
- `memory/security/web-security-patterns.md` - Web security knowledge base (OWASP Top 10)

### Features

**Security Testing Capabilities:**
- Cross-Site Scripting (XSS) detection - reflected, stored, DOM-based
- SQL Injection testing - error-based and blind techniques
- CSRF protection validation
- Security header analysis (CSP, HSTS, X-Frame-Options, etc.)
- Cookie security flags validation (Secure, HttpOnly, SameSite)
- Sensitive data exposure scanning (API keys, credentials, PII)
- TLS/SSL configuration checks

**Crawling & Authentication:**
- Automated web crawling with configurable depth and page limits
- Multiple authentication methods: form-based, bearer token, basic auth
- Authenticated session management
- URL exclusion patterns (logout, delete endpoints)

**Output & Integration:**
- Findings in Unified Finding Format (UFFormat)
- Integration with `/jpspec:security_triage` for TP/FP classification
- JSON output for automation
- Severity-based reporting (critical, high, medium, low)

## Fixes from Copilot Review

### Issue 1: Form Method Selector Case
**Location:** `.claude/skills/security-dast.md:232`

```python
# BEFORE (WRONG):
forms = await page.locator("form[method=post], form[method=PUT]").all()

# AFTER (CORRECT):
forms = await page.locator("form[method=post], form[method=put]").all()
```

**Reason:** HTML attribute values are normalized to lowercase by browsers.

### Issue 2: Finding ID Format Inconsistency
**Location:** `.claude/skills/security-dast.md:403`

```json
// BEFORE (WRONG):
"id": "DAST-WEB-XSS-001"

// AFTER (CORRECT):
"id": "DAST-XSS-001"
```

**Reason:** UFFormat specification at `templates/commands/jpspec/security_web.md:202` defines ID format as `DAST-{test_type}-{counter:03d}`, not including "WEB-".

### Issue 3: Playwright submit() Method
**Locations:** `memory/security/web-security-patterns.md:441, 454, 478`

```python
# BEFORE (WRONG):
await form.submit()

# AFTER (CORRECT):
await form.evaluate("form => form.submit()")
```

**Reason:** Playwright locators don't have a direct `submit()` method. Must use `evaluate()` to call the DOM form's submit method.

## Verification

All three issues verified as fixed:
```bash
# No method=PUT found
grep -n "method=PUT" .claude/skills/security-dast.md
# (empty - GOOD)

# No DAST-WEB- found
grep -n "DAST-WEB-" .claude/skills/security-dast.md
# (empty - GOOD)

# No await form.submit() found
grep -n "await form\.submit()" memory/security/web-security-patterns.md
# (empty - GOOD)

# Correct replacements exist
grep -n "method=put" .claude/skills/security-dast.md
# 232:forms = await page.locator("form[method=post], form[method=put]").all()

grep -n '"DAST-XSS-001"' .claude/skills/security-dast.md
# 403:    "id": "DAST-XSS-001",

grep -n 'form.evaluate.*form.submit' memory/security/web-security-patterns.md
# 441:await form.evaluate("form => form.submit()")
# 454:await form.evaluate("form => form.submit()")
# 478:await form.evaluate("form => form.submit()")
```

## Testing

### Manual Testing Commands
```bash
# Run web security scan on a target
/jpspec:security_web --url https://example.com --crawl

# Authenticated scan
/jpspec:security_web \
  --url https://app.example.com \
  --crawl \
  --auth-type form \
  --login-url /login \
  --username testuser \
  --password $TEST_PASSWORD

# Scan with exclusions
/jpspec:security_web \
  --url https://example.com \
  --crawl \
  --exclude "/logout" \
  --exclude "/admin/delete*"
```

### Expected Outputs
- `docs/security/web-findings.json` - Findings in UFFormat
- Exit code 0 if no critical findings, 1 if critical vulnerabilities found
- Severity breakdown report

## Integration

This PR integrates with existing security infrastructure:

1. **Triage**: `/jpspec:security_triage --input docs/security/web-findings.json`
2. **Reporting**: `/jpspec:security_report` (includes DAST findings)
3. **Backlog**: Convert findings to tasks for remediation

## Documentation

- Security DAST skill: `.claude/skills/security-dast.md`
- Command reference: `templates/commands/jpspec/security_web.md`
- Security patterns: `memory/security/web-security-patterns.md`

## Related

- ADR-007: Unified Security Finding Format
- Task-222: Implement Web Security Testing with Playwright DAST

Generated with [Claude Code](https://claude.com/claude-code)