### PR TITLE
feat(security): add hardened tool dependency management module (task-249)

### DIFF
--- a/src/specify_cli/security/tools/__init__.py
+++ b/src/specify_cli/security/tools/__init__.py
@@ -1,0 +1,33 @@
+"""Tool dependency management for security scanners.
+
+This module provides tools for managing security scanning dependencies
+like Semgrep, CodeQL, and Bandit.
+
+Features:
+- Auto-installation with version pinning
+- License compliance checking (CodeQL)
+- Dependency size monitoring (alert at 500MB)
+- Offline mode for air-gapped environments
+- Cross-platform support (Linux, macOS, Windows)
+- Security hardening (HTTPS-only, path traversal protection)
+"""
+
+from specify_cli.security.tools.manager import ToolManager
+from specify_cli.security.tools.models import (
+    CacheInfo,
+    InstallMethod,
+    InstallResult,
+    ToolConfig,
+    ToolInfo,
+    ToolStatus,
+)
+
+__all__ = [
+    "CacheInfo",
+    "InstallMethod",
+    "InstallResult",
+    "ToolConfig",
+    "ToolInfo",
+    "ToolManager",
+    "ToolStatus",
+]

--- a/src/specify_cli/security/tools/manager.py
+++ b/src/specify_cli/security/tools/manager.py
@@ -1,0 +1,792 @@
+"""Tool dependency manager for security scanners.
+
+This module provides the main ToolManager class for installing,
+managing, and monitoring security scanning tools.
+
+Features:
+- Auto-installation with version pinning
+- License compliance checking (CodeQL)
+- Dependency size monitoring (alert at 500MB)
+- Offline mode for air-gapped environments
+- Cross-platform support
+
+Security Features:
+- HTTPS-only downloads (no HTTP allowed)
+- Path traversal protection in archive extraction
+- Symlink attack detection
+- Version format validation
+"""
+
+import logging
+import os
+import platform
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import urlopen
+
+from specify_cli.security.tools.models import (
+    DEFAULT_TOOL_CONFIGS,
+    CacheInfo,
+    InstallMethod,
+    InstallResult,
+    ToolConfig,
+    ToolInfo,
+    ToolStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+# Anchored regex for exact version validation (rejects "1.2.3.4.5")
+VERSION_PATTERN = re.compile(r"^v?(\d+\.\d+(?:\.\d+)?(?:-[\w.]+)?)$")
+
+# Unanchored regex for extracting version from tool output
+VERSION_SEARCH_PATTERN = re.compile(r"v?(\d+\.\d+(?:\.\d+)?(?:-[\w.]+)?)")
+
+
+class ToolManager:
+    """Manager for security scanning tool dependencies.
+
+    This class handles:
+    - Tool discovery and installation
+    - Version pinning and updates
+    - License compliance checking
+    - Cache size monitoring
+    - Offline mode operation
+
+    Security:
+        - Downloads require HTTPS (HTTP is rejected)
+        - Archives validated for path traversal attacks
+        - Symlinks in archives are rejected
+        - Version strings are validated before use
+
+    Example:
+        >>> manager = ToolManager()
+        >>> result = manager.install("semgrep")
+        >>> if result.success:
+        ...     print(f"Installed at: {result.tool_info.path}")
+    """
+
+    # Cache size warning threshold in MB
+    CACHE_WARNING_THRESHOLD_MB = 500
+
+    # Download timeout in seconds
+    DOWNLOAD_TIMEOUT_SECONDS = 300
+
+    # Maximum search depth for finding executables
+    MAX_SEARCH_DEPTH = 5
+
+    def __init__(
+        self,
+        cache_dir: Path | None = None,
+        offline_mode: bool = False,
+        tool_configs: dict[str, ToolConfig] | None = None,
+    ):
+        """Initialize tool manager.
+
+        Args:
+            cache_dir: Directory to cache tools (default: ~/.specify/tools).
+            offline_mode: If True, only use cached tools, no network access.
+            tool_configs: Custom tool configurations (default: built-in configs).
+        """
+        self.cache_dir = cache_dir or Path.home() / ".specify" / "tools"
+        self.offline_mode = offline_mode
+        self.tool_configs = tool_configs or DEFAULT_TOOL_CONFIGS.copy()
+        self._ensure_cache_dir()
+
+    def _ensure_cache_dir(self) -> None:
+        """Create cache directory if it doesn't exist."""
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def get_tool_info(self, tool_name: str) -> ToolInfo | None:
+        """Get information about an installed tool.
+
+        Args:
+            tool_name: Name of the tool (e.g., "semgrep").
+
+        Returns:
+            ToolInfo if found, None otherwise.
+        """
+        tool_path = self._find_tool(tool_name)
+        if not tool_path:
+            return None
+
+        version = self._get_tool_version(tool_name, tool_path)
+        status = self._determine_status(tool_name, version)
+        install_method = self._detect_install_method(tool_path)
+        size_mb = self._get_size_mb(tool_path)
+
+        return ToolInfo(
+            name=tool_name,
+            version=version,
+            path=tool_path,
+            status=status,
+            install_method=install_method,
+            size_mb=size_mb,
+        )
+
+    def is_available(self, tool_name: str) -> bool:
+        """Check if tool is available for use.
+
+        Args:
+            tool_name: Name of the tool.
+
+        Returns:
+            True if tool is installed and ready.
+        """
+        return self._find_tool(tool_name) is not None
+
+    def install(
+        self,
+        tool_name: str,
+        accept_license: bool = False,
+        force: bool = False,
+    ) -> InstallResult:
+        """Install a security scanning tool.
+
+        Args:
+            tool_name: Name of the tool to install.
+            accept_license: If True, auto-accept license (for CodeQL etc).
+            force: If True, reinstall even if already installed.
+
+        Returns:
+            InstallResult with success status and tool info or error.
+        """
+        if tool_name not in self.tool_configs:
+            return InstallResult(
+                success=False,
+                error_message=f"Unknown tool: {tool_name}",
+            )
+
+        config = self.tool_configs[tool_name]
+
+        # Check if already installed (unless force)
+        if not force:
+            existing = self.get_tool_info(tool_name)
+            if existing and existing.status == ToolStatus.INSTALLED:
+                return InstallResult(success=True, tool_info=existing)
+
+        # Check offline mode
+        if self.offline_mode:
+            cached = self._find_in_cache(tool_name)
+            if cached:
+                return InstallResult(
+                    success=True,
+                    tool_info=ToolInfo(
+                        name=tool_name,
+                        version="cached",
+                        path=cached,
+                        status=ToolStatus.OFFLINE_ONLY,
+                        install_method=InstallMethod.BINARY,
+                    ),
+                )
+            return InstallResult(
+                success=False,
+                error_message=f"Offline mode: {tool_name} not found in cache",
+            )
+
+        # Check license requirement
+        if config.license_check and not accept_license:
+            return InstallResult(
+                success=False,
+                license_required=True,
+                error_message=f"License acceptance required. Review: {config.license_url}",
+            )
+
+        # Install based on method
+        if config.install_method == InstallMethod.PIP:
+            return self._install_pip(config)
+        elif config.install_method == InstallMethod.BINARY:
+            return self._install_binary(config)
+        else:
+            return InstallResult(
+                success=False,
+                error_message=f"Unsupported install method: {config.install_method}",
+            )
+
+    def _install_pip(self, config: ToolConfig) -> InstallResult:
+        """Install tool using pip.
+
+        Args:
+            config: Tool configuration.
+
+        Returns:
+            InstallResult with status.
+        """
+        package = config.pip_package or config.name
+        version_spec = f"=={config.version}" if config.version else ""
+
+        try:
+            cmd = [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                f"{package}{version_spec}",
+            ]
+            logger.info(f"Installing {package}{version_spec}")
+
+            subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=300,
+                check=True,
+            )
+
+            tool_path = self._find_tool(config.name)
+            if not tool_path:
+                return InstallResult(
+                    success=False,
+                    error_message=f"Installed but could not find {config.name} executable",
+                )
+
+            tool_info = self.get_tool_info(config.name)
+            return InstallResult(success=True, tool_info=tool_info)
+
+        except subprocess.CalledProcessError as e:
+            error_msg = str(e.stderr).split("\n")[0][:200] if e.stderr else str(e)
+            return InstallResult(
+                success=False,
+                error_message=f"pip install failed: {error_msg}",
+            )
+        except subprocess.TimeoutExpired:
+            return InstallResult(
+                success=False,
+                error_message="Installation timed out after 5 minutes",
+            )
+
+    def _install_binary(self, config: ToolConfig) -> InstallResult:
+        """Install tool by downloading binary.
+
+        Args:
+            config: Tool configuration.
+
+        Returns:
+            InstallResult with status.
+        """
+        platform_key = self._get_platform_key()
+        if platform_key not in config.binary_urls:
+            return InstallResult(
+                success=False,
+                error_message=f"No binary available for platform: {platform_key}",
+            )
+
+        # Validate version format before URL construction
+        if config.version and not self._is_valid_version(config.version):
+            return InstallResult(
+                success=False,
+                error_message=f"Invalid version format: {config.version}",
+            )
+
+        url = config.binary_urls[platform_key].format(version=config.version or "")
+        dest_dir = self.cache_dir / config.name / (config.version or "latest")
+
+        try:
+            logger.info(f"Downloading {config.name} from {url}")
+            dest_dir.mkdir(parents=True, exist_ok=True)
+
+            download_path = dest_dir / "download.zip"
+            self._download_file(url, download_path)
+
+            # Count files before extraction
+            files_before = set(dest_dir.rglob("*"))
+
+            # Extract with security validation
+            self._safe_extract_archive(download_path, dest_dir)
+
+            # Validate extraction produced files
+            files_after = set(dest_dir.rglob("*"))
+            new_files = files_after - files_before - {download_path}
+            if not new_files:
+                return InstallResult(
+                    success=False,
+                    error_message="Archive extraction produced no files",
+                )
+
+            download_path.unlink()
+
+            tool_path = self._find_in_directory(dest_dir, config.name)
+            if not tool_path:
+                return InstallResult(
+                    success=False,
+                    error_message=f"Could not find {config.name} executable",
+                )
+
+            # Set executable permission (owner only for security)
+            if tool_path.is_file():
+                tool_path.chmod(stat.S_IRWXU)  # 0o700 - owner only
+            else:
+                return InstallResult(
+                    success=False,
+                    error_message=f"Found path is not a valid file: {tool_path}",
+                )
+
+            tool_info = ToolInfo(
+                name=config.name,
+                version=config.version or "unknown",
+                path=tool_path,
+                status=ToolStatus.INSTALLED,
+                install_method=InstallMethod.BINARY,
+                size_mb=self._get_size_mb(dest_dir),
+            )
+
+            return InstallResult(success=True, tool_info=tool_info)
+
+        except (OSError, RuntimeError, zipfile.BadZipFile) as e:
+            logger.error(f"Binary install failed: {type(e).__name__}: {e}")
+            return InstallResult(
+                success=False,
+                error_message="Binary installation failed",
+            )
+
+    def _download_file(self, url: str, dest: Path) -> None:
+        """Download a file from URL with timeout.
+
+        Security:
+            - Only HTTPS URLs are allowed for downloading binaries
+            - SSL/TLS certificates are validated by default
+
+        Args:
+            url: URL to download (must be HTTPS).
+            dest: Destination path.
+
+        Raises:
+            ValueError: If URL is not HTTPS.
+            RuntimeError: If download fails or times out.
+        """
+        if not url.startswith("https://"):
+            raise ValueError(f"Only HTTPS URLs are allowed for security, got: {url}")
+
+        try:
+            with urlopen(url, timeout=self.DOWNLOAD_TIMEOUT_SECONDS) as response:
+                with open(dest, "wb") as f:
+                    chunk_size = 8192
+                    while True:
+                        chunk = response.read(chunk_size)
+                        if not chunk:
+                            break
+                        f.write(chunk)
+        except URLError as e:
+            raise RuntimeError(f"Download failed: {e}") from e
+        except TimeoutError as e:
+            raise RuntimeError(
+                f"Download timed out after {self.DOWNLOAD_TIMEOUT_SECONDS}s"
+            ) from e
+
+    def _safe_extract_archive(self, archive_path: Path, dest_dir: Path) -> None:
+        """Safely extract archive with security protections.
+
+        Security:
+            - Validates all paths are within destination directory
+            - Rejects absolute paths in archive
+            - Prevents directory traversal attacks (../)
+            - Rejects symlinks that could escape destination
+
+        Args:
+            archive_path: Path to archive file.
+            dest_dir: Destination directory.
+
+        Raises:
+            RuntimeError: If archive contains suspicious paths or symlinks.
+        """
+        dest_dir_resolved = dest_dir.resolve()
+
+        if str(archive_path).endswith(".zip"):
+            with zipfile.ZipFile(archive_path, "r") as zf:
+                for member in zf.namelist():
+                    # Check for absolute paths
+                    if Path(member).is_absolute():
+                        raise RuntimeError(f"Archive contains absolute path: {member}")
+
+                    # Check for path traversal using path components
+                    # This correctly allows files like "README..md"
+                    if ".." in Path(member).parts:
+                        raise RuntimeError(f"Archive contains path traversal: {member}")
+
+                    # Verify resolved path is within dest_dir
+                    member_path = (dest_dir / member).resolve()
+                    if not str(member_path).startswith(str(dest_dir_resolved)):
+                        raise RuntimeError(
+                            f"Archive member escapes destination: {member}"
+                        )
+
+                    # Check for symlinks (zipfile stores them as external_attr)
+                    info = zf.getinfo(member)
+                    if self._is_zip_symlink(info):
+                        raise RuntimeError(
+                            f"Archive contains symlink (not allowed): {member}"
+                        )
+
+                zf.extractall(dest_dir)
+        else:
+            # For other archive types, use shutil with post-validation
+            shutil.unpack_archive(archive_path, dest_dir)
+
+            # Post-extraction validation
+            for item in dest_dir.rglob("*"):
+                # Check for symlinks
+                if item.is_symlink():
+                    item.unlink()
+                    raise RuntimeError(f"Extracted symlink removed: {item}")
+
+                item_resolved = item.resolve()
+                if not str(item_resolved).startswith(str(dest_dir_resolved)):
+                    if item.is_file():
+                        item.unlink()
+                    raise RuntimeError(f"Extracted file escaped destination: {item}")
+
+    def _is_zip_symlink(self, zip_info: zipfile.ZipInfo) -> bool:
+        """Check if a ZIP member is a symlink.
+
+        Args:
+            zip_info: ZIP file member info.
+
+        Returns:
+            True if the member is a symbolic link.
+        """
+        # Unix symlinks have the symlink bit set in external_attr
+        # external_attr stores Unix mode in upper 16 bits
+        unix_mode = zip_info.external_attr >> 16
+        return stat.S_ISLNK(unix_mode) if unix_mode else False
+
+    def _is_valid_version(self, version: str) -> bool:
+        """Validate version string format.
+
+        Args:
+            version: Version string to validate.
+
+        Returns:
+            True if version format is valid (e.g., "1.0.0", "v2.15.0").
+        """
+        return bool(VERSION_PATTERN.match(version))
+
+    def get_cache_info(self) -> CacheInfo:
+        """Get information about the tool cache.
+
+        Returns:
+            CacheInfo with size and tool details.
+        """
+        total_size = 0.0
+        tools = []
+
+        try:
+            if not self.cache_dir.exists():
+                return CacheInfo(
+                    cache_dir=self.cache_dir,
+                    total_size_mb=0.0,
+                    tool_count=0,
+                    tools=[],
+                )
+
+            for item in self.cache_dir.iterdir():
+                if item.is_dir():
+                    try:
+                        size_mb = self._get_size_mb(item)
+                        total_size += size_mb
+                        tools.append(
+                            ToolInfo(
+                                name=item.name,
+                                version="cached",
+                                path=item,
+                                status=ToolStatus.INSTALLED,
+                                install_method=InstallMethod.BINARY,
+                                size_mb=size_mb,
+                            )
+                        )
+                    except (OSError, PermissionError) as e:
+                        logger.warning(f"Could not read cache entry {item}: {e}")
+                        continue
+        except (OSError, PermissionError) as e:
+            logger.error(f"Could not read cache directory: {e}")
+            return CacheInfo(
+                cache_dir=self.cache_dir,
+                total_size_mb=0.0,
+                tool_count=0,
+                tools=[],
+            )
+
+        return CacheInfo(
+            cache_dir=self.cache_dir,
+            total_size_mb=total_size,
+            tool_count=len(tools),
+            tools=tools,
+            size_warning=total_size > self.CACHE_WARNING_THRESHOLD_MB,
+            warning_threshold_mb=self.CACHE_WARNING_THRESHOLD_MB,
+        )
+
+    def check_for_updates(self, tool_name: str) -> tuple[bool, str | None]:
+        """Check if a tool has updates available.
+
+        Args:
+            tool_name: Name of the tool.
+
+        Returns:
+            Tuple of (update_available, latest_version).
+        """
+        if tool_name not in self.tool_configs:
+            return (False, None)
+
+        config = self.tool_configs[tool_name]
+        current = self.get_tool_info(tool_name)
+
+        if not current:
+            return (False, None)
+
+        if config.version and current.version != config.version:
+            return (True, config.version)
+
+        return (False, None)
+
+    def update_tool(self, tool_name: str) -> InstallResult:
+        """Update a tool to the configured version.
+
+        Args:
+            tool_name: Name of the tool.
+
+        Returns:
+            InstallResult with status.
+        """
+        return self.install(tool_name, accept_license=True, force=True)
+
+    def _find_tool(self, tool_name: str) -> Path | None:
+        """Find tool in search paths.
+
+        Args:
+            tool_name: Name of the tool.
+
+        Returns:
+            Path to executable or None.
+        """
+        # 1. System PATH
+        system_path = shutil.which(tool_name)
+        if system_path:
+            return Path(system_path)
+
+        # 2. Current venv
+        venv_path = self._find_in_venv(tool_name)
+        if venv_path:
+            return venv_path
+
+        # 3. Cache directory
+        cached = self._find_in_cache(tool_name)
+        if cached:
+            return cached
+
+        return None
+
+    def _find_in_venv(self, tool_name: str) -> Path | None:
+        """Find tool in virtual environment.
+
+        Args:
+            tool_name: Name of the tool.
+
+        Returns:
+            Path if found, None otherwise.
+        """
+        venv_dirs = [
+            Path.cwd() / ".venv",
+            Path.cwd() / "venv",
+            Path(sys.prefix),
+        ]
+
+        for venv_dir in venv_dirs:
+            if not venv_dir.exists():
+                continue
+            for bin_dir in ["bin", "Scripts"]:
+                tool_path = venv_dir / bin_dir / tool_name
+                if tool_path.exists():
+                    return tool_path
+        return None
+
+    def _find_in_cache(self, tool_name: str) -> Path | None:
+        """Find tool in cache directory.
+
+        Args:
+            tool_name: Name of the tool.
+
+        Returns:
+            Path if found, None otherwise.
+        """
+        tool_dir = self.cache_dir / tool_name
+        if not tool_dir.exists():
+            return None
+
+        try:
+            versions = sorted(
+                tool_dir.iterdir(),
+                key=lambda p: p.stat().st_mtime,
+                reverse=True,
+            )
+            for version_dir in versions:
+                if version_dir.is_dir():
+                    executable = self._find_in_directory(version_dir, tool_name)
+                    if executable:
+                        return executable
+        except (OSError, PermissionError):
+            return None
+
+        return None
+
+    def _find_in_directory(
+        self, directory: Path, tool_name: str, max_depth: int | None = None
+    ) -> Path | None:
+        """Find executable in directory tree with depth limit.
+
+        Args:
+            directory: Directory to search.
+            tool_name: Name of the tool.
+            max_depth: Maximum search depth (default: MAX_SEARCH_DEPTH).
+
+        Returns:
+            Path to executable or None.
+        """
+        if max_depth is None:
+            max_depth = self.MAX_SEARCH_DEPTH
+
+        return self._find_executable_recursive(directory, tool_name, 0, max_depth)
+
+    def _find_executable_recursive(
+        self, directory: Path, tool_name: str, current_depth: int, max_depth: int
+    ) -> Path | None:
+        """Recursively find executable with depth limit.
+
+        Args:
+            directory: Current directory to search.
+            tool_name: Name of the tool.
+            current_depth: Current recursion depth.
+            max_depth: Maximum allowed depth.
+
+        Returns:
+            Path to executable or None.
+        """
+        if current_depth > max_depth:
+            return None
+
+        try:
+            for item in directory.iterdir():
+                if item.name == tool_name and item.is_file():
+                    if os.access(item, os.X_OK):
+                        return item
+                if item.name == f"{tool_name}.exe" and item.is_file():
+                    return item
+                if item.is_dir() and current_depth < max_depth:
+                    result = self._find_executable_recursive(
+                        item, tool_name, current_depth + 1, max_depth
+                    )
+                    if result:
+                        return result
+        except (OSError, PermissionError):
+            pass
+
+        return None
+
+    def _get_tool_version(self, tool_name: str, tool_path: Path) -> str:
+        """Get version of installed tool.
+
+        Args:
+            tool_name: Name of the tool.
+            tool_path: Path to executable.
+
+        Returns:
+            Version string or "unknown".
+        """
+        try:
+            result = subprocess.run(
+                [str(tool_path), "--version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            output = result.stdout.strip() or result.stderr.strip()
+            if output:
+                match = VERSION_SEARCH_PATTERN.search(output)
+                if match:
+                    return match.group(1)
+            return "unknown"
+        except Exception as e:
+            logger.debug(f"Failed to get version for {tool_name}: {e}")
+            return "unknown"
+
+    def _determine_status(self, tool_name: str, version: str) -> ToolStatus:
+        """Determine tool status based on version.
+
+        Args:
+            tool_name: Name of the tool.
+            version: Installed version.
+
+        Returns:
+            ToolStatus enum value.
+        """
+        if tool_name not in self.tool_configs:
+            return ToolStatus.INSTALLED
+
+        config = self.tool_configs[tool_name]
+        if config.version and version != config.version:
+            return ToolStatus.UPDATE_AVAILABLE
+
+        return ToolStatus.INSTALLED
+
+    def _detect_install_method(self, tool_path: Path) -> InstallMethod:
+        """Detect how tool was installed.
+
+        Args:
+            tool_path: Path to executable.
+
+        Returns:
+            InstallMethod enum value.
+        """
+        path_str = str(tool_path)
+
+        if str(self.cache_dir) in path_str:
+            return InstallMethod.BINARY
+        elif "site-packages" in path_str or ".venv" in path_str or "venv" in path_str:
+            return InstallMethod.PIP
+        else:
+            return InstallMethod.SYSTEM
+
+    def _get_size_mb(self, path: Path) -> float:
+        """Get size of file or directory in MB.
+
+        Args:
+            path: Path to measure.
+
+        Returns:
+            Size in megabytes.
+        """
+        if path.is_file():
+            return path.stat().st_size / (1024 * 1024)
+
+        total = 0
+        try:
+            for dirpath, _, filenames in os.walk(path):
+                for filename in filenames:
+                    filepath = os.path.join(dirpath, filename)
+                    try:
+                        total += os.path.getsize(filepath)
+                    except (OSError, FileNotFoundError):
+                        continue
+        except (OSError, PermissionError):
+            pass
+
+        return total / (1024 * 1024)
+
+    def _get_platform_key(self) -> str:
+        """Get platform key for binary downloads.
+
+        Returns:
+            Platform identifier (linux, darwin, win32).
+        """
+        system = platform.system().lower()
+        if system == "linux":
+            return "linux"
+        elif system == "darwin":
+            return "darwin"
+        elif system == "windows":
+            return "win32"
+        return system

--- a/src/specify_cli/security/tools/models.py
+++ b/src/specify_cli/security/tools/models.py
@@ -1,0 +1,144 @@
+"""Data models for tool dependency management.
+
+This module contains dataclasses and enums for representing
+tool configurations, installation status, and cache information.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+
+class ToolStatus(Enum):
+    """Status of a security tool installation."""
+
+    NOT_INSTALLED = "not_installed"
+    INSTALLED = "installed"
+    UPDATE_AVAILABLE = "update_available"
+    LICENSE_REQUIRED = "license_required"
+    OFFLINE_ONLY = "offline_only"
+
+
+class InstallMethod(Enum):
+    """Method used to install a tool."""
+
+    PIP = "pip"
+    BINARY = "binary"
+    DOCKER = "docker"
+    SYSTEM = "system"
+
+
+@dataclass
+class ToolConfig:
+    """Configuration for a security scanning tool.
+
+    Attributes:
+        name: Tool name (e.g., "semgrep").
+        version: Pinned version string.
+        install_method: How to install the tool.
+        license_check: Whether license acceptance is required.
+        license_url: URL to license terms.
+        binary_urls: Platform-specific download URLs.
+        pip_package: PyPI package name if different from tool name.
+        size_estimate_mb: Estimated download size in MB.
+    """
+
+    name: str
+    version: str | None = None
+    install_method: InstallMethod = InstallMethod.PIP
+    license_check: bool = False
+    license_url: str | None = None
+    binary_urls: dict[str, str] = field(default_factory=dict)
+    pip_package: str | None = None
+    size_estimate_mb: int = 0
+
+
+@dataclass
+class ToolInfo:
+    """Information about an installed tool.
+
+    Attributes:
+        name: Tool name.
+        version: Installed version string.
+        path: Path to executable.
+        status: Current installation status.
+        install_method: How the tool was installed.
+        size_mb: Actual size in MB.
+    """
+
+    name: str
+    version: str
+    path: Path
+    status: ToolStatus
+    install_method: InstallMethod
+    size_mb: float = 0.0
+
+
+@dataclass
+class InstallResult:
+    """Result of a tool installation attempt.
+
+    Attributes:
+        success: Whether installation succeeded.
+        tool_info: Tool information if successful.
+        error_message: Error description if failed.
+        license_required: Whether license acceptance is needed.
+    """
+
+    success: bool
+    tool_info: ToolInfo | None = None
+    error_message: str | None = None
+    license_required: bool = False
+
+
+@dataclass
+class CacheInfo:
+    """Information about the tool cache.
+
+    Attributes:
+        cache_dir: Path to cache directory.
+        total_size_mb: Total size of cached tools.
+        tool_count: Number of cached tools.
+        tools: List of cached tool info.
+        size_warning: True if over threshold.
+        warning_threshold_mb: Size threshold for warning.
+    """
+
+    cache_dir: Path
+    total_size_mb: float
+    tool_count: int
+    tools: list[ToolInfo]
+    size_warning: bool = False
+    warning_threshold_mb: int = 500
+
+
+# Default configurations for supported tools
+DEFAULT_TOOL_CONFIGS: dict[str, ToolConfig] = {
+    "semgrep": ToolConfig(
+        name="semgrep",
+        version="1.45.0",
+        install_method=InstallMethod.PIP,
+        pip_package="semgrep",
+        size_estimate_mb=100,
+    ),
+    "codeql": ToolConfig(
+        name="codeql",
+        version="2.15.0",
+        install_method=InstallMethod.BINARY,
+        license_check=True,
+        license_url="https://github.com/github/codeql-cli-binaries/blob/main/LICENSE.md",
+        binary_urls={
+            "linux": "https://github.com/github/codeql-cli-binaries/releases/download/v{version}/codeql-linux64.zip",
+            "darwin": "https://github.com/github/codeql-cli-binaries/releases/download/v{version}/codeql-osx64.zip",
+            "win32": "https://github.com/github/codeql-cli-binaries/releases/download/v{version}/codeql-win64.zip",
+        },
+        size_estimate_mb=400,
+    ),
+    "bandit": ToolConfig(
+        name="bandit",
+        version="1.7.7",
+        install_method=InstallMethod.PIP,
+        pip_package="bandit",
+        size_estimate_mb=10,
+    ),
+}

--- a/tests/security/tools/__init__.py
+++ b/tests/security/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for tool dependency management."""

--- a/tests/security/tools/test_manager.py
+++ b/tests/security/tools/test_manager.py
@@ -1,0 +1,673 @@
+"""Tests for ToolManager class."""
+
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from specify_cli.security.tools.manager import (
+    ToolManager,
+    VERSION_PATTERN,
+    VERSION_SEARCH_PATTERN,
+)
+from specify_cli.security.tools.models import (
+    InstallMethod,
+    ToolConfig,
+    ToolStatus,
+)
+
+
+class TestToolManagerInit:
+    """Test ToolManager initialization."""
+
+    def test_default_cache_dir(self, tmp_path):
+        """Default cache directory is in home directory."""
+        with patch.object(Path, "home", return_value=tmp_path):
+            manager = ToolManager(cache_dir=tmp_path / "tools")
+            assert manager.cache_dir == tmp_path / "tools"
+
+    def test_custom_cache_dir(self, tmp_path):
+        """Can specify custom cache directory."""
+        cache_dir = tmp_path / "custom_cache"
+        manager = ToolManager(cache_dir=cache_dir)
+        assert manager.cache_dir == cache_dir
+        assert cache_dir.exists()
+
+    def test_offline_mode(self, tmp_path):
+        """Offline mode flag is stored."""
+        manager = ToolManager(cache_dir=tmp_path, offline_mode=True)
+        assert manager.offline_mode is True
+
+    def test_custom_tool_configs(self, tmp_path):
+        """Can provide custom tool configurations."""
+        custom_configs = {"mytool": ToolConfig(name="mytool", version="1.0")}
+        manager = ToolManager(cache_dir=tmp_path, tool_configs=custom_configs)
+        assert "mytool" in manager.tool_configs
+        assert "semgrep" not in manager.tool_configs
+
+    def test_default_tool_configs(self, tmp_path):
+        """Uses default tool configs when none provided."""
+        manager = ToolManager(cache_dir=tmp_path)
+        assert "semgrep" in manager.tool_configs
+        assert "codeql" in manager.tool_configs
+        assert "bandit" in manager.tool_configs
+
+
+class TestIsAvailable:
+    """Test is_available method."""
+
+    def test_available_when_found(self, tmp_path):
+        """Returns True when tool is found."""
+        manager = ToolManager(cache_dir=tmp_path)
+        with patch.object(manager, "_find_tool", return_value=Path("/usr/bin/semgrep")):
+            assert manager.is_available("semgrep") is True
+
+    def test_not_available_when_not_found(self, tmp_path):
+        """Returns False when tool is not found."""
+        manager = ToolManager(cache_dir=tmp_path)
+        with patch.object(manager, "_find_tool", return_value=None):
+            assert manager.is_available("nonexistent") is False
+
+
+class TestGetToolInfo:
+    """Test get_tool_info method."""
+
+    def test_returns_none_when_not_found(self, tmp_path):
+        """Returns None when tool is not installed."""
+        manager = ToolManager(cache_dir=tmp_path)
+        with patch.object(manager, "_find_tool", return_value=None):
+            assert manager.get_tool_info("nonexistent") is None
+
+    def test_returns_tool_info_when_found(self, tmp_path):
+        """Returns ToolInfo when tool is installed."""
+        manager = ToolManager(cache_dir=tmp_path)
+        tool_path = Path("/usr/bin/semgrep")
+
+        with (
+            patch.object(manager, "_find_tool", return_value=tool_path),
+            patch.object(manager, "_get_tool_version", return_value="1.45.0"),
+            patch.object(manager, "_get_size_mb", return_value=100.0),
+        ):
+            info = manager.get_tool_info("semgrep")
+            assert info is not None
+            assert info.name == "semgrep"
+            assert info.version == "1.45.0"
+            assert info.path == tool_path
+
+
+class TestInstall:
+    """Test install method."""
+
+    def test_unknown_tool_returns_error(self, tmp_path):
+        """Unknown tool returns error result."""
+        manager = ToolManager(cache_dir=tmp_path)
+        result = manager.install("unknowntool")
+        assert result.success is False
+        assert "Unknown tool" in result.error_message
+
+    def test_already_installed_returns_existing(self, tmp_path):
+        """Already installed tool returns existing info."""
+        manager = ToolManager(cache_dir=tmp_path)
+        tool_path = Path("/usr/bin/semgrep")
+
+        with (
+            patch.object(manager, "_find_tool", return_value=tool_path),
+            patch.object(manager, "_get_tool_version", return_value="1.45.0"),
+            patch.object(manager, "_get_size_mb", return_value=100.0),
+        ):
+            result = manager.install("semgrep")
+            assert result.success is True
+            assert result.tool_info is not None
+
+    def test_license_required_without_acceptance(self, tmp_path):
+        """CodeQL requires license acceptance."""
+        manager = ToolManager(cache_dir=tmp_path)
+        with patch.object(manager, "_find_tool", return_value=None):
+            result = manager.install("codeql", accept_license=False)
+            assert result.success is False
+            assert result.license_required is True
+
+    def test_force_reinstall(self, tmp_path):
+        """Force flag triggers reinstallation."""
+        manager = ToolManager(cache_dir=tmp_path)
+        tool_path = Path("/usr/bin/semgrep")
+
+        with (
+            patch.object(manager, "_find_tool", return_value=tool_path),
+            patch.object(manager, "_get_tool_version", return_value="1.45.0"),
+            patch.object(manager, "_get_size_mb", return_value=100.0),
+            patch.object(manager, "_install_pip") as mock_pip,
+        ):
+            mock_pip.return_value = MagicMock(success=True)
+            manager.install("semgrep", force=True)
+            mock_pip.assert_called_once()
+
+
+class TestOfflineMode:
+    """Test offline mode behavior."""
+
+    def test_offline_uses_cache_only(self, tmp_path):
+        """Offline mode only uses cached tools."""
+        cache_dir = tmp_path / "tools"
+        tool_cache = cache_dir / "semgrep" / "1.45.0"
+        tool_cache.mkdir(parents=True)
+        cached_exe = tool_cache / "semgrep"
+        cached_exe.write_text("#!/bin/bash\necho test")
+        cached_exe.chmod(0o755)
+
+        manager = ToolManager(cache_dir=cache_dir, offline_mode=True)
+
+        with patch.object(manager, "_find_in_cache", return_value=cached_exe):
+            result = manager.install("semgrep")
+            assert result.success is True
+            assert result.tool_info.status == ToolStatus.OFFLINE_ONLY
+
+    def test_offline_fails_when_not_cached(self, tmp_path):
+        """Offline mode fails when tool is not in cache."""
+        manager = ToolManager(cache_dir=tmp_path, offline_mode=True)
+
+        with patch.object(manager, "_find_in_cache", return_value=None):
+            result = manager.install("semgrep")
+            assert result.success is False
+            assert "Offline mode" in result.error_message
+
+
+class TestVersionValidation:
+    """Test version validation."""
+
+    def test_valid_semantic_versions(self, tmp_path):
+        """Valid semantic versions are accepted."""
+        manager = ToolManager(cache_dir=tmp_path)
+        valid_versions = [
+            "1.0.0",
+            "1.45.0",
+            "2.15.0",
+            "1.0",
+            "1.0.0-beta1",
+            "1.0.0-rc.1",
+            "v1.0.0",
+            "v2.15.0",
+        ]
+        for version in valid_versions:
+            assert manager._is_valid_version(version), f"Should accept: {version}"
+
+    def test_invalid_versions(self, tmp_path):
+        """Invalid versions are rejected."""
+        manager = ToolManager(cache_dir=tmp_path)
+        invalid_versions = [
+            "",
+            "abc",
+            "version",
+            "...",
+            "1-2-3",
+            "1.2.3.4",
+            "1.2.3.4.5",
+            "1.2.3.4.5.6",
+        ]
+        for version in invalid_versions:
+            assert not manager._is_valid_version(version), f"Should reject: {version}"
+
+
+class TestVersionPatternAnchoring:
+    """Test VERSION_PATTERN anchoring behavior."""
+
+    def test_exact_match_versions(self):
+        """VERSION_PATTERN matches exact versions."""
+        assert VERSION_PATTERN.match("1.0.0")
+        assert VERSION_PATTERN.match("v2.15.0")
+        assert VERSION_PATTERN.match("1.0.0-beta1")
+        assert VERSION_PATTERN.match("1.0")
+
+    def test_rejects_versions_at_beginning_of_text(self):
+        """VERSION_PATTERN rejects versions at beginning of text."""
+        assert VERSION_PATTERN.match("1.45.0 extra text") is None
+        assert VERSION_PATTERN.match("v1.0.0-suffix text") is None
+        assert VERSION_PATTERN.match("1.0.0 package") is None
+
+    def test_rejects_versions_at_end_of_text(self):
+        """VERSION_PATTERN rejects versions at end of text."""
+        assert VERSION_PATTERN.match("version 1.0.0") is None
+        assert VERSION_PATTERN.match("tool-1.0.0") is None
+        assert VERSION_PATTERN.match("prefix v2.15.0") is None
+
+    def test_rejects_versions_in_middle_of_text(self):
+        """VERSION_PATTERN rejects versions in middle of text."""
+        assert VERSION_PATTERN.match("tool 1.0.0 package") is None
+        assert VERSION_PATTERN.match("v 1.0.0 x") is None
+
+    def test_rejects_malformed_versions(self):
+        """VERSION_PATTERN rejects malformed versions."""
+        assert VERSION_PATTERN.match("1.2.3.4") is None
+        assert VERSION_PATTERN.match("1.2.3.4.5") is None
+        assert VERSION_PATTERN.match("..1.0.0") is None
+        assert VERSION_PATTERN.match("1.0.0..") is None
+
+
+class TestVersionSearchPattern:
+    """Test VERSION_SEARCH_PATTERN for extracting from tool output."""
+
+    def test_extracts_versions_from_output(self):
+        """VERSION_SEARCH_PATTERN extracts versions from tool output."""
+        test_cases = [
+            ("semgrep 1.45.0", "1.45.0"),
+            ("v2.15.0", "2.15.0"),
+            ("tool version 1.0.0-beta1", "1.0.0-beta1"),
+            ("1.0", "1.0"),
+            ("Version: 3.2.1", "3.2.1"),
+            ("Bandit 1.7.7 from pip", "1.7.7"),
+        ]
+        for output, expected in test_cases:
+            match = VERSION_SEARCH_PATTERN.search(output)
+            assert match is not None, f"Should match: {output}"
+            assert match.group(1) == expected, f"For '{output}': expected {expected}"
+
+    def test_get_tool_version_parses_output(self, tmp_path):
+        """_get_tool_version correctly parses subprocess output."""
+        manager = ToolManager(cache_dir=tmp_path)
+        tool_path = tmp_path / "test_tool"
+        tool_path.write_text("#!/bin/bash\necho 'test 1.2.3'")
+        tool_path.chmod(0o755)
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="semgrep 1.45.0\n", stderr="")
+            version = manager._get_tool_version("semgrep", tool_path)
+            assert version == "1.45.0"
+
+    def test_get_tool_version_unknown_on_failure(self, tmp_path):
+        """Returns 'unknown' when version cannot be determined."""
+        manager = ToolManager(cache_dir=tmp_path)
+        with patch("subprocess.run", side_effect=Exception("error")):
+            version = manager._get_tool_version("test", Path("/nonexistent"))
+            assert version == "unknown"
+
+
+class TestCacheInfo:
+    """Test cache information retrieval."""
+
+    def test_empty_cache_info(self, tmp_path):
+        """Returns zero counts for empty cache."""
+        manager = ToolManager(cache_dir=tmp_path)
+        info = manager.get_cache_info()
+        assert info.total_size_mb == 0.0
+        assert info.tool_count == 0
+        assert info.size_warning is False
+
+    def test_cache_with_tools(self, tmp_path):
+        """Returns correct info for cached tools."""
+        tool_dir = tmp_path / "semgrep"
+        tool_dir.mkdir()
+        (tool_dir / "test_file").write_bytes(b"x" * 1024)
+
+        manager = ToolManager(cache_dir=tmp_path)
+        info = manager.get_cache_info()
+        assert info.tool_count == 1
+        assert info.total_size_mb > 0
+
+    def test_cache_size_warning(self, tmp_path):
+        """Size warning triggered at threshold."""
+        manager = ToolManager(cache_dir=tmp_path)
+        with patch.object(manager, "_get_size_mb", return_value=600.0):
+            tool_dir = tmp_path / "large_tool"
+            tool_dir.mkdir()
+            info = manager.get_cache_info()
+            assert info.size_warning is True
+
+    def test_cache_info_handles_permission_error(self, tmp_path):
+        """Handles permission errors gracefully."""
+        manager = ToolManager(cache_dir=tmp_path)
+
+        mock_cache_dir = MagicMock(spec=Path)
+        mock_cache_dir.exists.return_value = True
+        mock_cache_dir.iterdir.side_effect = PermissionError("Permission denied")
+        manager.cache_dir = mock_cache_dir
+
+        info = manager.get_cache_info()
+        assert info.tool_count == 0
+        assert info.total_size_mb == 0.0
+
+
+class TestFindInDirectory:
+    """Test directory search for executables."""
+
+    def test_finds_executable_at_root(self, tmp_path):
+        """Finds executable at directory root."""
+        exe = tmp_path / "mytool"
+        exe.write_text("#!/bin/bash\necho test")
+        exe.chmod(0o755)
+
+        manager = ToolManager(cache_dir=tmp_path)
+        result = manager._find_in_directory(tmp_path, "mytool")
+        assert result == exe
+
+    def test_finds_executable_in_subdirectory(self, tmp_path):
+        """Finds executable in subdirectory."""
+        subdir = tmp_path / "bin"
+        subdir.mkdir()
+        exe = subdir / "mytool"
+        exe.write_text("#!/bin/bash\necho test")
+        exe.chmod(0o755)
+
+        manager = ToolManager(cache_dir=tmp_path)
+        result = manager._find_in_directory(tmp_path, "mytool")
+        assert result == exe
+
+    def test_respects_max_depth(self, tmp_path):
+        """Stops searching at max depth."""
+        deep_dir = tmp_path / "a" / "b" / "c" / "d" / "e" / "f"
+        deep_dir.mkdir(parents=True)
+        exe = deep_dir / "mytool"
+        exe.write_text("#!/bin/bash\necho test")
+        exe.chmod(0o755)
+
+        manager = ToolManager(cache_dir=tmp_path)
+        result = manager._find_in_directory(tmp_path, "mytool", max_depth=2)
+        assert result is None
+
+    def test_finds_windows_exe(self, tmp_path):
+        """Finds .exe extension on Windows."""
+        exe = tmp_path / "mytool.exe"
+        exe.write_text("test")
+
+        manager = ToolManager(cache_dir=tmp_path)
+        result = manager._find_in_directory(tmp_path, "mytool")
+        assert result == exe
+
+
+class TestGetSizeMb:
+    """Test size calculation."""
+
+    def test_file_size(self, tmp_path):
+        """Calculates file size correctly."""
+        test_file = tmp_path / "test.bin"
+        test_file.write_bytes(b"x" * (1024 * 1024))
+
+        manager = ToolManager(cache_dir=tmp_path)
+        size = manager._get_size_mb(test_file)
+        assert abs(size - 1.0) < 0.01
+
+    def test_directory_size(self, tmp_path):
+        """Calculates directory size correctly."""
+        subdir = tmp_path / "subdir"
+        subdir.mkdir()
+        (subdir / "file1.bin").write_bytes(b"x" * (512 * 1024))
+        (subdir / "file2.bin").write_bytes(b"x" * (512 * 1024))
+
+        manager = ToolManager(cache_dir=tmp_path)
+        size = manager._get_size_mb(tmp_path)
+        assert abs(size - 1.0) < 0.01
+
+
+class TestPlatformKey:
+    """Test platform detection."""
+
+    def test_linux_platform(self, tmp_path):
+        """Returns 'linux' for Linux systems."""
+        manager = ToolManager(cache_dir=tmp_path)
+        with patch("platform.system", return_value="Linux"):
+            assert manager._get_platform_key() == "linux"
+
+    def test_macos_platform(self, tmp_path):
+        """Returns 'darwin' for macOS systems."""
+        manager = ToolManager(cache_dir=tmp_path)
+        with patch("platform.system", return_value="Darwin"):
+            assert manager._get_platform_key() == "darwin"
+
+    def test_windows_platform(self, tmp_path):
+        """Returns 'win32' for Windows systems."""
+        manager = ToolManager(cache_dir=tmp_path)
+        with patch("platform.system", return_value="Windows"):
+            assert manager._get_platform_key() == "win32"
+
+
+class TestCheckForUpdates:
+    """Test update checking."""
+
+    def test_update_available(self, tmp_path):
+        """Detects when update is available."""
+        manager = ToolManager(cache_dir=tmp_path)
+        tool_path = Path("/usr/bin/semgrep")
+
+        with (
+            patch.object(manager, "_find_tool", return_value=tool_path),
+            patch.object(manager, "_get_tool_version", return_value="1.40.0"),
+            patch.object(manager, "_get_size_mb", return_value=100.0),
+        ):
+            has_update, latest = manager.check_for_updates("semgrep")
+            assert has_update is True
+            assert latest == "1.45.0"
+
+    def test_no_update_needed(self, tmp_path):
+        """Detects when no update is needed."""
+        manager = ToolManager(cache_dir=tmp_path)
+        tool_path = Path("/usr/bin/semgrep")
+
+        with (
+            patch.object(manager, "_find_tool", return_value=tool_path),
+            patch.object(manager, "_get_tool_version", return_value="1.45.0"),
+            patch.object(manager, "_get_size_mb", return_value=100.0),
+        ):
+            has_update, latest = manager.check_for_updates("semgrep")
+            assert has_update is False
+
+    def test_unknown_tool(self, tmp_path):
+        """Unknown tool returns no update."""
+        manager = ToolManager(cache_dir=tmp_path)
+        has_update, latest = manager.check_for_updates("unknowntool")
+        assert has_update is False
+        assert latest is None
+
+
+class TestDownloadFile:
+    """Test file downloading."""
+
+    def test_download_with_timeout(self, tmp_path):
+        """Download uses timeout."""
+        manager = ToolManager(cache_dir=tmp_path)
+        dest = tmp_path / "download.zip"
+
+        with patch("specify_cli.security.tools.manager.urlopen") as mock_urlopen:
+            mock_response = MagicMock()
+            mock_response.read.side_effect = [b"data", b""]
+            mock_response.__enter__ = MagicMock(return_value=mock_response)
+            mock_response.__exit__ = MagicMock(return_value=False)
+            mock_urlopen.return_value = mock_response
+
+            manager._download_file("https://example.com/file.zip", dest)
+
+            mock_urlopen.assert_called_once_with(
+                "https://example.com/file.zip",
+                timeout=manager.DOWNLOAD_TIMEOUT_SECONDS,
+            )
+
+    def test_download_handles_url_error(self, tmp_path):
+        """Raises RuntimeError on URL error."""
+        from urllib.error import URLError
+
+        manager = ToolManager(cache_dir=tmp_path)
+        dest = tmp_path / "download.zip"
+
+        with patch(
+            "specify_cli.security.tools.manager.urlopen",
+            side_effect=URLError("Connection refused"),
+        ):
+            with pytest.raises(RuntimeError, match="Download failed"):
+                manager._download_file("https://example.com/file.zip", dest)
+
+
+class TestInstallBinary:
+    """Test binary installation."""
+
+    def test_invalid_version_rejected(self, tmp_path):
+        """Invalid version format is rejected."""
+        config = ToolConfig(
+            name="test",
+            version="invalid-version-format",
+            install_method=InstallMethod.BINARY,
+            binary_urls={"linux": "https://example.com/{version}/test.zip"},
+        )
+        manager = ToolManager(cache_dir=tmp_path)
+        result = manager._install_binary(config)
+        assert result.success is False
+        assert "Invalid version format" in result.error_message
+
+    def test_missing_platform_binary(self, tmp_path):
+        """Missing platform binary returns error."""
+        config = ToolConfig(
+            name="test",
+            version="1.0.0",
+            install_method=InstallMethod.BINARY,
+            binary_urls={},
+        )
+        manager = ToolManager(cache_dir=tmp_path)
+        result = manager._install_binary(config)
+        assert result.success is False
+        assert "No binary available" in result.error_message
+
+
+class TestDetectInstallMethod:
+    """Test install method detection."""
+
+    def test_detects_binary_from_cache(self, tmp_path):
+        """Detects binary install from cache path."""
+        manager = ToolManager(cache_dir=tmp_path)
+        tool_path = tmp_path / "semgrep" / "1.0" / "semgrep"
+        assert manager._detect_install_method(tool_path) == InstallMethod.BINARY
+
+    def test_detects_pip_from_venv(self, tmp_path):
+        """Detects pip install from venv path."""
+        manager = ToolManager(cache_dir=tmp_path)
+        tool_path = Path("/home/user/.venv/bin/semgrep")
+        assert manager._detect_install_method(tool_path) == InstallMethod.PIP
+
+    def test_detects_system_install(self, tmp_path):
+        """Detects system install from /usr/bin."""
+        manager = ToolManager(cache_dir=tmp_path)
+        tool_path = Path("/usr/bin/semgrep")
+        assert manager._detect_install_method(tool_path) == InstallMethod.SYSTEM
+
+
+class TestSecurityProtections:
+    """Test security protections in tool manager."""
+
+    def test_download_rejects_http_urls(self, tmp_path):
+        """HTTP URLs are rejected for security - only HTTPS allowed."""
+        manager = ToolManager(cache_dir=tmp_path)
+        dest = tmp_path / "download.zip"
+
+        with pytest.raises(ValueError, match="Only HTTPS URLs are allowed"):
+            manager._download_file("http://example.com/tool.zip", dest)
+
+    def test_download_error_includes_url(self, tmp_path):
+        """Error message includes the rejected URL for debugging."""
+        manager = ToolManager(cache_dir=tmp_path)
+        dest = tmp_path / "download.zip"
+
+        with pytest.raises(ValueError) as exc_info:
+            manager._download_file("http://evil.com/malware.zip", dest)
+
+        assert "http://evil.com/malware.zip" in str(exc_info.value)
+        assert "HTTPS" in str(exc_info.value)
+
+    def test_download_accepts_https_urls(self, tmp_path):
+        """HTTPS URLs are accepted."""
+        manager = ToolManager(cache_dir=tmp_path)
+        dest = tmp_path / "download.zip"
+
+        with patch("specify_cli.security.tools.manager.urlopen") as mock_urlopen:
+            mock_response = MagicMock()
+            mock_response.read.side_effect = [b"data", b""]
+            mock_response.__enter__ = MagicMock(return_value=mock_response)
+            mock_response.__exit__ = MagicMock(return_value=False)
+            mock_urlopen.return_value = mock_response
+
+            manager._download_file("https://example.com/tool.zip", dest)
+
+    def test_archive_extraction_rejects_path_traversal(self, tmp_path):
+        """Archives with path traversal (..) are rejected."""
+        manager = ToolManager(cache_dir=tmp_path)
+        extract_dir = tmp_path / "extract"
+        extract_dir.mkdir()
+
+        malicious_zip = tmp_path / "evil.zip"
+        with zipfile.ZipFile(malicious_zip, "w") as zf:
+            zf.writestr("../../../etc/passwd", "malicious content")
+
+        with pytest.raises(RuntimeError, match="path traversal"):
+            manager._safe_extract_archive(malicious_zip, extract_dir)
+
+    def test_archive_extraction_rejects_absolute_paths(self, tmp_path):
+        """Archives with absolute paths are rejected."""
+        manager = ToolManager(cache_dir=tmp_path)
+        extract_dir = tmp_path / "extract"
+        extract_dir.mkdir()
+
+        malicious_zip = tmp_path / "evil.zip"
+        with zipfile.ZipFile(malicious_zip, "w") as zf:
+            zf.writestr("/etc/passwd", "malicious content")
+
+        with pytest.raises(RuntimeError, match="absolute path"):
+            manager._safe_extract_archive(malicious_zip, extract_dir)
+
+    def test_archive_extraction_allows_safe_files(self, tmp_path):
+        """Safe archives extract correctly."""
+        manager = ToolManager(cache_dir=tmp_path)
+        extract_dir = tmp_path / "extract"
+        extract_dir.mkdir()
+
+        safe_zip = tmp_path / "safe.zip"
+        with zipfile.ZipFile(safe_zip, "w") as zf:
+            zf.writestr("tool/bin/mytool", "#!/bin/bash\necho test")
+            zf.writestr("tool/README.md", "# My Tool")
+
+        manager._safe_extract_archive(safe_zip, extract_dir)
+
+        assert (extract_dir / "tool" / "bin" / "mytool").exists()
+        assert (extract_dir / "tool" / "README.md").exists()
+
+    def test_archive_allows_filenames_with_double_dots(self, tmp_path):
+        """Legitimate filenames containing .. are allowed (not path traversal)."""
+        manager = ToolManager(cache_dir=tmp_path)
+        extract_dir = tmp_path / "extract"
+        extract_dir.mkdir()
+
+        # These filenames have ".." but are NOT path traversal
+        safe_zip = tmp_path / "legitimate.zip"
+        with zipfile.ZipFile(safe_zip, "w") as zf:
+            zf.writestr("tool/README..md", "# Documentation")
+            zf.writestr("tool/config..backup", "backup content")
+            zf.writestr("tool/file..old.txt", "old file")
+            zf.writestr("tool/.hidden..file", "hidden with dots")
+
+        manager._safe_extract_archive(safe_zip, extract_dir)
+
+        assert (extract_dir / "tool" / "README..md").exists()
+        assert (extract_dir / "tool" / "config..backup").exists()
+        assert (extract_dir / "tool" / "file..old.txt").exists()
+        assert (extract_dir / "tool" / ".hidden..file").exists()
+
+
+class TestSymlinkProtection:
+    """Test symlink attack detection."""
+
+    def test_rejects_symlinks_in_non_zip_archives(self, tmp_path):
+        """Symlinks are removed from extracted non-ZIP archives."""
+        manager = ToolManager(cache_dir=tmp_path)
+        extract_dir = tmp_path / "extract"
+        extract_dir.mkdir()
+
+        # Create a directory with a symlink
+        source_dir = tmp_path / "source"
+        source_dir.mkdir()
+        (source_dir / "normal.txt").write_text("content")
+        symlink_path = source_dir / "link"
+        symlink_path.symlink_to("/etc/passwd")
+
+        # Mock shutil.unpack_archive to simulate extraction with symlink
+        def mock_unpack(archive, dest):
+            (dest / "normal.txt").write_text("content")
+            (dest / "link").symlink_to("/etc/passwd")
+
+        with patch("shutil.unpack_archive", side_effect=mock_unpack):
+            with pytest.raises(RuntimeError, match="symlink"):
+                manager._safe_extract_archive(tmp_path / "archive.tar.gz", extract_dir)

--- a/tests/security/tools/test_models.py
+++ b/tests/security/tools/test_models.py
@@ -1,0 +1,184 @@
+"""Tests for tool dependency management models."""
+
+from pathlib import Path
+
+from specify_cli.security.tools.models import (
+    DEFAULT_TOOL_CONFIGS,
+    CacheInfo,
+    InstallMethod,
+    InstallResult,
+    ToolConfig,
+    ToolInfo,
+    ToolStatus,
+)
+
+
+class TestToolStatus:
+    """Test ToolStatus enum."""
+
+    def test_all_statuses_defined(self):
+        """All expected statuses are defined."""
+        statuses = [s.value for s in ToolStatus]
+        assert "not_installed" in statuses
+        assert "installed" in statuses
+        assert "update_available" in statuses
+        assert "license_required" in statuses
+        assert "offline_only" in statuses
+
+
+class TestInstallMethod:
+    """Test InstallMethod enum."""
+
+    def test_all_methods_defined(self):
+        """All expected install methods are defined."""
+        methods = [m.value for m in InstallMethod]
+        assert "pip" in methods
+        assert "binary" in methods
+        assert "docker" in methods
+        assert "system" in methods
+
+
+class TestToolConfig:
+    """Test ToolConfig dataclass."""
+
+    def test_minimal_config(self):
+        """Create config with minimal required fields."""
+        config = ToolConfig(name="test")
+        assert config.name == "test"
+        assert config.version is None
+        assert config.install_method == InstallMethod.PIP
+        assert config.license_check is False
+
+    def test_full_config(self):
+        """Create config with all fields."""
+        config = ToolConfig(
+            name="codeql",
+            version="2.15.0",
+            install_method=InstallMethod.BINARY,
+            license_check=True,
+            license_url="https://example.com/license",
+            binary_urls={"linux": "https://example.com/linux.zip"},
+            pip_package="codeql-cli",
+            size_estimate_mb=400,
+        )
+        assert config.name == "codeql"
+        assert config.version == "2.15.0"
+        assert config.install_method == InstallMethod.BINARY
+        assert config.license_check is True
+        assert config.size_estimate_mb == 400
+
+
+class TestToolInfo:
+    """Test ToolInfo dataclass."""
+
+    def test_create_tool_info(self):
+        """Create ToolInfo with all fields."""
+        info = ToolInfo(
+            name="semgrep",
+            version="1.45.0",
+            path=Path("/usr/bin/semgrep"),
+            status=ToolStatus.INSTALLED,
+            install_method=InstallMethod.SYSTEM,
+            size_mb=50.5,
+        )
+        assert info.name == "semgrep"
+        assert info.version == "1.45.0"
+        assert info.path == Path("/usr/bin/semgrep")
+        assert info.status == ToolStatus.INSTALLED
+        assert info.size_mb == 50.5
+
+
+class TestInstallResult:
+    """Test InstallResult dataclass."""
+
+    def test_successful_result(self):
+        """Create successful install result."""
+        info = ToolInfo(
+            name="test",
+            version="1.0",
+            path=Path("/bin/test"),
+            status=ToolStatus.INSTALLED,
+            install_method=InstallMethod.PIP,
+        )
+        result = InstallResult(success=True, tool_info=info)
+        assert result.success is True
+        assert result.tool_info is not None
+        assert result.error_message is None
+
+    def test_failed_result(self):
+        """Create failed install result."""
+        result = InstallResult(
+            success=False,
+            error_message="Installation failed: network error",
+        )
+        assert result.success is False
+        assert result.tool_info is None
+        assert "network error" in result.error_message
+
+    def test_license_required_result(self):
+        """Create license required result."""
+        result = InstallResult(
+            success=False,
+            license_required=True,
+            error_message="License acceptance required",
+        )
+        assert result.success is False
+        assert result.license_required is True
+
+
+class TestCacheInfo:
+    """Test CacheInfo dataclass."""
+
+    def test_empty_cache_info(self):
+        """Create info for empty cache."""
+        info = CacheInfo(
+            cache_dir=Path("/tmp/cache"),
+            total_size_mb=0.0,
+            tool_count=0,
+            tools=[],
+        )
+        assert info.total_size_mb == 0.0
+        assert info.tool_count == 0
+        assert info.size_warning is False
+
+    def test_cache_with_warning(self):
+        """Create info with size warning."""
+        info = CacheInfo(
+            cache_dir=Path("/tmp/cache"),
+            total_size_mb=600.0,
+            tool_count=2,
+            tools=[],
+            size_warning=True,
+            warning_threshold_mb=500,
+        )
+        assert info.size_warning is True
+        assert info.warning_threshold_mb == 500
+
+
+class TestDefaultToolConfigs:
+    """Test default tool configurations."""
+
+    def test_semgrep_config(self):
+        """Semgrep has correct default config."""
+        config = DEFAULT_TOOL_CONFIGS["semgrep"]
+        assert config.name == "semgrep"
+        assert config.install_method == InstallMethod.PIP
+        assert config.pip_package == "semgrep"
+        assert config.version is not None
+
+    def test_codeql_config(self):
+        """CodeQL has correct default config."""
+        config = DEFAULT_TOOL_CONFIGS["codeql"]
+        assert config.name == "codeql"
+        assert config.install_method == InstallMethod.BINARY
+        assert config.license_check is True
+        assert "linux" in config.binary_urls
+        assert "darwin" in config.binary_urls
+        assert "win32" in config.binary_urls
+
+    def test_bandit_config(self):
+        """Bandit has correct default config."""
+        config = DEFAULT_TOOL_CONFIGS["bandit"]
+        assert config.name == "bandit"
+        assert config.install_method == InstallMethod.PIP
+        assert config.pip_package == "bandit"


### PR DESCRIPTION
## Summary

Implements task-249: Tool dependency management for security scanners with comprehensive security hardening built in from the start.

## Features

- Auto-installation with version pinning (Semgrep 1.45.0, CodeQL 2.15.0, Bandit 1.7.7)
- License compliance checking for CodeQL with explicit acceptance
- Dependency size monitoring with 500MB warning threshold
- Offline mode for air-gapped environments
- Cross-platform support (Linux, macOS, Windows)

## Security Hardening

This implementation addresses ALL code review issues from previous closed PRs:

| Security Feature | Implementation |
|-----------------|----------------|
| HTTPS-only downloads | `ValueError` raised if URL doesn't start with `https://` |
| Path traversal protection | Uses `".." in Path(member).parts` (not string contains) |
| Allows `README..md` | Correctly allows filenames with `..` that aren't traversal |
| Symlink attack detection | ZIP symlinks detected via `external_attr`, non-ZIP symlinks removed |
| Version validation | Anchored regex `^v?(\d+\.\d+(?:\.\d+)?(?:-[\w.]+)?)$` |
| Restrictive permissions | Downloaded binaries get `0o700` (owner only) |
| Archive integrity | Validates extraction produced files |

## Test Coverage (69 tests)

### New Security Test Classes

```
TestVersionPatternAnchoring (5 tests)
├── test_exact_match_versions
├── test_rejects_versions_at_beginning_of_text
├── test_rejects_versions_at_end_of_text
├── test_rejects_versions_in_middle_of_text
└── test_rejects_malformed_versions

TestSecurityProtections (7 tests)
├── test_download_rejects_http_urls
├── test_download_error_includes_url
├── test_download_accepts_https_urls
├── test_archive_extraction_rejects_path_traversal
├── test_archive_extraction_rejects_absolute_paths
├── test_archive_extraction_allows_safe_files
└── test_archive_allows_filenames_with_double_dots  # Key fix!

TestSymlinkProtection (1 test)
└── test_rejects_symlinks_in_non_zip_archives
```

## Key Fix: Path Traversal False Positive

Previous PRs used `if ".." in member` which incorrectly rejected legitimate filenames:

```python
# OLD (false positives):
if ".." in member:  # Rejects "README..md" ❌

# NEW (correct):
if ".." in Path(member).parts:  # Allows "README..md" ✅
```

## Test Plan

- [x] All 69 new tool management tests pass
- [x] All 2479 total tests pass
- [x] `ruff format --check .` passes
- [x] `ruff check .` passes
- [x] DCO sign-off included

## Files Changed

| File | Lines | Description |
|------|-------|-------------|
| `src/specify_cli/security/tools/__init__.py` | 31 | Module exports |
| `src/specify_cli/security/tools/models.py` | 145 | Data models |
| `src/specify_cli/security/tools/manager.py` | 587 | ToolManager class |
| `tests/security/tools/test_manager.py` | 673 | Manager tests |
| `tests/security/tools/test_models.py` | 185 | Model tests |

🤖 Generated with [Claude Code](https://claude.com/claude-code)