### PR TITLE
fix(commands): correct broken constitution.md symlink (task-272)

### DIFF
--- a/.claude/commands/speckit/constitution.md
+++ b/.claude/commands/speckit/constitution.md
@@ -1,1 +1,1 @@
-../../../templates/commands/constitution.md
+../../../templates/commands/speckit/constitution.md


### PR DESCRIPTION
## Summary

Fixes the broken `constitution.md` symlink that was left over after the speckit migration.

### Problem
After the speckit commands were moved to `templates/commands/speckit/`, the symlink at `.claude/commands/speckit/constitution.md` was still pointing to the old path:
```
../../../templates/commands/constitution.md  (deleted)
```

### Fix
Updated the symlink to point to the correct path:
```
../../../templates/commands/speckit/constitution.md
```

### Verification
- ✅ All 8 speckit symlinks now resolve correctly
- ✅ All 29 dev-setup tests pass
- ✅ All 2489 project tests pass

## Test plan
- [x] Verify symlink resolves: `cat .claude/commands/speckit/constitution.md`
- [x] Run dev-setup tests: `pytest tests/test_dev_setup_*.py`
- [x] Run full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)