### PR TITLE
feat(init): add workflow transition validation configuration (task-182)

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -1233,6 +1233,107 @@ WORKFLOW_TRANSITIONS = [
 ]
 
 
+def prompt_validation_modes() -> dict[str, str]:
+    """Interactively prompt for validation mode on each transition.
+
+    Returns:
+        Dict mapping transition name to validation mode string.
+        Example: {"assess": "none", "specify": 'KEYWORD["PRD_APPROVED"]'}
+
+    Raises:
+        typer.Exit: If user cancels with Ctrl+C.
+    """
+    # Transitions to configure with descriptions
+    transitions_info = [
+        ("assess", "To Do → Assessed", "after /jpspec:assess"),
+        ("specify", "Assessed → Specified", "after /jpspec:specify, produces PRD"),
+        ("research", "Specified → Researched", "after /jpspec:research"),
+        ("plan", "Researched → Planned", "after /jpspec:plan, produces ADRs"),
+        ("implement", "Planned → In Implementation", "after /jpspec:implement"),
+        ("validate", "In Implementation → Validated", "after /jpspec:validate"),
+        ("operate", "Validated → Deployed", "after /jpspec:operate"),
+    ]
+
+    modes: dict[str, str] = {}
+
+    console.print()
+    console.print("[cyan]== Workflow Transition Validation Configuration ==[/cyan]")
+    console.print()
+    console.print("For each workflow transition, choose a validation mode:")
+    console.print("  - [green]NONE[/green]: No gate, proceed immediately (default)")
+    console.print("  - [yellow]KEYWORD[/yellow]: Require user to type approval keyword")
+    console.print("  - [blue]PULL_REQUEST[/blue]: Require PR to be merged")
+    console.print()
+
+    try:
+        for i, (name, state_change, description) in enumerate(transitions_info, 1):
+            console.print(f"[dim]{i}. {state_change}[/dim] ({description})")
+            console.print("   [1] NONE (default)")
+            console.print("   [2] KEYWORD")
+            console.print("   [3] PULL_REQUEST")
+
+            choice = typer.prompt("   > ", default="1")
+
+            # Validate and normalize choice
+            if choice not in ["1", "2", "3"]:
+                console.print(
+                    f"   [yellow]Invalid choice '{choice}', using NONE[/yellow]"
+                )
+                choice = "1"
+
+            if choice == "2":
+                keyword = typer.prompt("   Enter approval keyword", default="APPROVED")
+                if not keyword or not keyword.strip():
+                    console.print(
+                        "   [yellow]Empty keyword, using default 'APPROVED'[/yellow]"
+                    )
+                    keyword = "APPROVED"
+                modes[name] = f'KEYWORD["{keyword.strip()}"]'
+            elif choice == "3":
+                modes[name] = "pull-request"
+            else:
+                modes[name] = "none"
+
+            console.print()
+
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Validation mode configuration cancelled[/yellow]")
+        raise typer.Exit(1)
+
+    return modes
+
+
+def display_validation_summary(modes: dict[str, str]) -> None:
+    """Display a formatted summary of configured validation modes.
+
+    Args:
+        modes: Dict mapping transition name to validation mode string.
+    """
+    console.print()
+    console.print("[cyan]== Validation Mode Summary ==[/cyan]")
+    console.print()
+
+    # Filter to show only non-default modes
+    non_default = {k: v for k, v in modes.items() if v.lower() != "none"}
+
+    if non_default:
+        console.print("[green]Custom validation modes:[/green]")
+        for name, mode in non_default.items():
+            # Format the mode for display
+            if mode.lower().startswith("keyword["):
+                display_mode = mode.upper()
+            elif mode.lower() == "pull-request":
+                display_mode = "PULL_REQUEST"
+            else:
+                display_mode = mode.upper()
+
+            console.print(f"  [cyan]{name:12}[/cyan] → {display_mode}")
+    else:
+        console.print("[dim]All transitions using NONE (default)[/dim]")
+
+    console.print()
+
+
 def generate_jpspec_workflow_yml(
     project_path: Path,
     transition_modes: dict[str, str] | None = None,
@@ -2351,6 +2452,11 @@ def init(
         "--no-validation-prompts",
         help="Skip validation prompts and use NONE for all transitions",
     ),
+    validation_mode: str = typer.Option(
+        None,
+        "--validation-mode",
+        help="Set validation mode for ALL transitions: none, keyword, or pull-request. Per-transition flags override this.",
+    ),
     light: bool = typer.Option(
         False,
         "--light",
@@ -2983,31 +3089,74 @@ def init(
         )
 
     # Generate workflow configuration file with per-transition validation modes
+    # Priority order:
+    # 1. --no-validation-prompts: all NONE, no prompts
+    # 2. Per-transition flags (--validation-assess, etc.): explicit overrides
+    # 3. --validation-mode: batch mode for all transitions
+    # 4. Interactive prompts: if TTY and no explicit configuration
+
+    transition_names = [
+        "assess",
+        "research",
+        "specify",
+        "plan",
+        "implement",
+        "validate",
+        "operate",
+    ]
+    per_transition_flags = {
+        "assess": validation_assess,
+        "research": validation_research,
+        "specify": validation_specify,
+        "plan": validation_plan,
+        "implement": validation_implement,
+        "validate": validation_validate,
+        "operate": validation_operate,
+    }
+
     if no_validation_prompts:
-        # Use NONE for all transitions
-        transition_modes = {}
+        # Highest priority: --no-validation-prompts means all NONE
+        transition_modes: dict[str, str] = {}
+    elif validation_mode is not None:
+        # Batch mode: set all transitions to the specified mode
+        # But per-transition flags can still override
+        valid_batch_modes = {"none", "keyword", "pull-request"}
+        if validation_mode.lower() not in valid_batch_modes:
+            console.print(
+                f"[red]Error:[/red] Invalid --validation-mode '{validation_mode}'. "
+                f"Must be one of: {', '.join(valid_batch_modes)}"
+            )
+            raise typer.Exit(1)
+
+        # Start with batch mode for all transitions
+        transition_modes = {name: validation_mode.lower() for name in transition_names}
+
+        # Per-transition flags override batch mode
+        for name, flag_value in per_transition_flags.items():
+            if flag_value.lower() != "none":  # Only override if explicitly set
+                transition_modes[name] = flag_value
     else:
-        # Build per-transition mode dict from CLI flags
-        transition_modes = {
-            "assess": validation_assess,
-            "research": validation_research,
-            "specify": validation_specify,
-            "plan": validation_plan,
-            "implement": validation_implement,
-            "validate": validation_validate,
-            "operate": validation_operate,
-        }
+        # Check if any per-transition flag was explicitly set (non-default)
+        any_explicit = any(
+            v.lower() != "none" for v in per_transition_flags.values()
+        )
+
+        if any_explicit:
+            # Use per-transition flags as specified
+            transition_modes = per_transition_flags.copy()
+        elif sys.stdin.isatty() and sys.stdout.isatty():
+            # Interactive mode: prompt user for each transition
+            transition_modes = prompt_validation_modes()
+        else:
+            # Non-interactive with no explicit flags: use defaults (all NONE)
+            transition_modes = {}
 
     generate_jpspec_workflow_yml(project_path, transition_modes)
     console.print()
     console.print("[green]Generated jpspec_workflow.yml[/green]")
 
-    # Show non-default validation modes
-    non_default = {k: v for k, v in transition_modes.items() if v.lower() != "none"}
-    if non_default:
-        console.print("[dim]Custom validation modes:[/dim]")
-        for name, mode in non_default.items():
-            console.print(f"  [dim]{name}: {mode.upper()}[/dim]")
+    # Display validation summary
+    display_validation_summary(transition_modes)
 
     steps_lines = []
     if not here:
@@ -4917,6 +5066,149 @@ workflow_app = typer.Typer(
     add_completion=False,
 )
 app.add_typer(workflow_app, name="workflow")
+
+# Config subcommand group for managing configuration
+config_app = typer.Typer(
+    name="config",
+    help="Manage Specify configuration",
+    add_completion=False,
+)
+app.add_typer(config_app, name="config")
+
+
+@config_app.command("validation")
+def config_validation(
+    show: bool = typer.Option(
+        False,
+        "--show",
+        help="Show current validation configuration",
+    ),
+    transition: str = typer.Option(
+        None,
+        "--transition",
+        "-t",
+        help="Transition to update (assess, specify, research, plan, implement, validate, operate)",
+    ),
+    mode: str = typer.Option(
+        None,
+        "--mode",
+        "-m",
+        help="Validation mode: none, keyword, or pull-request",
+    ),
+    keyword: str = typer.Option(
+        "APPROVED",
+        "--keyword",
+        "-k",
+        help="Approval keyword for KEYWORD mode (default: APPROVED)",
+    ),
+) -> None:
+    """View or update workflow transition validation configuration.
+
+    Examples:
+        specify config validation --show
+        specify config validation -t plan -m pull-request
+        specify config validation -t specify -m keyword -k PRD_APPROVED
+    """
+    import yaml
+
+    workflow_path = Path.cwd() / "jpspec_workflow.yml"
+
+    if not workflow_path.exists():
+        console.print("[red]Error:[/red] No jpspec_workflow.yml found in current directory")
+        console.print("[dim]Run 'specify init' first to create a project[/dim]")
+        raise typer.Exit(1)
+
+    # Load current config
+    with workflow_path.open() as f:
+        config = yaml.safe_load(f)
+
+    transitions = config.get("transitions", [])
+    valid_transitions = {t["name"] for t in transitions}
+
+    # Default behavior: show configuration
+    if not transition and not mode:
+        show = True
+
+    # Show current configuration
+    if show:
+        console.print()
+        console.print("[cyan]== Validation Configuration ==[/cyan]")
+        console.print()
+
+        for t in transitions:
+            name = t["name"]
+            validation = t.get("validation", "NONE")
+
+            # Color code based on mode
+            if validation == "NONE":
+                mode_display = "[green]NONE[/green]"
+            elif validation.startswith("KEYWORD"):
+                mode_display = f"[yellow]{validation}[/yellow]"
+            elif validation == "PULL_REQUEST":
+                mode_display = "[blue]PULL_REQUEST[/blue]"
+            else:
+                mode_display = validation
+
+            from_state = t.get("from", "?")
+            to_state = t.get("to", "?")
+            console.print(f"  [cyan]{name:12}[/cyan] {from_state} → {to_state}: {mode_display}")
+
+        console.print()
+        return
+
+    # Validate update parameters
+    if transition and not mode:
+        console.print("[red]Error:[/red] --mode is required when --transition is specified")
+        raise typer.Exit(1)
+
+    if mode and not transition:
+        console.print("[red]Error:[/red] --transition is required when --mode is specified")
+        raise typer.Exit(1)
+
+    # Validate transition name
+    if transition not in valid_transitions:
+        console.print(f"[red]Error:[/red] Unknown transition '{transition}'")
+        console.print(f"[dim]Valid transitions: {', '.join(sorted(valid_transitions))}[/dim]")
+        raise typer.Exit(1)
+
+    # Validate mode
+    valid_modes = {"none", "keyword", "pull-request"}
+    if mode.lower() not in valid_modes:
+        console.print(f"[red]Error:[/red] Invalid mode '{mode}'")
+        console.print(f"[dim]Valid modes: {', '.join(valid_modes)}[/dim]")
+        raise typer.Exit(1)
+
+    # Format the mode for YAML
+    if mode.lower() == "none":
+        formatted_mode = "NONE"
+    elif mode.lower() == "keyword":
+        formatted_mode = f'KEYWORD["{keyword}"]'
+    elif mode.lower() == "pull-request":
+        formatted_mode = "PULL_REQUEST"
+    else:
+        formatted_mode = "NONE"
+
+    # Update the transition
+    for t in transitions:
+        if t["name"] == transition:
+            t["validation"] = formatted_mode
+            break
+
+    # Write back to file
+    with workflow_path.open("w") as f:
+        # Write header comments
+        f.write("# JPSpec Workflow Configuration\n")
+        f.write('version: "1.0"\n\n')
+        f.write("transitions:\n")
+
+        for t in transitions:
+            f.write(f"  - name: {t['name']}\n")
+            f.write(f'    from: "{t["from"]}"\n')
+            f.write(f'    to: "{t["to"]}"\n')
+            f.write(f"    validation: {t['validation']}\n\n")
+
+    console.print(f"[green]Updated[/green] {transition} → {formatted_mode}")
+
 
 # Hooks app (event emission and hook management)
 from specify_cli.hooks.cli import hooks_app  # noqa: E402

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,232 @@
+"""Tests for specify config validation command (AC9).
+
+These tests verify AC9: Support reconfiguration via `specify config validation`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from specify_cli import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def workflow_content() -> str:
+    """Return sample workflow YAML content."""
+    return """# JPSpec Workflow Configuration
+version: "1.0"
+
+transitions:
+  - name: assess
+    from: "To Do"
+    to: "Assessed"
+    validation: NONE
+
+  - name: research
+    from: "Assessed"
+    to: "Researched"
+    validation: NONE
+
+  - name: specify
+    from: "Researched"
+    to: "Specified"
+    validation: NONE
+
+  - name: plan
+    from: "Specified"
+    to: "Planned"
+    validation: NONE
+
+  - name: implement
+    from: "Planned"
+    to: "Implemented"
+    validation: NONE
+
+  - name: validate
+    from: "Implemented"
+    to: "Validated"
+    validation: NONE
+
+  - name: operate
+    from: "Validated"
+    to: "Operated"
+    validation: NONE
+"""
+
+
+@pytest.fixture
+def initialized_project(
+    tmp_path: Path, workflow_content: str, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    """Create a temp directory with jpspec_workflow.yml and chdir to it."""
+    workflow_file = tmp_path / "jpspec_workflow.yml"
+    workflow_file.write_text(workflow_content)
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+class TestConfigValidationShow:
+    """Tests for specify config validation --show."""
+
+    def test_show_displays_config(self, initialized_project: Path) -> None:
+        """Test --show displays current configuration."""
+        result = runner.invoke(app, ["config", "validation", "--show"])
+        assert result.exit_code == 0
+        assert "Validation Configuration" in result.output
+        assert "assess" in result.output
+        assert "plan" in result.output
+
+    def test_show_no_workflow_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test error when no jpspec_workflow.yml exists."""
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["config", "validation", "--show"])
+        assert result.exit_code == 1
+        assert "No jpspec_workflow.yml" in result.output
+
+
+class TestConfigValidationDefaultBehavior:
+    """Tests for default behavior (no flags)."""
+
+    def test_default_shows_config(self, initialized_project: Path) -> None:
+        """Test default behavior shows configuration."""
+        result = runner.invoke(app, ["config", "validation"])
+        assert result.exit_code == 0
+        assert "Validation Configuration" in result.output
+
+
+class TestConfigValidationSingleUpdate:
+    """Tests for updating single transition."""
+
+    def test_update_single_transition_none(self, initialized_project: Path) -> None:
+        """Test updating single transition to NONE."""
+        result = runner.invoke(
+            app, ["config", "validation", "-t", "plan", "-m", "none"]
+        )
+        assert result.exit_code == 0
+        assert "Updated" in result.output
+
+    def test_update_single_transition_keyword(self, initialized_project: Path) -> None:
+        """Test updating single transition to KEYWORD with custom keyword."""
+        result = runner.invoke(
+            app,
+            ["config", "validation", "-t", "specify", "-m", "keyword", "-k", "LGTM"],
+        )
+        assert result.exit_code == 0
+        workflow = (initialized_project / "jpspec_workflow.yml").read_text()
+        assert 'KEYWORD["LGTM"]' in workflow
+
+    def test_update_single_transition_keyword_default(
+        self, initialized_project: Path
+    ) -> None:
+        """Test updating single transition to KEYWORD uses default keyword."""
+        result = runner.invoke(
+            app, ["config", "validation", "-t", "specify", "-m", "keyword"]
+        )
+        assert result.exit_code == 0
+        workflow = (initialized_project / "jpspec_workflow.yml").read_text()
+        assert 'KEYWORD["APPROVED"]' in workflow
+
+    def test_update_single_transition_pull_request(
+        self, initialized_project: Path
+    ) -> None:
+        """Test updating single transition to PULL_REQUEST."""
+        result = runner.invoke(
+            app, ["config", "validation", "-t", "plan", "-m", "pull-request"]
+        )
+        assert result.exit_code == 0
+        workflow = (initialized_project / "jpspec_workflow.yml").read_text()
+        assert "PULL_REQUEST" in workflow
+
+    def test_update_invalid_transition(self, initialized_project: Path) -> None:
+        """Test error for invalid transition name."""
+        result = runner.invoke(
+            app, ["config", "validation", "-t", "invalid", "-m", "none"]
+        )
+        assert result.exit_code == 1
+        assert "Unknown transition" in result.output
+
+    def test_update_invalid_mode(self, initialized_project: Path) -> None:
+        """Test error for invalid mode."""
+        result = runner.invoke(
+            app, ["config", "validation", "-t", "plan", "-m", "invalid"]
+        )
+        assert result.exit_code == 1
+        assert "Invalid mode" in result.output
+
+    def test_transition_without_mode(self, initialized_project: Path) -> None:
+        """Test error when --transition without --mode."""
+        result = runner.invoke(app, ["config", "validation", "-t", "plan"])
+        assert result.exit_code == 1
+        assert "--mode is required" in result.output
+
+    def test_mode_without_transition(self, initialized_project: Path) -> None:
+        """Test error when --mode without --transition."""
+        result = runner.invoke(app, ["config", "validation", "-m", "none"])
+        assert result.exit_code == 1
+        assert "--transition is required" in result.output
+
+
+class TestConfigValidationColorOutput:
+    """Tests for colored output based on validation mode."""
+
+    def test_none_mode_shows_in_output(self, initialized_project: Path) -> None:
+        """Test NONE mode is displayed in output."""
+        result = runner.invoke(app, ["config", "validation", "--show"])
+        assert result.exit_code == 0
+        assert "NONE" in result.output
+
+    def test_keyword_mode_shows_in_output(self, initialized_project: Path) -> None:
+        """Test KEYWORD mode is displayed after update."""
+        # First update to KEYWORD
+        runner.invoke(
+            app, ["config", "validation", "-t", "plan", "-m", "keyword", "-k", "TEST"]
+        )
+        result = runner.invoke(app, ["config", "validation", "--show"])
+        assert result.exit_code == 0
+        assert "KEYWORD" in result.output
+
+    def test_pull_request_mode_shows_in_output(self, initialized_project: Path) -> None:
+        """Test PULL_REQUEST mode is displayed after update."""
+        # First update to PULL_REQUEST
+        runner.invoke(app, ["config", "validation", "-t", "plan", "-m", "pull-request"])
+        result = runner.invoke(app, ["config", "validation", "--show"])
+        assert result.exit_code == 0
+        assert "PULL_REQUEST" in result.output
+
+
+class TestConfigValidationPreservesOtherTransitions:
+    """Tests ensuring updates don't affect other transitions."""
+
+    def test_update_preserves_other_transitions(
+        self, initialized_project: Path
+    ) -> None:
+        """Test that updating one transition doesn't change others."""
+        # Update plan to PULL_REQUEST
+        runner.invoke(app, ["config", "validation", "-t", "plan", "-m", "pull-request"])
+
+        # Verify plan changed
+        workflow = (initialized_project / "jpspec_workflow.yml").read_text()
+        assert "validation: PULL_REQUEST" in workflow
+
+        # Verify other transitions still NONE
+        assert workflow.count("validation: NONE") >= 6
+
+    def test_multiple_updates_preserved(self, initialized_project: Path) -> None:
+        """Test that multiple sequential updates are preserved."""
+        # Update plan to PULL_REQUEST
+        runner.invoke(app, ["config", "validation", "-t", "plan", "-m", "pull-request"])
+        # Update specify to KEYWORD
+        runner.invoke(
+            app, ["config", "validation", "-t", "specify", "-m", "keyword", "-k", "OK"]
+        )
+
+        workflow = (initialized_project / "jpspec_workflow.yml").read_text()
+        assert "PULL_REQUEST" in workflow
+        assert 'KEYWORD["OK"]' in workflow

--- a/tests/test_init_batch_validation.py
+++ b/tests/test_init_batch_validation.py
@@ -1,0 +1,234 @@
+"""Tests for batch --validation-mode flag in specify init (AC6).
+
+These tests verify AC6: Add --validation-mode {none|keyword|pull-request} flag
+for setting all transitions at once.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from specify_cli import app
+
+runner = CliRunner()
+
+
+class TestBatchValidationModeFlag:
+    """Tests for the --validation-mode batch flag."""
+
+    def test_batch_none_sets_all_none(self, tmp_path: Path) -> None:
+        """Test --validation-mode none sets all transitions to NONE."""
+        project_dir = tmp_path / "test-project"
+        result = runner.invoke(
+            app,
+            [
+                "init",
+                str(project_dir),
+                "--ai",
+                "claude",
+                "--no-git",
+                "--validation-mode",
+                "none",
+            ],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        assert "Generated jpspec_workflow.yml" in result.output
+
+        workflow_file = project_dir / "jpspec_workflow.yml"
+        assert workflow_file.exists()
+        content = workflow_file.read_text()
+        # All transitions should be NONE
+        assert content.count("validation: NONE") >= 7
+
+    def test_batch_keyword_sets_all_keyword(self, tmp_path: Path) -> None:
+        """Test --validation-mode keyword sets all transitions to KEYWORD."""
+        project_dir = tmp_path / "test-project"
+        result = runner.invoke(
+            app,
+            [
+                "init",
+                str(project_dir),
+                "--ai",
+                "claude",
+                "--no-git",
+                "--validation-mode",
+                "keyword",
+            ],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        assert "Generated jpspec_workflow.yml" in result.output
+
+        workflow_file = project_dir / "jpspec_workflow.yml"
+        assert workflow_file.exists()
+        content = workflow_file.read_text()
+        # All transitions should use KEYWORD with default "APPROVED"
+        assert content.count('KEYWORD["APPROVED"]') >= 7
+
+    def test_batch_pull_request_sets_all_pull_request(self, tmp_path: Path) -> None:
+        """Test --validation-mode pull-request sets all transitions to PULL_REQUEST."""
+        project_dir = tmp_path / "test-project"
+        result = runner.invoke(
+            app,
+            [
+                "init",
+                str(project_dir),
+                "--ai",
+                "claude",
+                "--no-git",
+                "--validation-mode",
+                "pull-request",
+            ],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        assert "Generated jpspec_workflow.yml" in result.output
+
+        workflow_file = project_dir / "jpspec_workflow.yml"
+        assert workflow_file.exists()
+        content = workflow_file.read_text()
+        # All transitions should be PULL_REQUEST
+        assert content.count("validation: PULL_REQUEST") >= 7
+
+    def test_invalid_batch_mode_fails(self, tmp_path: Path) -> None:
+        """Test that invalid --validation-mode value fails with error."""
+        project_dir = tmp_path / "test-project"
+        result = runner.invoke(
+            app,
+            [
+                "init",
+                str(project_dir),
+                "--ai",
+                "claude",
+                "--no-git",
+                "--validation-mode",
+                "invalid",
+            ],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 1
+        assert "Invalid --validation-mode" in result.output
+
+    def test_per_transition_overrides_batch(self, tmp_path: Path) -> None:
+        """Test that per-transition flags override batch mode."""
+        project_dir = tmp_path / "test-project"
+        result = runner.invoke(
+            app,
+            [
+                "init",
+                str(project_dir),
+                "--ai",
+                "claude",
+                "--no-git",
+                "--validation-mode",
+                "none",
+                "--validation-plan",
+                "pull-request",
+            ],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        assert "Generated jpspec_workflow.yml" in result.output
+
+        workflow_file = project_dir / "jpspec_workflow.yml"
+        assert workflow_file.exists()
+        content = workflow_file.read_text()
+
+        # Plan should be PULL_REQUEST (override)
+        assert "validation: PULL_REQUEST" in content
+        # Others should still be NONE from batch
+        assert "validation: NONE" in content
+
+    def test_no_validation_prompts_takes_precedence(self, tmp_path: Path) -> None:
+        """Test that --no-validation-prompts takes precedence over --validation-mode."""
+        project_dir = tmp_path / "test-project"
+        result = runner.invoke(
+            app,
+            [
+                "init",
+                str(project_dir),
+                "--ai",
+                "claude",
+                "--no-git",
+                "--no-validation-prompts",
+                "--validation-mode",
+                "pull-request",
+            ],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+
+        workflow_file = project_dir / "jpspec_workflow.yml"
+        assert workflow_file.exists()
+        content = workflow_file.read_text()
+        # Should be all NONE due to --no-validation-prompts precedence
+        assert content.count("validation: NONE") >= 7
+
+
+class TestValidationModeInWorkflowFile:
+    """Tests verifying validation modes are correctly written to workflow file."""
+
+    def test_workflow_file_has_version(self, tmp_path: Path) -> None:
+        """Test that generated workflow file has version field."""
+        project_dir = tmp_path / "test-project"
+        result = runner.invoke(
+            app,
+            ["init", str(project_dir), "--ai", "claude", "--no-git", "--validation-mode", "none"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+
+        workflow_file = project_dir / "jpspec_workflow.yml"
+        content = workflow_file.read_text()
+        assert 'version: "1.0"' in content
+
+    def test_workflow_file_has_transitions_section(self, tmp_path: Path) -> None:
+        """Test that generated workflow file has transitions section."""
+        project_dir = tmp_path / "test-project"
+        result = runner.invoke(
+            app,
+            ["init", str(project_dir), "--ai", "claude", "--no-git", "--validation-mode", "none"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+
+        workflow_file = project_dir / "jpspec_workflow.yml"
+        content = workflow_file.read_text()
+        assert "transitions:" in content
+
+    def test_workflow_file_has_all_transitions(self, tmp_path: Path) -> None:
+        """Test that workflow file contains all standard transitions."""
+        project_dir = tmp_path / "test-project"
+        result = runner.invoke(
+            app,
+            ["init", str(project_dir), "--ai", "claude", "--no-git", "--validation-mode", "none"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+
+        workflow_file = project_dir / "jpspec_workflow.yml"
+        content = workflow_file.read_text()
+
+        expected_transitions = [
+            "assess",
+            "specify",
+            "research",
+            "plan",
+            "implement",
+            "validate",
+            "operate",
+        ]
+        for t in expected_transitions:
+            assert f"name: {t}" in content, f"Missing transition {t}"

--- a/tests/test_init_validation_prompts.py
+++ b/tests/test_init_validation_prompts.py
@@ -1,0 +1,300 @@
+"""Tests for interactive validation mode prompts in specify init (AC1-4, AC8).
+
+These tests verify:
+- AC1: Add validation mode prompts to specify init command
+- AC2: Support NONE selection (default, press Enter)
+- AC3: Support KEYWORD selection with custom keyword input
+- AC4: Support PULL_REQUEST selection
+- AC8: Display summary of configured validation modes at end
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from specify_cli import (
+    WORKFLOW_TRANSITIONS,
+    display_validation_summary,
+    prompt_validation_modes,
+)
+
+runner = CliRunner()
+
+
+class TestPromptValidationModes:
+    """Tests for the prompt_validation_modes() helper function."""
+
+    def test_all_defaults_returns_all_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that pressing Enter for all prompts returns all NONE modes."""
+        # Mock typer.prompt to return default "1" for mode and empty for keyword
+        mock_prompt = MagicMock(side_effect=["1"] * 7)
+        monkeypatch.setattr("specify_cli.typer.prompt", mock_prompt)
+
+        result = prompt_validation_modes()
+
+        assert len(result) == 7
+        for mode in result.values():
+            assert mode == "none"
+
+    def test_keyword_selection_prompts_for_keyword(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that selecting KEYWORD (option 2) prompts for the keyword."""
+        # Simulate: select KEYWORD for specify transition, then enter custom keyword
+        prompt_responses = [
+            "1",  # assess: NONE
+            "1",  # specify: We'll override below
+            "1",  # research: NONE
+            "1",  # plan: NONE
+            "1",  # implement: NONE
+            "1",  # validate: NONE
+            "1",  # operate: NONE
+        ]
+        prompt_responses[1] = "2"  # Change specify to KEYWORD
+
+        # For KEYWORD, we need an additional prompt for the keyword value
+        prompt_index = [0]
+
+        def mock_prompt(message: str, default: str = "") -> str:
+            idx = prompt_index[0]
+            prompt_index[0] += 1
+
+            # Return keyword when prompted for keyword
+            if "keyword" in message.lower():
+                return "PRD_APPROVED"
+
+            # Return the choice for transition prompts
+            if idx < len(prompt_responses):
+                return prompt_responses[idx]
+            return default
+
+        monkeypatch.setattr("specify_cli.typer.prompt", mock_prompt)
+
+        result = prompt_validation_modes()
+
+        assert result["specify"] == 'KEYWORD["PRD_APPROVED"]'
+        assert result["assess"] == "none"
+
+    def test_pull_request_selection(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that selecting PULL_REQUEST (option 3) sets the correct mode."""
+        # Select PULL_REQUEST for plan transition
+        call_count = [0]
+
+        def mock_prompt(message: str, default: str = "") -> str:
+            call_count[0] += 1
+            # Plan is the 4th transition
+            if call_count[0] == 4:
+                return "3"  # PULL_REQUEST
+            return "1"  # NONE for others
+
+        monkeypatch.setattr("specify_cli.typer.prompt", mock_prompt)
+
+        result = prompt_validation_modes()
+
+        assert result["plan"] == "pull-request"
+        assert result["assess"] == "none"
+        assert result["specify"] == "none"
+
+    def test_invalid_choice_defaults_to_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that invalid choices default to NONE."""
+        call_count = [0]
+
+        def mock_prompt(message: str, default: str = "") -> str:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return "invalid"
+            return "1"
+
+        monkeypatch.setattr("specify_cli.typer.prompt", mock_prompt)
+
+        result = prompt_validation_modes()
+
+        # First transition should be NONE due to invalid choice
+        assert result["assess"] == "none"
+
+    def test_empty_keyword_uses_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that empty keyword input uses APPROVED as default."""
+        call_count = [0]
+
+        def mock_prompt(message: str, default: str = "") -> str:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return "2"  # KEYWORD for first transition
+            if "keyword" in message.lower():
+                return ""  # Empty keyword
+            return "1"
+
+        monkeypatch.setattr("specify_cli.typer.prompt", mock_prompt)
+
+        result = prompt_validation_modes()
+
+        assert result["assess"] == 'KEYWORD["APPROVED"]'
+
+    def test_keyboard_interrupt_exits(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that Ctrl+C during prompts raises typer.Exit."""
+        import typer
+
+        def mock_prompt(message: str, default: str = "") -> str:
+            raise KeyboardInterrupt()
+
+        monkeypatch.setattr("specify_cli.typer.prompt", mock_prompt)
+
+        with pytest.raises(typer.Exit):
+            prompt_validation_modes()
+
+    def test_all_transitions_covered(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that all 7 standard transitions are covered."""
+        mock_prompt = MagicMock(return_value="1")
+        monkeypatch.setattr("specify_cli.typer.prompt", mock_prompt)
+
+        result = prompt_validation_modes()
+
+        expected_transitions = {t["name"] for t in WORKFLOW_TRANSITIONS}
+        assert set(result.keys()) == expected_transitions
+
+
+class TestDisplayValidationSummary:
+    """Tests for the display_validation_summary() helper function."""
+
+    def test_empty_modes_shows_default_message(self, capsys: pytest.CaptureFixture) -> None:
+        """Test that empty modes dict shows default message."""
+        with patch("specify_cli.console.print") as mock_print:
+            display_validation_summary({})
+
+            # Verify the default message was printed
+            printed_calls = [str(call) for call in mock_print.call_args_list]
+            assert any("All transitions using NONE" in str(call) for call in printed_calls)
+
+    def test_all_none_shows_default_message(self) -> None:
+        """Test that all NONE modes shows default message."""
+        modes = {
+            "assess": "none",
+            "specify": "none",
+            "plan": "none",
+        }
+
+        with patch("specify_cli.console.print") as mock_print:
+            display_validation_summary(modes)
+
+            printed_calls = [str(call) for call in mock_print.call_args_list]
+            assert any("All transitions using NONE" in str(call) for call in printed_calls)
+
+    def test_non_default_modes_displayed(self) -> None:
+        """Test that non-default modes are displayed in summary."""
+        modes = {
+            "assess": "none",
+            "specify": 'KEYWORD["PRD"]',
+            "plan": "pull-request",
+        }
+
+        with patch("specify_cli.console.print") as mock_print:
+            display_validation_summary(modes)
+
+            printed_calls = [str(call) for call in mock_print.call_args_list]
+            # Should show the custom modes
+            all_output = " ".join(str(c) for c in printed_calls)
+            assert "specify" in all_output
+            assert "plan" in all_output
+
+    def test_keyword_mode_uppercase_display(self) -> None:
+        """Test that KEYWORD modes are displayed in uppercase."""
+        modes = {"specify": 'keyword["test"]'}
+
+        with patch("specify_cli.console.print") as mock_print:
+            display_validation_summary(modes)
+
+            printed_calls = [str(call) for call in mock_print.call_args_list]
+            all_output = " ".join(str(c) for c in printed_calls)
+            assert "KEYWORD" in all_output
+
+    def test_pull_request_mode_formatted(self) -> None:
+        """Test that pull-request mode is displayed as PULL_REQUEST."""
+        modes = {"plan": "pull-request"}
+
+        with patch("specify_cli.console.print") as mock_print:
+            display_validation_summary(modes)
+
+            printed_calls = [str(call) for call in mock_print.call_args_list]
+            all_output = " ".join(str(c) for c in printed_calls)
+            assert "PULL_REQUEST" in all_output
+
+
+class TestInitInteractivePrompts:
+    """Tests for interactive prompts during specify init."""
+
+    def test_non_interactive_skips_prompts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that non-interactive mode (no TTY) skips validation prompts."""
+        from specify_cli import app
+
+        # Mock stdin.isatty to return False
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+        monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+
+        project_dir = tmp_path / "test-project"
+        result = runner.invoke(
+            app,
+            ["init", str(project_dir), "--ai", "claude", "--no-git"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        # Should generate workflow file with defaults
+        workflow_file = project_dir / "jpspec_workflow.yml"
+        assert workflow_file.exists()
+        content = workflow_file.read_text()
+        # All should be NONE (default)
+        assert content.count("validation: NONE") >= 7
+
+    def test_no_validation_prompts_flag_skips_interactive(
+        self, tmp_path: Path
+    ) -> None:
+        """Test that --no-validation-prompts skips interactive prompts."""
+        from specify_cli import app
+
+        project_dir = tmp_path / "test-project"
+        result = runner.invoke(
+            app,
+            [
+                "init",
+                str(project_dir),
+                "--ai",
+                "claude",
+                "--no-git",
+                "--no-validation-prompts",
+            ],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        workflow_file = project_dir / "jpspec_workflow.yml"
+        assert workflow_file.exists()
+        content = workflow_file.read_text()
+        # All should be NONE
+        assert content.count("validation: NONE") >= 7
+
+
+class TestWorkflowTransitionsConstant:
+    """Tests for WORKFLOW_TRANSITIONS constant."""
+
+    def test_has_seven_transitions(self) -> None:
+        """Test that WORKFLOW_TRANSITIONS has all 7 standard transitions."""
+        assert len(WORKFLOW_TRANSITIONS) == 7
+
+    def test_all_have_required_fields(self) -> None:
+        """Test that all transitions have required fields."""
+        required_fields = {"name", "from", "to", "default"}
+        for t in WORKFLOW_TRANSITIONS:
+            assert required_fields.issubset(t.keys()), f"Missing fields in {t}"
+
+    def test_all_defaults_are_none(self) -> None:
+        """Test that all default validation modes are NONE."""
+        for t in WORKFLOW_TRANSITIONS:
+            assert t["default"] == "NONE", f"Non-NONE default in {t['name']}"


### PR DESCRIPTION
## Summary

This PR completes task-182 by adding comprehensive workflow transition validation configuration to `specify init`. This is a consolidated, clean implementation that replaces the 3 previous PRs (#520, #522, #523) which had CI/lint issues.

### Features Added

- **Interactive validation prompts (AC1-4)**: When running `specify init` in a TTY, users are prompted to configure validation mode for each of the 7 workflow transitions
- **Validation summary display (AC8)**: After configuration, a summary shows non-default validation modes
- **Batch `--validation-mode` flag (AC6)**: Set all transitions at once with `--validation-mode {none|keyword|pull-request}`
- **Per-transition override**: Flags like `--validation-plan pull-request` override batch mode
- **Config validation command (AC9)**: New `specify config validation` command for viewing/updating validation after init

### Validation Mode Options

| Mode | Description |
|------|-------------|
| `NONE` | No gate, immediate pass-through (default) |
| `KEYWORD["..."]` | Require user to type exact keyword |
| `PULL_REQUEST` | Require PR to be merged |

### Example Usage

```bash
# Interactive configuration
specify init my-project --ai claude

# Batch configuration
specify init my-project --ai claude --validation-mode pull-request

# View current config
specify config validation --show

# Update single transition
specify config validation -t plan -m keyword -k "DESIGN_APPROVED"
```

## Test Plan

- [x] 42 new tests covering all acceptance criteria
- [x] All 2599 tests pass (no regressions)
- [x] Ruff lint passes
- [x] DCO sign-off included

### Acceptance Criteria

- [x] AC1: Add validation mode prompts to specify init command
- [x] AC2: Support NONE selection (default, press Enter)
- [x] AC3: Support KEYWORD selection with custom keyword input
- [x] AC4: Support PULL_REQUEST selection
- [x] AC5: Generate jpspec_workflow.yml with validation modes (existing)
- [x] AC6: Add --validation-mode {none|keyword|pull-request} flag
- [x] AC7: Add --no-validation-prompts flag (existing)
- [x] AC8: Display summary of configured validation modes at end
- [x] AC9: Support reconfiguration via `specify config validation`

## Lessons Learned from Previous PRs

This consolidated PR addresses issues from the previous attempts:
- Removed unused imports (`io`, `patch` in test files)
- Properly asserted on `result` variables in all tests (no unused variables)
- Included DCO sign-off with `-s` flag
- Clean test structure with proper fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)