### PR TITLE
feat(security): add PatchApplicator for task-213

### DIFF
--- a/src/specify_cli/security/fixer/__init__.py
+++ b/src/specify_cli/security/fixer/__init__.py
@@ -15,12 +15,27 @@ from specify_cli.security.fixer.models import (
 )
 from specify_cli.security.fixer.generator import FixGenerator
 from specify_cli.security.fixer.patterns import FixPatternLibrary
+from specify_cli.security.fixer.applicator import (
+    ApplyResult,
+    ApplyStatus,
+    BatchApplyResult,
+    PatchApplicator,
+    PatchApplicatorConfig,
+)
 
 __all__ = [
+    # Models
     "FixResult",
     "FixStatus",
     "Patch",
     "FixPattern",
+    # Generator
     "FixGenerator",
     "FixPatternLibrary",
+    # Applicator
+    "ApplyResult",
+    "ApplyStatus",
+    "BatchApplyResult",
+    "PatchApplicator",
+    "PatchApplicatorConfig",
 ]

--- a/src/specify_cli/security/fixer/applicator.py
+++ b/src/specify_cli/security/fixer/applicator.py
@@ -1,0 +1,409 @@
+"""Patch application and rollback functionality.
+
+This module handles applying security fix patches to source files,
+with support for dry-run validation, backup creation, and rollback.
+"""
+
+import json
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+
+from specify_cli.security.fixer.models import Patch, FixResult
+
+
+class ApplyStatus(Enum):
+    """Status of patch application."""
+
+    SUCCESS = "success"  # Patch applied successfully
+    FAILED = "failed"  # Patch failed to apply
+    CONFLICT = "conflict"  # Patch has merge conflicts
+    SKIPPED = "skipped"  # Patch was skipped (dry-run or user declined)
+
+
+@dataclass
+class ApplyResult:
+    """Result of applying a single patch."""
+
+    patch: Patch
+    status: ApplyStatus
+    message: str = ""
+    backup_path: Path | None = None
+
+    @property
+    def is_successful(self) -> bool:
+        """Returns True if patch was applied successfully."""
+        return self.status == ApplyStatus.SUCCESS
+
+    def to_dict(self) -> dict:
+        """Serialize to dictionary."""
+        return {
+            "file_path": str(self.patch.file_path),
+            "status": self.status.value,
+            "message": self.message,
+            "backup_path": str(self.backup_path) if self.backup_path else None,
+        }
+
+
+@dataclass
+class BatchApplyResult:
+    """Result of applying multiple patches."""
+
+    results: list[ApplyResult] = field(default_factory=list)
+    timestamp: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+    @property
+    def successful_count(self) -> int:
+        """Count of successfully applied patches."""
+        return sum(1 for r in self.results if r.is_successful)
+
+    @property
+    def failed_count(self) -> int:
+        """Count of failed patches."""
+        return sum(1 for r in self.results if not r.is_successful)
+
+    @property
+    def all_successful(self) -> bool:
+        """Returns True if all patches were applied successfully."""
+        return all(r.is_successful for r in self.results)
+
+    def to_dict(self) -> dict:
+        """Serialize to dictionary."""
+        return {
+            "timestamp": self.timestamp,
+            "total": len(self.results),
+            "successful": self.successful_count,
+            "failed": self.failed_count,
+            "results": [r.to_dict() for r in self.results],
+        }
+
+
+@dataclass
+class PatchApplicatorConfig:
+    """Configuration for patch application."""
+
+    backup_dir: Path | None = None  # Directory for backups (default: .specify/backups)
+    create_backups: bool = True  # Create backups before applying
+    use_git_apply: bool = True  # Use git apply (vs manual file modification)
+
+
+class PatchApplicator:
+    """Applies security patches to source files.
+
+    Provides functionality for applying patches with backup and rollback
+    capabilities. Supports both git-based and manual patch application.
+
+    Example:
+        >>> applicator = PatchApplicator()
+        >>> result = applicator.apply_patch(patch, dry_run=True)
+        >>> if result.status == ApplyStatus.SUCCESS:
+        ...     applicator.apply_patch(patch)  # Actually apply
+    """
+
+    def __init__(self, config: PatchApplicatorConfig | None = None):
+        """Initialize patch applicator.
+
+        Args:
+            config: Applicator configuration options.
+        """
+        self.config = config or PatchApplicatorConfig()
+        self._history: list[ApplyResult] = []
+
+    def apply_patch(self, patch: Patch, dry_run: bool = False) -> ApplyResult:
+        """Apply a single patch to its target file.
+
+        Args:
+            patch: Patch to apply.
+            dry_run: If True, validate without applying.
+
+        Returns:
+            ApplyResult with status and details.
+        """
+        # Validate target file exists
+        if not patch.file_path.exists():
+            return ApplyResult(
+                patch=patch,
+                status=ApplyStatus.FAILED,
+                message=f"Target file does not exist: {patch.file_path}",
+            )
+
+        # Dry-run validation
+        if dry_run:
+            return self._validate_patch(patch)
+
+        # Create backup if enabled
+        backup_path = None
+        if self.config.create_backups:
+            backup_path = self._create_backup(patch.file_path)
+            if backup_path is None:
+                return ApplyResult(
+                    patch=patch,
+                    status=ApplyStatus.FAILED,
+                    message="Failed to create backup",
+                )
+
+        # Apply patch
+        if self.config.use_git_apply:
+            result = self._apply_with_git(patch)
+        else:
+            result = self._apply_manually(patch)
+
+        result.backup_path = backup_path
+
+        # Track in history for rollback
+        if result.is_successful:
+            self._history.append(result)
+
+        return result
+
+    def apply_patches(
+        self, patches: list[Patch], dry_run: bool = False
+    ) -> BatchApplyResult:
+        """Apply multiple patches in sequence.
+
+        Args:
+            patches: List of patches to apply.
+            dry_run: If True, validate without applying.
+
+        Returns:
+            BatchApplyResult with all results.
+        """
+        batch_result = BatchApplyResult()
+
+        for patch in patches:
+            result = self.apply_patch(patch, dry_run=dry_run)
+            batch_result.results.append(result)
+
+        return batch_result
+
+    def apply_fix_results(
+        self, fix_results: list[FixResult], dry_run: bool = False
+    ) -> BatchApplyResult:
+        """Apply patches from fix results.
+
+        Extracts patches from FixResults and applies them.
+
+        Args:
+            fix_results: List of fix generation results.
+            dry_run: If True, validate without applying.
+
+        Returns:
+            BatchApplyResult with all results.
+        """
+        patches = [fr.patch for fr in fix_results if fr.patch is not None]
+        return self.apply_patches(patches, dry_run=dry_run)
+
+    def rollback(self, result: ApplyResult) -> bool:
+        """Rollback a single applied patch.
+
+        Args:
+            result: ApplyResult with backup information.
+
+        Returns:
+            True if rollback succeeded.
+        """
+        if not result.backup_path or not result.backup_path.exists():
+            return False
+
+        try:
+            shutil.copy2(result.backup_path, result.patch.file_path)
+            return True
+        except OSError:
+            return False
+
+    def rollback_all(self) -> int:
+        """Rollback all applied patches in reverse order.
+
+        Returns:
+            Number of successfully rolled back patches.
+        """
+        rolled_back = 0
+
+        for result in reversed(self._history):
+            if self.rollback(result):
+                rolled_back += 1
+
+        self._history.clear()
+        return rolled_back
+
+    def save_history(self, output_path: Path) -> None:
+        """Save application history to JSON file.
+
+        Args:
+            output_path: Path to write history JSON.
+        """
+        history_data = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "applied": [r.to_dict() for r in self._history],
+        }
+        output_path.write_text(json.dumps(history_data, indent=2), encoding="utf-8")
+
+    def _validate_patch(self, patch: Patch) -> ApplyResult:
+        """Validate a patch without applying it."""
+        if self.config.use_git_apply:
+            return self._validate_with_git(patch)
+        return self._validate_manually(patch)
+
+    def _validate_with_git(self, patch: Patch) -> ApplyResult:
+        """Validate patch using git apply --check."""
+        try:
+            # Write patch to temp file
+            patch_content = patch.to_patch_file()
+            result = subprocess.run(
+                ["git", "apply", "--check", "-"],
+                input=patch_content,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            if result.returncode == 0:
+                return ApplyResult(
+                    patch=patch,
+                    status=ApplyStatus.SKIPPED,
+                    message="Dry-run: patch would apply cleanly",
+                )
+            else:
+                # Check for conflict indicators
+                if "patch does not apply" in result.stderr:
+                    return ApplyResult(
+                        patch=patch,
+                        status=ApplyStatus.CONFLICT,
+                        message=f"Patch conflict: {result.stderr.strip()}",
+                    )
+                return ApplyResult(
+                    patch=patch,
+                    status=ApplyStatus.FAILED,
+                    message=f"Validation failed: {result.stderr.strip()}",
+                )
+
+        except subprocess.TimeoutExpired:
+            return ApplyResult(
+                patch=patch,
+                status=ApplyStatus.FAILED,
+                message="Git apply timed out",
+            )
+        except FileNotFoundError:
+            # Git not available, fall back to manual validation
+            return self._validate_manually(patch)
+
+    def _validate_manually(self, patch: Patch) -> ApplyResult:
+        """Validate patch manually by checking original code exists."""
+        try:
+            content = patch.file_path.read_text(encoding="utf-8")
+
+            # Check if original code fragment exists in file
+            if patch.original_code.strip() in content:
+                return ApplyResult(
+                    patch=patch,
+                    status=ApplyStatus.SKIPPED,
+                    message="Dry-run: original code found, patch can be applied",
+                )
+            else:
+                return ApplyResult(
+                    patch=patch,
+                    status=ApplyStatus.CONFLICT,
+                    message="Original code not found in file (may have changed)",
+                )
+
+        except OSError as e:
+            return ApplyResult(
+                patch=patch,
+                status=ApplyStatus.FAILED,
+                message=f"Failed to read file: {e}",
+            )
+
+    def _apply_with_git(self, patch: Patch) -> ApplyResult:
+        """Apply patch using git apply."""
+        try:
+            patch_content = patch.to_patch_file()
+            result = subprocess.run(
+                ["git", "apply", "-"],
+                input=patch_content,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            if result.returncode == 0:
+                return ApplyResult(
+                    patch=patch,
+                    status=ApplyStatus.SUCCESS,
+                    message="Patch applied successfully via git",
+                )
+            else:
+                if "patch does not apply" in result.stderr:
+                    return ApplyResult(
+                        patch=patch,
+                        status=ApplyStatus.CONFLICT,
+                        message=f"Merge conflict: {result.stderr.strip()}",
+                    )
+                return ApplyResult(
+                    patch=patch,
+                    status=ApplyStatus.FAILED,
+                    message=f"Git apply failed: {result.stderr.strip()}",
+                )
+
+        except subprocess.TimeoutExpired:
+            return ApplyResult(
+                patch=patch,
+                status=ApplyStatus.FAILED,
+                message="Git apply timed out",
+            )
+        except FileNotFoundError:
+            # Git not available, fall back to manual
+            return self._apply_manually(patch)
+
+    def _apply_manually(self, patch: Patch) -> ApplyResult:
+        """Apply patch by direct file modification."""
+        try:
+            content = patch.file_path.read_text(encoding="utf-8")
+
+            # Find and replace original code with fixed code
+            if patch.original_code.strip() not in content:
+                return ApplyResult(
+                    patch=patch,
+                    status=ApplyStatus.CONFLICT,
+                    message="Original code not found in file",
+                )
+
+            new_content = content.replace(
+                patch.original_code.strip(),
+                patch.fixed_code.strip(),
+                1,  # Replace only first occurrence
+            )
+
+            patch.file_path.write_text(new_content, encoding="utf-8")
+
+            return ApplyResult(
+                patch=patch,
+                status=ApplyStatus.SUCCESS,
+                message="Patch applied successfully via file modification",
+            )
+
+        except OSError as e:
+            return ApplyResult(
+                patch=patch,
+                status=ApplyStatus.FAILED,
+                message=f"Failed to modify file: {e}",
+            )
+
+    def _create_backup(self, file_path: Path) -> Path | None:
+        """Create a backup of a file before patching."""
+        backup_dir = self.config.backup_dir or Path(".specify/backups")
+        backup_dir.mkdir(parents=True, exist_ok=True)
+
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        backup_name = f"{file_path.name}.{timestamp}.bak"
+        backup_path = backup_dir / backup_name
+
+        try:
+            shutil.copy2(file_path, backup_path)
+            return backup_path
+        except OSError:
+            return None

--- a/tests/security/fixer/test_applicator.py
+++ b/tests/security/fixer/test_applicator.py
@@ -1,0 +1,460 @@
+"""Tests for PatchApplicator."""
+
+from pathlib import Path
+from unittest.mock import patch as mock_patch, MagicMock
+
+import pytest
+
+from specify_cli.security.fixer.applicator import (
+    ApplyResult,
+    ApplyStatus,
+    BatchApplyResult,
+    PatchApplicator,
+    PatchApplicatorConfig,
+)
+from specify_cli.security.fixer.models import FixResult, FixStatus, Patch
+
+
+@pytest.fixture
+def sample_patch(tmp_path):
+    """Create a sample patch with a real file."""
+    target_file = tmp_path / "vulnerable.py"
+    target_file.write_text('query = "SELECT * FROM users WHERE id = " + user_id')
+
+    return Patch(
+        file_path=target_file,
+        original_code='query = "SELECT * FROM users WHERE id = " + user_id',
+        fixed_code='cursor.execute("SELECT * FROM users WHERE id = ?", (user_id,))',
+        unified_diff='--- a/vulnerable.py\n+++ b/vulnerable.py\n@@ -1 +1 @@\n-query = "SELECT * FROM users WHERE id = " + user_id\n+cursor.execute("SELECT * FROM users WHERE id = ?", (user_id,))',
+        line_start=1,
+        line_end=1,
+    )
+
+
+@pytest.fixture
+def applicator(tmp_path):
+    """Create applicator with temp backup directory."""
+    config = PatchApplicatorConfig(
+        backup_dir=tmp_path / "backups",
+        create_backups=True,
+        use_git_apply=False,  # Use manual apply for predictable tests
+    )
+    return PatchApplicator(config=config)
+
+
+class TestApplyStatus:
+    """Tests for ApplyStatus enum."""
+
+    def test_values(self):
+        """Test status values."""
+        assert ApplyStatus.SUCCESS.value == "success"
+        assert ApplyStatus.FAILED.value == "failed"
+        assert ApplyStatus.CONFLICT.value == "conflict"
+        assert ApplyStatus.SKIPPED.value == "skipped"
+
+
+class TestApplyResult:
+    """Tests for ApplyResult dataclass."""
+
+    def test_is_successful_true(self, sample_patch):
+        """Test is_successful for success status."""
+        result = ApplyResult(
+            patch=sample_patch,
+            status=ApplyStatus.SUCCESS,
+            message="Applied",
+        )
+        assert result.is_successful is True
+
+    def test_is_successful_false(self, sample_patch):
+        """Test is_successful for non-success statuses."""
+        for status in [ApplyStatus.FAILED, ApplyStatus.CONFLICT, ApplyStatus.SKIPPED]:
+            result = ApplyResult(
+                patch=sample_patch,
+                status=status,
+                message="Not applied",
+            )
+            assert result.is_successful is False
+
+    def test_to_dict(self, sample_patch, tmp_path):
+        """Test serialization."""
+        backup = tmp_path / "backup.py"
+        result = ApplyResult(
+            patch=sample_patch,
+            status=ApplyStatus.SUCCESS,
+            message="Applied",
+            backup_path=backup,
+        )
+
+        data = result.to_dict()
+
+        assert "vulnerable.py" in data["file_path"]
+        assert data["status"] == "success"
+        assert data["message"] == "Applied"
+        assert "backup.py" in data["backup_path"]
+
+
+class TestBatchApplyResult:
+    """Tests for BatchApplyResult dataclass."""
+
+    def test_successful_count(self, sample_patch):
+        """Test counting successful results."""
+        results = [
+            ApplyResult(patch=sample_patch, status=ApplyStatus.SUCCESS),
+            ApplyResult(patch=sample_patch, status=ApplyStatus.SUCCESS),
+            ApplyResult(patch=sample_patch, status=ApplyStatus.FAILED),
+        ]
+        batch = BatchApplyResult(results=results)
+
+        assert batch.successful_count == 2
+        assert batch.failed_count == 1
+
+    def test_all_successful(self, sample_patch):
+        """Test all_successful property."""
+        all_success = BatchApplyResult(
+            results=[
+                ApplyResult(patch=sample_patch, status=ApplyStatus.SUCCESS),
+                ApplyResult(patch=sample_patch, status=ApplyStatus.SUCCESS),
+            ]
+        )
+        assert all_success.all_successful is True
+
+        mixed = BatchApplyResult(
+            results=[
+                ApplyResult(patch=sample_patch, status=ApplyStatus.SUCCESS),
+                ApplyResult(patch=sample_patch, status=ApplyStatus.FAILED),
+            ]
+        )
+        assert mixed.all_successful is False
+
+    def test_to_dict(self, sample_patch):
+        """Test serialization."""
+        batch = BatchApplyResult(
+            results=[
+                ApplyResult(patch=sample_patch, status=ApplyStatus.SUCCESS),
+            ]
+        )
+
+        data = batch.to_dict()
+
+        assert data["total"] == 1
+        assert data["successful"] == 1
+        assert data["failed"] == 0
+        assert "timestamp" in data
+
+
+class TestPatchApplicator:
+    """Tests for PatchApplicator."""
+
+    def test_initialization(self):
+        """Test applicator initializes correctly."""
+        applicator = PatchApplicator()
+
+        assert applicator.config.create_backups is True
+        assert applicator.config.use_git_apply is True
+
+    def test_initialization_with_config(self, tmp_path):
+        """Test applicator with custom config."""
+        config = PatchApplicatorConfig(
+            backup_dir=tmp_path / "custom",
+            create_backups=False,
+        )
+        applicator = PatchApplicator(config=config)
+
+        assert applicator.config.backup_dir == tmp_path / "custom"
+        assert applicator.config.create_backups is False
+
+    def test_apply_patch_file_not_found(self, applicator):
+        """Test applying patch when file doesn't exist."""
+        patch = Patch(
+            file_path=Path("/nonexistent/file.py"),
+            original_code="old",
+            fixed_code="new",
+            unified_diff="diff",
+            line_start=1,
+            line_end=1,
+        )
+
+        result = applicator.apply_patch(patch)
+
+        assert result.status == ApplyStatus.FAILED
+        assert "does not exist" in result.message
+
+    def test_apply_patch_dry_run(self, applicator, sample_patch):
+        """Test dry-run validation."""
+        result = applicator.apply_patch(sample_patch, dry_run=True)
+
+        # Should validate without modifying file
+        assert result.status == ApplyStatus.SKIPPED
+        assert "dry-run" in result.message.lower()
+
+        # File should be unchanged
+        content = sample_patch.file_path.read_text()
+        assert "SELECT * FROM users WHERE id = " in content
+
+    def test_apply_patch_success(self, applicator, sample_patch):
+        """Test successful patch application."""
+        result = applicator.apply_patch(sample_patch)
+
+        assert result.status == ApplyStatus.SUCCESS
+        assert result.backup_path is not None
+        assert result.backup_path.exists()
+
+        # File should be modified
+        content = sample_patch.file_path.read_text()
+        assert "cursor.execute" in content
+
+    def test_apply_patch_creates_backup(self, applicator, sample_patch):
+        """Test backup creation."""
+        result = applicator.apply_patch(sample_patch)
+
+        assert result.backup_path is not None
+        assert result.backup_path.exists()
+
+        # Backup should contain original content
+        backup_content = result.backup_path.read_text()
+        assert "SELECT * FROM users WHERE id = " in backup_content
+
+    def test_apply_patch_conflict(self, applicator, tmp_path):
+        """Test patch with non-matching original code."""
+        target_file = tmp_path / "changed.py"
+        target_file.write_text("completely different code")
+
+        patch = Patch(
+            file_path=target_file,
+            original_code="original code that does not exist",
+            fixed_code="fixed code",
+            unified_diff="diff",
+            line_start=1,
+            line_end=1,
+        )
+
+        result = applicator.apply_patch(patch)
+
+        assert result.status == ApplyStatus.CONFLICT
+        assert "not found" in result.message.lower()
+
+
+class TestPatchApplicatorBatch:
+    """Tests for batch patch application."""
+
+    def test_apply_patches(self, applicator, tmp_path):
+        """Test applying multiple patches."""
+        # Create two files
+        file1 = tmp_path / "file1.py"
+        file1.write_text("old code 1")
+
+        file2 = tmp_path / "file2.py"
+        file2.write_text("old code 2")
+
+        patches = [
+            Patch(
+                file_path=file1,
+                original_code="old code 1",
+                fixed_code="new code 1",
+                unified_diff="diff1",
+                line_start=1,
+                line_end=1,
+            ),
+            Patch(
+                file_path=file2,
+                original_code="old code 2",
+                fixed_code="new code 2",
+                unified_diff="diff2",
+                line_start=1,
+                line_end=1,
+            ),
+        ]
+
+        batch_result = applicator.apply_patches(patches)
+
+        assert batch_result.successful_count == 2
+        assert batch_result.all_successful is True
+
+        assert file1.read_text() == "new code 1"
+        assert file2.read_text() == "new code 2"
+
+    def test_apply_fix_results(self, applicator, tmp_path):
+        """Test applying patches from FixResults."""
+        target_file = tmp_path / "vuln.py"
+        target_file.write_text("vulnerable code")
+
+        patch = Patch(
+            file_path=target_file,
+            original_code="vulnerable code",
+            fixed_code="secure code",
+            unified_diff="diff",
+            line_start=1,
+            line_end=1,
+        )
+
+        fix_results = [
+            FixResult(
+                finding_id="F1",
+                status=FixStatus.SUCCESS,
+                patch=patch,
+                explanation="Fixed",
+                confidence=0.9,
+            ),
+            FixResult(
+                finding_id="F2",
+                status=FixStatus.FAILED,
+                patch=None,  # No patch for failed fix
+                explanation="Could not fix",
+                confidence=0.0,
+            ),
+        ]
+
+        batch_result = applicator.apply_fix_results(fix_results)
+
+        # Only one patch should be applied (F2 has no patch)
+        assert len(batch_result.results) == 1
+        assert batch_result.successful_count == 1
+
+
+class TestPatchApplicatorRollback:
+    """Tests for rollback functionality."""
+
+    def test_rollback_single(self, applicator, sample_patch):
+        """Test rolling back a single patch."""
+        # Apply patch
+        result = applicator.apply_patch(sample_patch)
+        assert result.is_successful
+
+        # Verify file was modified
+        content = sample_patch.file_path.read_text()
+        assert "cursor.execute" in content
+
+        # Rollback
+        success = applicator.rollback(result)
+        assert success is True
+
+        # Verify file was restored
+        content = sample_patch.file_path.read_text()
+        assert "SELECT * FROM users WHERE id = " in content
+
+    def test_rollback_all(self, applicator, tmp_path):
+        """Test rolling back all patches."""
+        # Create and patch multiple files
+        files = []
+        for i in range(3):
+            f = tmp_path / f"file{i}.py"
+            f.write_text(f"original {i}")
+            files.append(f)
+
+        patches = [
+            Patch(
+                file_path=f,
+                original_code=f"original {i}",
+                fixed_code=f"patched {i}",
+                unified_diff="diff",
+                line_start=1,
+                line_end=1,
+            )
+            for i, f in enumerate(files)
+        ]
+
+        # Apply all patches
+        applicator.apply_patches(patches)
+
+        # Verify all patched
+        for i, f in enumerate(files):
+            assert f.read_text() == f"patched {i}"
+
+        # Rollback all
+        rolled_back = applicator.rollback_all()
+        assert rolled_back == 3
+
+        # Verify all restored
+        for i, f in enumerate(files):
+            assert f.read_text() == f"original {i}"
+
+    def test_rollback_no_backup(self, sample_patch):
+        """Test rollback fails when no backup exists."""
+        config = PatchApplicatorConfig(create_backups=False, use_git_apply=False)
+        applicator = PatchApplicator(config=config)
+
+        result = applicator.apply_patch(sample_patch)
+
+        # No backup was created
+        success = applicator.rollback(result)
+        assert success is False
+
+
+class TestPatchApplicatorHistory:
+    """Tests for history tracking."""
+
+    def test_save_history(self, applicator, sample_patch, tmp_path):
+        """Test saving application history."""
+        applicator.apply_patch(sample_patch)
+
+        history_file = tmp_path / "history.json"
+        applicator.save_history(history_file)
+
+        assert history_file.exists()
+
+        import json
+
+        history = json.loads(history_file.read_text())
+        assert "timestamp" in history
+        assert "applied" in history
+        assert len(history["applied"]) == 1
+
+
+class TestPatchApplicatorGitApply:
+    """Tests for git-based patch application."""
+
+    def test_validate_with_git_success(self, tmp_path):
+        """Test git apply --check validation."""
+        config = PatchApplicatorConfig(use_git_apply=True)
+        applicator = PatchApplicator(config=config)
+
+        target_file = tmp_path / "test.py"
+        target_file.write_text("original")
+
+        test_patch = Patch(
+            file_path=target_file,
+            original_code="original",
+            fixed_code="fixed",
+            unified_diff="--- a/test.py\n+++ b/test.py\n@@ -1 +1 @@\n-original\n+fixed",
+            line_start=1,
+            line_end=1,
+        )
+
+        # Mock subprocess to simulate git not being in a repo
+        with mock_patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+
+            applicator.apply_patch(test_patch, dry_run=True)
+
+            # Should use git apply --check
+            mock_run.assert_called()
+            call_args = mock_run.call_args[0][0]
+            assert "git" in call_args
+            assert "apply" in call_args
+
+    def test_fallback_to_manual_when_git_unavailable(self, tmp_path):
+        """Test fallback to manual application when git is not available."""
+        config = PatchApplicatorConfig(use_git_apply=True)
+        applicator = PatchApplicator(config=config)
+
+        target_file = tmp_path / "test.py"
+        target_file.write_text("original code")
+
+        test_patch = Patch(
+            file_path=target_file,
+            original_code="original code",
+            fixed_code="fixed code",
+            unified_diff="diff",
+            line_start=1,
+            line_end=1,
+        )
+
+        # Mock subprocess to simulate git not found
+        with mock_patch("subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError("git not found")
+
+            result = applicator.apply_patch(test_patch)
+
+            # Should fall back to manual and succeed
+            assert result.status == ApplyStatus.SUCCESS
+            assert target_file.read_text() == "fixed code"


### PR DESCRIPTION
## Summary

- Adds `PatchApplicator` class with apply/rollback functionality to complete AC#4 of task-213
- Supports both `git apply` and manual file modification fallback
- Creates backups before applying patches for safe rollback
- Provides batch application and history tracking capabilities
- Adds 22 comprehensive tests for the applicator module

## Changes

| File | Description |
|------|-------------|
| `src/specify_cli/security/fixer/applicator.py` | New PatchApplicator class with ApplyResult, BatchApplyResult models |
| `src/specify_cli/security/fixer/__init__.py` | Export new applicator classes |
| `tests/security/fixer/test_applicator.py` | 22 tests covering all functionality |

## Task-213 Acceptance Criteria Status

| AC | Status | Notes |
|----|--------|-------|
| #1 Fix pattern library | ✅ Already complete | 5 CWE patterns |
| #2 AI generates patches | ✅ Already complete | FixGenerator |
| #3 Syntax validation | ✅ Already complete | Python/JS validation |
| #4 Patch application workflow | ✅ **This PR** | PatchApplicator |
| #5 Fix quality >75% | ⚠️ Manual validation | Requires empirical testing |
| #6 Generate .patch files | ✅ Already complete | Patch.save_patch() |

## Test plan

- [x] All 57 fixer tests pass
- [x] New applicator tests cover: apply, rollback, batch, history
- [x] Ruff linting passes
- [ ] Verify on real vulnerability findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)