### PR TITLE
feat(upgrade): add file-friendly timestamp to specify-backup path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased]
 
+### Changed
+
+- **File-friendly timestamp in specify-backup path**: Backup directories now include timestamp (`YYYYMMDD-HHMMSS`) format
+  - Previous backups are preserved instead of being overwritten
+  - Example: `.specify-backup-20251207-143052/` instead of `.specify-backup/`
+  - Enables rollback to any previous backup version
+
 ## [0.2.316] - 2025-12-07
 
 ### Fixed

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -35,6 +35,7 @@ import subprocess
 import sys
 import tempfile
 import zipfile
+from datetime import datetime
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -3670,11 +3671,10 @@ def upgrade_repo(
             local_ssl_context = ssl_context if verify else False
             local_client = httpx.Client(verify=local_ssl_context)
 
-            # Create backup of existing templates
+            # Create backup of existing templates with timestamp
             tracker.start("backup")
-            backup_dir = project_path / ".specify-backup"
-            if backup_dir.exists():
-                shutil.rmtree(backup_dir)
+            timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+            backup_dir = project_path / f".specify-backup-{timestamp}"
             backup_dir.mkdir(parents=True)
 
             # Backup key directories
@@ -5410,11 +5410,12 @@ def quality(
 
     Returns a 0-100 score with detailed recommendations.
     """
-    from pathlib import Path
     import json as json_lib
+    from pathlib import Path
+
     from rich.table import Table
 
-    from specify_cli.quality import QualityScorer, QualityConfig
+    from specify_cli.quality import QualityConfig, QualityScorer
 
     # Determine spec path
     if spec_path is None:
@@ -5586,7 +5587,8 @@ def gate(
         specify gate --force            # Bypass failed gate (not recommended)
     """
     from pathlib import Path
-    from specify_cli.quality import QualityScorer, QualityConfig
+
+    from specify_cli.quality import QualityConfig, QualityScorer
 
     project_root = Path.cwd()
     spec_path = project_root / ".specify" / "spec.md"
@@ -6013,12 +6015,13 @@ def security_scan(
         specify security scan --format json -o out.json # JSON output to file
     """
     import json
-    from specify_cli.security.orchestrator import ScannerOrchestrator
+
     from specify_cli.security.adapters.semgrep import SemgrepAdapter
-    from specify_cli.security.exporters.sarif import SARIFExporter
     from specify_cli.security.exporters.json import JSONExporter
     from specify_cli.security.exporters.markdown import MarkdownExporter
+    from specify_cli.security.exporters.sarif import SARIFExporter
     from specify_cli.security.models import Severity
+    from specify_cli.security.orchestrator import ScannerOrchestrator
 
     # Validate fail-on severity
     try:


### PR DESCRIPTION
## Summary

- Backup directories now include timestamp in `YYYYMMDD-HHMMSS` format
- Previous backups are preserved instead of being overwritten
- Example: `.specify-backup-20251207-143052/` instead of `.specify-backup/`

## Changes

- Added `datetime` import to `__init__.py`
- Modified backup directory name to include timestamp
- Removed `shutil.rmtree()` call that deleted previous backup
- Updated CHANGELOG.md

## Test plan

- [ ] Run `specify upgrade-tools` twice and verify two separate backup directories exist
- [ ] Verify console output shows full timestamped path
- [ ] Verify timestamps are in `YYYYMMDD-HHMMSS` format

Closes task-300

🤖 Generated with [Claude Code](https://claude.com/claude-code)