### PR TITLE
fix(release): use subdirectory structure for colon-namespaced commands

### DIFF
--- a/.github/workflows/scripts/create-release-packages.sh
+++ b/.github/workflows/scripts/create-release-packages.sh
@@ -91,13 +91,20 @@ generate_commands() {
     # Apply other substitutions
     body=$(printf '%s\n' "$body" | sed "s/{ARGS}/$arg_format/g" | sed "s/__AGENT__/$agent/g" | rewrite_paths)
     
+    # For md-based agents (Claude, Cursor, etc.), use subdirectory structure for colon-namespacing
+    # e.g., .claude/commands/speckit/specify.md -> /speckit:specify
+    # For toml-based agents (Gemini, Qwen), use dot notation in filename
+    # e.g., .gemini/commands/speckit.specify.toml -> /speckit.specify
     case $ext in
       toml)
         body=$(printf '%s\n' "$body" | sed 's/\\/\\\\/g')
         { echo "description = \"$description\""; echo; echo "prompt = \"\"\""; echo "$body"; echo "\"\"\""; } > "$output_dir/speckit.$name.$ext" ;;
       md)
-        echo "$body" > "$output_dir/speckit.$name.$ext" ;;
+        # Create speckit subdirectory for colon-namespaced commands
+        mkdir -p "$output_dir/speckit"
+        echo "$body" > "$output_dir/speckit/$name.$ext" ;;
       prompt.md)
+        # GitHub Copilot uses dot notation in filenames
         echo "$body" > "$output_dir/speckit.$name.$ext" ;;
     esac
   done
@@ -154,13 +161,20 @@ generate_commands() {
       # Apply other substitutions
       body=$(printf '%s\n' "$body" | sed "s/{ARGS}/$arg_format/g" | sed "s/__AGENT__/$agent/g" | rewrite_paths)
       
+      # For md-based agents (Claude, Cursor, etc.), use subdirectory structure for colon-namespacing
+      # e.g., .claude/commands/jpspec/init.md -> /jpspec:init
+      # For toml-based agents (Gemini, Qwen), use dot notation in filename
+      # e.g., .gemini/commands/jpspec.init.toml -> /jpspec.init
       case $ext in
         toml)
           body=$(printf '%s\n' "$body" | sed 's/\\/\\\\/g')
           { echo "description = \"$description\""; echo; echo "prompt = \"\"\""; echo "$body"; echo "\"\"\""; } > "$output_dir/jpspec.$name.$ext" ;;
         md)
-          echo "$body" > "$output_dir/jpspec.$name.$ext" ;;
+          # Create jpspec subdirectory for colon-namespaced commands
+          mkdir -p "$output_dir/jpspec"
+          echo "$body" > "$output_dir/jpspec/$name.$ext" ;;
         prompt.md)
+          # GitHub Copilot uses dot notation in filenames
           echo "$body" > "$output_dir/jpspec.$name.$ext" ;;
       esac
     done


### PR DESCRIPTION
## Summary

**This is the actual fix for the missing `/jpspec:init` and `/jpspec:reset` commands!**

The release script was creating flat files with dot notation:
```
.claude/commands/jpspec.init.md -> /jpspec.init (WRONG)
```

But Claude Code expects subdirectory structure for colon-namespaced commands:
```
.claude/commands/jpspec/init.md -> /jpspec:init (CORRECT)
```

## Changes

- Creates `jpspec/` and `speckit/` subdirectories for md-based agents (Claude, Cursor, OpenCode, Windsurf, etc.)
- Preserves dot notation for toml-based agents (Gemini, Qwen)
- Preserves dot notation for prompt.md files (GitHub Copilot)

## Before (v0.2.322)
```
.claude/commands/jpspec.init.md   -> /jpspec.init (doesn't work)
.claude/commands/jpspec.reset.md  -> /jpspec.reset (doesn't work)
```

## After (this PR)
```
.claude/commands/jpspec/init.md   -> /jpspec:init (works!)
.claude/commands/jpspec/reset.md  -> /jpspec:reset (works!)
```

## Test plan

- [ ] Merge PR
- [ ] Create new release (v0.2.323)
- [ ] Verify zip contains `.claude/commands/jpspec/init.md` instead of `.claude/commands/jpspec.init.md`
- [ ] Run `specify upgrade-repo` or `specify init` in a test project
- [ ] Verify `/jpspec:init` appears in Claude Code autocomplete

🤖 Generated with [Claude Code](https://claude.com/claude-code)