### PR TITLE
fix(upgrade): install from release tag and sync version numbers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "specify-cli"
 
-version = "0.2.326"
+version = "0.2.328"
 
 
 

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -595,7 +595,7 @@ BANNER = """
 """
 
 # Version - keep in sync with pyproject.toml
-__version__ = "0.2.322"
+__version__ = "0.2.328"
 
 # Constitution template version
 CONSTITUTION_VERSION = "1.0.0"
@@ -3905,7 +3905,14 @@ def _upgrade_jp_spec_kit(dry_run: bool = False) -> tuple[bool, str]:
     except FileNotFoundError:
         pass
 
-    # Fallback: reinstall from git (always try if uv upgrade didn't work)
+    # Fallback: reinstall from git at the specific release tag
+    # IMPORTANT: Install from release tag, not main branch, to ensure version consistency
+    # Main branch pyproject.toml may lag behind the latest release tag
+    git_url = f"git+https://github.com/{EXTENSION_REPO_OWNER}/{EXTENSION_REPO_NAME}.git"
+    if available_version:
+        # Install from specific release tag (e.g., @v0.2.327)
+        git_url = f"{git_url}@v{available_version}"
+
     try:
         subprocess.run(
             [
@@ -3915,7 +3922,7 @@ def _upgrade_jp_spec_kit(dry_run: bool = False) -> tuple[bool, str]:
                 "--force",
                 "specify-cli",
                 "--from",
-                "git+https://github.com/jpoley/jp-spec-kit.git",
+                git_url,
             ],
             capture_output=True,
             text=True,


### PR DESCRIPTION
## Summary

**This fixes why `specify upgrade-tools` doesn't actually upgrade to the latest version!**

### 3 Bugs Fixed

#### Bug 1: upgrade-tools installed from main branch, not release tag
- **Was:** `git+https://github.com/jpoley/jp-spec-kit.git` (main branch)
- **Now:** `git+https://github.com/jpoley/jp-spec-kit.git@v0.2.328` (release tag)
- Main branch pyproject.toml often lags behind the latest release tag

#### Bug 2: `__init__.py` version stuck at 0.2.322
- pyproject.toml was 0.2.326, but `__init__.py` showed 0.2.322
- `specify version` reported the wrong version
- Version comparison logic used `__version__`, causing upgrades to appear unnecessary

#### Bug 3: Version drift between pyproject.toml and releases
- Synced both pyproject.toml and `__init__.py` to 0.2.328

## Technical Details

The upgrade command now:
```python
# Build URL with specific release tag
git_url = f"git+https://github.com/{EXTENSION_REPO_OWNER}/{EXTENSION_REPO_NAME}.git"
if available_version:
    git_url = f"{git_url}@v{available_version}"  # e.g., @v0.2.328
```

## Test plan

- [x] Lint and format pass
- [x] Upgrade-related tests pass (47 passed)
- [ ] After merge, verify `specify upgrade-tools` installs correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)