### PR TITLE
chore(backlog): add bug tasks for upgrade-tools and version-bump branches

### DIFF
--- a/backlog/tasks/task-310 - Fix-upgrade-tools-Reports-success-but-doesnt-actually-upgrade.md
+++ b/backlog/tasks/task-310 - Fix-upgrade-tools-Reports-success-but-doesnt-actually-upgrade.md
@@ -1,0 +1,92 @@
+---
+id: task-310
+title: 'Fix upgrade-tools: Reports success but doesn''t actually upgrade'
+status: To Do
+assignee: []
+created_date: '2025-12-08 01:40'
+labels:
+  - bug
+  - cli
+  - upgrade-tools
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Bug Description
+
+`specify upgrade-tools` reports successful upgrade but the version doesn't change.
+
+**Observed Behavior:**
+```
+Component      Current    Available    Status
+jp-spec-kit    0.2.328    0.2.332      ✓ Installed version 0.2.328 (was: 0.2.328)
+```
+
+Notice: Status shows ✓ success, but version stayed at 0.2.328 (should be 0.2.332).
+
+## Root Cause Analysis
+
+The issue is in `_upgrade_jp_spec_kit()` at line 3973-3986 in `src/specify_cli/__init__.py`:
+
+```python
+# For latest, try uv upgrade first
+if not target_version:
+    try:
+        result = subprocess.run(
+            ["uv", "tool", "upgrade", "specify-cli"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            new_version = _get_installed_jp_spec_kit_version()
+            if new_version and compare_semver(new_version, current_version) > 0:
+                return True, f"Upgraded from {current_version} to {new_version}"
+    except FileNotFoundError:
+        pass
+
+# Install from git at the specific release tag
+git_url = f"git+https://github.com/{EXTENSION_REPO_OWNER}/{EXTENSION_REPO_NAME}.git"
+git_url = f"{git_url}@v{install_version}"
+```
+
+**The Bug:** When `uv tool upgrade specify-cli` returns `returncode == 0` but the version didn't actually change (because `uv` thinks it's already up-to-date), the code checks if `new_version > current_version`. Since the versions are equal, it does NOT return early - this part is correct.
+
+**However**, the code then falls through to the git install section (lines 3988-4010), which DOES install from git. The issue is that `_get_installed_jp_spec_kit_version()` runs `specify version` which invokes the **same Python process that's already running** - it can't detect the newly installed version because the `specify` binary being executed might be cached or the shell hasn't refreshed its PATH cache.
+
+**Additionally**, there's a more subtle issue: `uv tool upgrade` may return success (0) even when no upgrade was needed, because `specify-cli` was installed via git, not PyPI. The `uv tool upgrade` command doesn't know about the GitHub release versions.
+
+## Technical Details
+
+1. `uv tool upgrade specify-cli` returns 0 but doesn't upgrade (package not on PyPI, installed from git)
+2. Version check `new_version > current_version` is false (0.2.328 == 0.2.328)
+3. Falls through to git install section
+4. Git install succeeds with `check=True`
+5. `_get_installed_jp_spec_kit_version()` runs `specify version` but may get stale version
+6. Reports "Installed version 0.2.328 (was: 0.2.328)" - technically the git install ran, but version detection is broken
+
+## Suspected Fix Locations
+
+- `src/specify_cli/__init__.py:3903-3917` - `_get_installed_jp_spec_kit_version()` may need to use a different method
+- `src/specify_cli/__init__.py:4007-4009` - Post-install version detection logic
+
+## Possible Solutions
+
+1. **Skip `uv tool upgrade` entirely** for git-installed packages - go straight to git install
+2. **Hash-based detection**: Compare file hashes before/after to verify install changed
+3. **Use `uv tool list --show-paths`** to get the installation path and read version from there
+4. **Force shell PATH refresh** before running `specify version` (exec new shell)
+5. **Read version from installed package metadata** instead of running binary
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 When Available > Current version, `specify upgrade-tools` actually installs the new version
+- [ ] #2 Status message shows correct 'Upgraded from X to Y' (not same version twice)
+- [ ] #3 Version detection after install correctly reads new version
+- [ ] #4 Works for both targeted (--version X.X.X) and latest upgrades
+- [ ] #5 Unit tests cover the upgrade flow scenarios
+<!-- AC:END -->

--- a/backlog/tasks/task-310.01 - Fix-version-detection-after-upgrade-install.md
+++ b/backlog/tasks/task-310.01 - Fix-version-detection-after-upgrade-install.md
@@ -1,0 +1,35 @@
+---
+id: task-310.01
+title: Fix version detection after upgrade install
+status: To Do
+assignee: []
+created_date: '2025-12-08 01:41'
+labels:
+  - bug
+  - cli
+  - upgrade-tools
+dependencies: []
+parent_task_id: task-310
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix `_get_installed_jp_spec_kit_version()` to correctly detect the newly installed version after `uv tool install --force` completes.
+
+**Current Problem**: The function runs `specify version` which may return stale version due to shell/OS caching.
+
+**Options**:
+1. Trust the install and use `install_version` directly
+2. Read version from package metadata via `uv tool list`
+3. Use absolute path to the newly installed binary
+
+**Location**: `src/specify_cli/__init__.py:3888-3921` and `4007-4010`
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Version detection returns correct version after fresh install
+- [ ] #2 No reliance on shell PATH cache
+<!-- AC:END -->

--- a/backlog/tasks/task-310.02 - Remove-unnecessary-uv-tool-upgrade-attempt.md
+++ b/backlog/tasks/task-310.02 - Remove-unnecessary-uv-tool-upgrade-attempt.md
@@ -1,0 +1,35 @@
+---
+id: task-310.02
+title: Remove unnecessary uv tool upgrade attempt
+status: To Do
+assignee: []
+created_date: '2025-12-08 01:41'
+labels:
+  - bug
+  - cli
+  - upgrade-tools
+  - cleanup
+dependencies: []
+parent_task_id: task-310
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Remove or skip the `uv tool upgrade specify-cli` attempt at lines 3973-3986.
+
+**Rationale**: `specify-cli` is installed from git, not PyPI. The `uv tool upgrade` command cannot upgrade git-installed packages - it always returns success without doing anything useful.
+
+**Current behavior**: Wastes time trying `uv tool upgrade`, then falls through to git install anyway.
+
+**Proposed**: Go directly to git install for all upgrades.
+
+**Location**: `src/specify_cli/__init__.py:3973-3986`
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 uv tool upgrade is not called for git-installed packages
+- [ ] #2 Git install is used directly for upgrades
+<!-- AC:END -->

--- a/backlog/tasks/task-310.03 - Add-unit-tests-for-upgrade-tools-scenarios.md
+++ b/backlog/tasks/task-310.03 - Add-unit-tests-for-upgrade-tools-scenarios.md
@@ -1,0 +1,37 @@
+---
+id: task-310.03
+title: Add unit tests for upgrade-tools scenarios
+status: To Do
+assignee: []
+created_date: '2025-12-08 01:41'
+labels:
+  - test
+  - cli
+  - upgrade-tools
+dependencies: []
+parent_task_id: task-310
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add comprehensive unit tests for `_upgrade_jp_spec_kit()` covering:
+
+1. Upgrade when newer version available
+2. No-op when already at latest
+3. Downgrade with explicit `--version`
+4. Version not found error handling
+5. uv not installed error handling
+6. Git install failure handling
+
+**Location**: `tests/test_upgrade_commands.py` (existing file)
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Tests cover upgrade success path
+- [ ] #2 Tests cover already-at-latest path
+- [ ] #3 Tests cover error scenarios
+- [ ] #4 Tests use mocking for subprocess calls
+<!-- AC:END -->

--- a/backlog/tasks/task-311 - Fix-orphaned-chore-version-bump-branches-not-being-cleaned-up.md
+++ b/backlog/tasks/task-311 - Fix-orphaned-chore-version-bump-branches-not-being-cleaned-up.md
@@ -1,0 +1,79 @@
+---
+id: task-311
+title: Fix orphaned chore/version-bump branches not being cleaned up
+status: To Do
+assignee: []
+created_date: '2025-12-08 01:43'
+labels:
+  - bug
+  - ci
+  - github-actions
+  - cleanup
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Bug Description
+
+Branches like `chore/version-bump--0.2.332` are created by the release workflow but never cleaned up, leaving orphaned branches in the repository.
+
+**Observed**: Multiple `chore/version-bump-*` branches accumulating in the repo.
+
+## Root Cause Analysis
+
+The issue is in `.github/workflows/release.yml` at lines 96-114.
+
+**The workflow logic**:
+1. After creating a release, tries to update version in source files
+2. Tries direct push to main (line 89) - **fails due to branch protection**
+3. Falls back to creating a branch `chore/version-bump-{version}` (lines 97-99)
+4. Pushes the branch (line 99)
+5. Tries to create a PR (lines 102-106)
+
+**Problems identified**:
+
+1. **PR creation likely fails** - GitHub Actions token may not have permission to create PRs, or the PR creation fails silently and the branch is left orphaned
+
+2. **No cleanup on PR merge** - Even if PR is created and merged, the branch is never deleted
+
+3. **No cleanup on PR creation failure** - If PR creation fails (lines 108-114), the branch remains with a manual action note but no automation to clean it up
+
+4. **Double-dash in branch name** - The regex `${NEW_VERSION//[^0-9.]/-}` creates `chore/version-bump--0.2.332` (double dash) because it replaces `v` with `-` from `v0.2.332`
+
+## Code Location
+
+`.github/workflows/release.yml:96-114`
+
+```yaml
+# Create a branch and PR for the version bump
+BRANCH_NAME="chore/version-bump-${NEW_VERSION//[^0-9.]/-}"  # Bug: double dash
+git checkout -b "$BRANCH_NAME"
+git push origin "$BRANCH_NAME"
+
+# Try to create PR - may fail if Actions can't create PRs
+if gh pr create ...; then
+  echo "✅ Created PR for version bump"
+else
+  # Branch left orphaned here!
+  echo "⚠️ Could not create PR automatically."
+  ...
+fi
+```
+
+## Impact
+
+- Repository accumulates stale branches over time
+- Confusing for developers who see these orphaned branches
+- Potential for conflicts if version bump branches pile up
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Branch is deleted after PR is merged (enable delete branch on merge)
+- [ ] #2 Branch is deleted if PR creation fails
+- [ ] #3 Fix double-dash in branch name (v0.2.332 → 0.2.332 not --0.2.332)
+- [ ] #4 Add workflow to periodically clean up stale version-bump branches
+<!-- AC:END -->

--- a/backlog/tasks/task-311.01 - Fix-double-dash-in-version-bump-branch-name.md
+++ b/backlog/tasks/task-311.01 - Fix-double-dash-in-version-bump-branch-name.md
@@ -1,0 +1,41 @@
+---
+id: task-311.01
+title: Fix double-dash in version-bump branch name
+status: To Do
+assignee: []
+created_date: '2025-12-08 01:43'
+labels:
+  - bug
+  - ci
+  - github-actions
+dependencies: []
+parent_task_id: task-311
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix the branch naming regex in `.github/workflows/release.yml` line 97.
+
+**Current code**:
+```bash
+BRANCH_NAME="chore/version-bump-${NEW_VERSION//[^0-9.]/-}"
+```
+
+**Problem**: When `NEW_VERSION=v0.2.332`, the regex replaces `v` with `-`, creating `chore/version-bump--0.2.332` (double dash).
+
+**Fix**: Strip the `v` prefix first:
+```bash
+VERSION_NUM="${NEW_VERSION#v}"
+BRANCH_NAME="chore/version-bump-${VERSION_NUM}"
+```
+
+**Location**: `.github/workflows/release.yml:97`
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Branch name is chore/version-bump-0.2.332 (single dash)
+- [ ] #2 No regex replacement needed - just strip v prefix
+<!-- AC:END -->

--- a/backlog/tasks/task-311.02 - Delete-branch-after-PR-creation-failure.md
+++ b/backlog/tasks/task-311.02 - Delete-branch-after-PR-creation-failure.md
@@ -1,0 +1,47 @@
+---
+id: task-311.02
+title: Delete branch after PR creation failure
+status: To Do
+assignee: []
+created_date: '2025-12-08 01:43'
+labels:
+  - bug
+  - ci
+  - github-actions
+dependencies: []
+parent_task_id: task-311
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+When PR creation fails in the release workflow, the orphaned branch should be deleted.
+
+**Current behavior** (lines 108-114):
+```yaml
+else
+  echo "⚠️ Could not create PR automatically."
+  echo "📌 Manual action needed..."
+  # Branch is left orphaned!
+fi
+```
+
+**Proposed fix**:
+```yaml
+else
+  echo "⚠️ Could not create PR automatically."
+  echo "Cleaning up orphaned branch..."
+  git push origin --delete "$BRANCH_NAME" || true
+  echo "📌 Manual action needed: version files need to be updated"
+fi
+```
+
+**Location**: `.github/workflows/release.yml:108-114`
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Branch is deleted when PR creation fails
+- [ ] #2 Deletion failure is non-fatal (|| true)
+<!-- AC:END -->

--- a/backlog/tasks/task-311.03 - Enable-auto-delete-branch-on-PR-merge-in-GitHub-repo-settings.md
+++ b/backlog/tasks/task-311.03 - Enable-auto-delete-branch-on-PR-merge-in-GitHub-repo-settings.md
@@ -1,0 +1,35 @@
+---
+id: task-311.03
+title: Enable auto-delete branch on PR merge in GitHub repo settings
+status: To Do
+assignee: []
+created_date: '2025-12-08 01:43'
+labels:
+  - ci
+  - github-actions
+  - config
+dependencies: []
+parent_task_id: task-311
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Ensure the GitHub repository has "Automatically delete head branches" enabled.
+
+**Steps**:
+1. Go to repository Settings → General
+2. Under "Pull Requests" section
+3. Enable "Automatically delete head branches"
+
+This ensures version-bump branches are deleted when their PRs are merged.
+
+**Note**: This is a repo setting, not a code change.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 GitHub repo setting 'Automatically delete head branches' is enabled
+- [ ] #2 Merged PR branches are automatically deleted
+<!-- AC:END -->

--- a/backlog/tasks/task-311.04 - Add-scheduled-workflow-to-cleanup-stale-version-bump-branches.md
+++ b/backlog/tasks/task-311.04 - Add-scheduled-workflow-to-cleanup-stale-version-bump-branches.md
@@ -1,0 +1,55 @@
+---
+id: task-311.04
+title: Add scheduled workflow to cleanup stale version-bump branches
+status: To Do
+assignee: []
+created_date: '2025-12-08 01:43'
+labels:
+  - ci
+  - github-actions
+  - cleanup
+dependencies: []
+parent_task_id: task-311
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a scheduled GitHub Action to periodically clean up any orphaned `chore/version-bump-*` branches older than 7 days.
+
+**New workflow**: `.github/workflows/cleanup-branches.yml`
+
+```yaml
+name: Cleanup Stale Branches
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Weekly on Sunday
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Delete stale version-bump branches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Find and delete version-bump branches older than 7 days
+          for branch in $(gh api repos/${{ github.repository }}/branches --paginate -q '.[].name | select(startswith("chore/version-bump"))'); do
+            echo "Deleting stale branch: $branch"
+            git push origin --delete "$branch" || true
+          done
+```
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Workflow runs weekly on schedule
+- [ ] #2 Deletes chore/version-bump-* branches
+- [ ] #3 Can be triggered manually via workflow_dispatch
+<!-- AC:END -->


### PR DESCRIPTION
## Summary

- Add task-310: Fix `upgrade-tools` reports success but doesn't actually upgrade
- Add task-311: Fix orphaned `chore/version-bump` branches not being cleaned up

## Tasks Added

### task-310: upgrade-tools bug
The `specify upgrade-tools` command reports success but doesn't actually upgrade (e.g., shows `✓ Installed version 0.2.328 (was: 0.2.328)` when 0.2.332 is available).

**Subtasks:**
- task-310.01: Fix version detection after upgrade install
- task-310.02: Remove unnecessary uv tool upgrade attempt  
- task-310.03: Add unit tests for upgrade-tools scenarios

### task-311: orphaned version-bump branches
Branches like `chore/version-bump--0.2.332` are created by the release workflow but never cleaned up.

**Subtasks:**
- task-311.01: Fix double-dash in branch name
- task-311.02: Delete branch after PR creation failure
- task-311.03: Enable auto-delete branch on PR merge
- task-311.04: Add scheduled cleanup workflow

## Test plan
- [x] Tasks are properly formatted
- [x] Parent-child relationships are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)