### PR TITLE
chore: task-300, task-308 updates and docs

### DIFF
--- a/backlog/tasks/task-300 - Add-file-friendly-timestamp-to-specify-backup-directory-path.md
+++ b/backlog/tasks/task-300 - Add-file-friendly-timestamp-to-specify-backup-directory-path.md
@@ -1,0 +1,48 @@
+---
+id: task-300
+title: Add file-friendly timestamp to specify-backup directory path
+status: In Progress
+assignee:
+  - '@pm-planner'
+created_date: '2025-12-07 22:28'
+updated_date: '2025-12-07 22:34'
+labels:
+  - backend
+  - implement
+  - size-s
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The `.specify-backup/` directory created during `specify upgrade-tools` command overwrites previous backups without preserving history. Add a file-friendly timestamp to the backup directory name to preserve multiple backup versions.
+
+Current behavior:
+- Backup created at `.specify-backup/`
+- Each upgrade overwrites previous backup
+
+Desired behavior:
+- Backup created at `.specify-backup-YYYYMMDD-HHMMSS/`
+- Multiple backups preserved for rollback options
+
+Files to modify:
+- `src/specify_cli/__init__.py` (line ~3675)
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Backup directory includes ISO 8601-like timestamp (YYYYMMDD-HHMMSS format)
+- [ ] #2 Timestamp is file-system safe (no colons or special characters)
+- [ ] #3 Multiple consecutive upgrades create separate backup directories
+- [ ] #4 Backup directory name displayed correctly in console output
+- [ ] #5 Existing tests pass and new tests cover timestamp format
+- [ ] #6 Documentation updated to reflect new backup naming
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+PR created: https://github.com/jpoley/jp-spec-kit/pull/600
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-308 - Add-version-flag-to-specify-upgrade-tools-command.md
+++ b/backlog/tasks/task-308 - Add-version-flag-to-specify-upgrade-tools-command.md
@@ -1,11 +1,11 @@
 ---
 id: task-308
 title: Add --version flag to specify upgrade-tools command
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2025-12-07 23:51'
-updated_date: '2025-12-08 00:50'
+updated_date: '2025-12-08 00:54'
 labels:
   - enhancement
   - cli
@@ -41,9 +41,9 @@ specify install --version 0.2.322
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Users can install specific versions with --version flag
-- [ ] #2 Version is validated against available releases
-- [ ] #3 Clear error message if version doesn't exist
+- [x] #1 Users can install specific versions with --version flag
+- [x] #2 Version is validated against available releases
+- [x] #3 Clear error message if version doesn't exist
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -73,3 +73,19 @@ specify install --version 0.2.322
 ### Files to modify:
 - `src/specify_cli/__init__.py`: Add arguments and logic
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented in PR #612.
+
+New commands:
+- `specify upgrade-tools --list-versions` - Shows available releases
+- `specify upgrade-tools --version 0.2.325` - Installs specific version
+
+Implementation:
+- Added `get_github_releases()` and `version_exists_in_releases()` helper functions
+- Modified `_upgrade_jp_spec_kit()` to accept `target_version` parameter
+- Added `_list_jp_spec_kit_versions()` for displaying releases in table format
+- Version validation happens before install attempt
+<!-- SECTION:NOTES:END -->

--- a/docs/jpspec-copilot-slash-commands.md
+++ b/docs/jpspec-copilot-slash-commands.md
@@ -1,0 +1,232 @@
+# Issue: `/jpspec:` slash commands not appearing in VS Code Copilot Chat
+
+**Repository:** https://github.com/jpoley/jp-spec-kit  
+**Labels:** `bug`, `copilot`, `documentation`  
+**Priority:** High  
+**Created:** 2025-12-07
+
+---
+
+## Problem Summary
+
+Custom slash commands defined in `.claude/commands/` (e.g., `/jpspec:specify`, `/jpspec:implement`) are **not appearing** in VS Code Copilot Chat. The commands work correctly in Claude Code CLI but are completely invisible in VS Code / VS Code Insiders with GitHub Copilot extension.
+
+---
+
+## Current Setup
+
+Commands are currently located in `.claude/commands/`:
+
+```
+.claude/commands/
+├── jpspec/
+├── jpspec._backlog-instructions.md
+├── jpspec._workflow-state.md
+├── jpspec.assess.md
+├── jpspec.implement.md
+├── jpspec.operate.md
+├── jpspec.plan.md
+├── jpspec.prune-branch.md
+├── jpspec.research.md
+├── jpspec.specify.md
+├── jpspec.validate.md
+├── speckit.analyze.md
+├── speckit.checklist.md
+├── speckit.clarify.md
+├── speckit.constitution.md
+├── speckit.implement.md
+├── speckit.plan.md
+├── speckit.specify.md
+├── speckit.tasks.md
+└── speckit.taskstoissues.md
+```
+
+### Current File Format (Claude Code)
+
+```markdown
+---
+description: Create or update feature specifications using PM planner agent
+mode: agent
+---
+
+## User Input
+...
+```
+
+---
+
+## Root Cause Analysis
+
+Research into [github/spec-kit](https://github.com/github/spec-kit) reveals that **VS Code Copilot uses a completely different directory structure and file format** than Claude Code:
+
+### Agent Directory Comparison
+
+| Agent | Directory | Format | CLI Tool |
+|-------|-----------|--------|----------|
+| Claude Code | `.claude/commands/` | Markdown | `claude` |
+| **GitHub Copilot** | **`.github/agents/`** | Markdown | N/A (IDE-based) |
+| Cursor | `.cursor/commands/` | Markdown | `cursor-agent` |
+| Gemini | `.gemini/commands/` | TOML | `gemini` |
+
+### File Format Difference
+
+**Claude Code format:**
+```markdown
+---
+description: "Command description"
+mode: agent
+---
+```
+
+**GitHub Copilot format (REQUIRED):**
+```markdown
+---
+description: "Command description"
+mode: jpspec.specify
+---
+```
+
+Key difference: Copilot requires `mode: <command-name>` where the mode value becomes the slash command name (e.g., `mode: jpspec.specify` → `/jpspec.specify`).
+
+---
+
+## Evidence from spec-kit
+
+### From AGENTS.md
+
+> **GitHub Copilot** | `.github/agents/` | Markdown | N/A (IDE-based) | GitHub Copilot in VS Code
+
+### From CHANGELOG.md (v0.0.22)
+
+> - Support for VS Code/Copilot agents, and moving away from prompts to proper agents with hand-offs.
+> - Move to use `AGENTS.md` for Copilot workloads, since it's already supported out-of-the-box.
+
+### From Command File Formats section
+
+**GitHub Copilot Chat Mode format:**
+
+```markdown
+---
+description: "Command description"
+mode: speckit.command-name
+---
+
+Command content with {SCRIPT} and $ARGUMENTS placeholders.
+```
+
+---
+
+## Solution Required
+
+### 1. Create `.github/agents/` Directory
+
+```bash
+mkdir -p .github/agents
+```
+
+### 2. Convert Commands to Copilot Format
+
+For each command in `.claude/commands/jpspec.*.md`, create a corresponding file in `.github/agents/` with:
+
+**Example: `.github/agents/jpspec.specify.md`**
+```markdown
+---
+description: Create or update feature specifications using PM planner agent (manages /speckit.tasks).
+mode: jpspec.specify
+---
+
+## User Input
+
+$ARGUMENTS
+
+## Execution Instructions
+...
+```
+
+### 3. Commands to Convert
+
+| Source File | Target File | Mode Value |
+|-------------|-------------|------------|
+| `.claude/commands/jpspec.specify.md` | `.github/agents/jpspec.specify.md` | `jpspec.specify` |
+| `.claude/commands/jpspec.implement.md` | `.github/agents/jpspec.implement.md` | `jpspec.implement` |
+| `.claude/commands/jpspec.assess.md` | `.github/agents/jpspec.assess.md` | `jpspec.assess` |
+| `.claude/commands/jpspec.plan.md` | `.github/agents/jpspec.plan.md` | `jpspec.plan` |
+| `.claude/commands/jpspec.research.md` | `.github/agents/jpspec.research.md` | `jpspec.research` |
+| `.claude/commands/jpspec.validate.md` | `.github/agents/jpspec.validate.md` | `jpspec.validate` |
+| `.claude/commands/jpspec.operate.md` | `.github/agents/jpspec.operate.md` | `jpspec.operate` |
+| `.claude/commands/jpspec.prune-branch.md` | `.github/agents/jpspec.prune-branch.md` | `jpspec.prune-branch` |
+| `.claude/commands/speckit.specify.md` | `.github/agents/speckit.specify.md` | `speckit.specify` |
+| `.claude/commands/speckit.plan.md` | `.github/agents/speckit.plan.md` | `speckit.plan` |
+| `.claude/commands/speckit.tasks.md` | `.github/agents/speckit.tasks.md` | `speckit.tasks` |
+| `.claude/commands/speckit.implement.md` | `.github/agents/speckit.implement.md` | `speckit.implement` |
+| `.claude/commands/speckit.constitution.md` | `.github/agents/speckit.constitution.md` | `speckit.constitution` |
+| `.claude/commands/speckit.clarify.md` | `.github/agents/speckit.clarify.md` | `speckit.clarify` |
+| `.claude/commands/speckit.analyze.md` | `.github/agents/speckit.analyze.md` | `speckit.analyze` |
+| `.claude/commands/speckit.checklist.md` | `.github/agents/speckit.checklist.md` | `speckit.checklist` |
+| `.claude/commands/speckit.taskstoissues.md` | `.github/agents/speckit.taskstoissues.md` | `speckit.taskstoissues` |
+
+### 4. Update Documentation
+
+- Add note to README about dual-agent support (Claude Code + VS Code Copilot)
+- Document that both `.claude/commands/` and `.github/agents/` must be kept in sync
+- Consider creating a sync script to generate Copilot agents from Claude commands
+
+---
+
+## Acceptance Criteria
+
+- [ ] `.github/agents/` directory exists with all jpspec commands
+- [ ] All commands have correct `mode:` frontmatter
+- [ ] `/jpspec:specify` appears in VS Code Copilot Chat
+- [ ] `/jpspec:implement` appears in VS Code Copilot Chat
+- [ ] All other `/jpspec:*` commands appear
+- [ ] All `/speckit.*` commands appear
+- [ ] Commands execute correctly when invoked
+- [ ] Documentation updated
+
+---
+
+## Environment
+
+- **IDE:** VS Code Insiders (also affects regular VS Code)
+- **Extension:** GitHub Copilot Chat
+- **OS:** macOS
+- **Working:** Claude Code CLI (`claude` command)
+- **Not Working:** VS Code Copilot Chat
+
+---
+
+## References
+
+- [github/spec-kit repository](https://github.com/github/spec-kit)
+- [AGENTS.md - Agent configuration](https://github.com/github/spec-kit/blob/main/AGENTS.md)
+- [Command File Formats](https://github.com/github/spec-kit/blob/main/AGENTS.md#command-file-formats)
+- [Copilot directory convention](https://github.com/github/spec-kit/blob/main/AGENTS.md#directory-conventions)
+
+---
+
+## Quick Fix (Manual)
+
+If you need this working immediately, run:
+
+```bash
+# From jp-spec-kit repo root
+mkdir -p .github/agents
+
+# For each command, copy and modify the frontmatter
+# Example for jpspec.specify:
+cp .claude/commands/jpspec.specify.md .github/agents/jpspec.specify.md
+
+# Then edit .github/agents/jpspec.specify.md and change:
+# mode: agent
+# to:
+# mode: jpspec.specify
+```
+
+Or use spec-kit's CLI to regenerate:
+
+```bash
+uvx --from git+https://github.com/github/spec-kit.git specify init --here --force --ai copilot
+```
+
+**Warning:** The spec-kit command will overwrite files. Back up customizations first.

--- a/docs/prd/backup-timestamp-prd.md
+++ b/docs/prd/backup-timestamp-prd.md
@@ -1,0 +1,327 @@
+# Feature Specification: File-Friendly Timestamp in Specify-Backup Path
+
+**Feature Branch**: `300-backup-timestamp`
+**Created**: 2025-12-07
+**Status**: Draft
+**Backlog Task**: task-300
+**Input**: User description: "we need to add a file friendly timestamp in the specify-backup path"
+
+---
+
+## 1. Executive Summary
+
+### Problem Statement (Customer Opportunity Focus)
+
+When users run `specify upgrade-tools`, the backup directory `.specify-backup/` is created without a timestamp. Each subsequent upgrade operation **overwrites** the previous backup, eliminating the user's ability to:
+
+- Roll back to earlier template versions
+- Compare changes between upgrade iterations
+- Recover from failed upgrades that corrupt the most recent backup
+
+### Proposed Solution (Outcome-Driven)
+
+Add a file-system-safe timestamp to the backup directory name using the format:
+```
+.specify-backup-YYYYMMDD-HHMMSS/
+```
+
+Example: `.specify-backup-20251207-143052/`
+
+### Success Metrics (North Star + Key Outcomes)
+
+| Metric | Target |
+|--------|--------|
+| **North Star**: Backup preservation rate | 100% of backups preserved across upgrades |
+| **User recovery capability** | Users can access any previous backup |
+| **Timestamp uniqueness** | No backup name collisions |
+
+### Business Value and Strategic Alignment
+
+- **Reduced support burden**: Users can self-service rollbacks
+- **Improved upgrade confidence**: Safe experimentation with upgrades
+- **Data safety**: Protection against cascading failures
+
+---
+
+## 2. User Stories and Use Cases
+
+### User Story 1 - Preserve Multiple Backup Versions (Priority: P1)
+
+As a developer using JP Spec Kit, I want each upgrade to create a uniquely named backup directory so that I can access previous versions of my templates after multiple upgrades.
+
+**Why this priority**: Core functionality - without this, the entire backup system is unreliable.
+
+**Independent Test**: Run `specify upgrade-tools` twice and verify two separate backup directories exist.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project with existing templates, **When** I run `specify upgrade-tools`, **Then** a backup directory with timestamp is created (e.g., `.specify-backup-20251207-143052/`)
+2. **Given** a project with an existing timestamped backup, **When** I run `specify upgrade-tools` again, **Then** a new backup with a different timestamp is created alongside the previous one
+
+---
+
+### User Story 2 - Console Output Shows Timestamped Path (Priority: P1)
+
+As a developer, I want the console output to display the exact timestamped backup path so I know where my backup is stored.
+
+**Why this priority**: Essential UX - users must know backup location.
+
+**Independent Test**: Run upgrade and verify console shows full timestamped path.
+
+**Acceptance Scenarios**:
+
+1. **Given** running `specify upgrade-tools`, **When** backup completes, **Then** console displays `saved to .specify-backup-YYYYMMDD-HHMMSS`
+2. **Given** upgrade fails, **When** error is displayed, **Then** console shows exact backup path for recovery
+
+---
+
+### User Story 3 - Rollback from Specific Backup (Priority: P2)
+
+As a developer who needs to rollback, I want to easily identify which backup corresponds to which upgrade attempt by looking at the timestamp in the directory name.
+
+**Why this priority**: Secondary value - relies on P1 features.
+
+**Independent Test**: List backup directories and verify timestamps are human-readable and sortable.
+
+**Acceptance Scenarios**:
+
+1. **Given** multiple backup directories exist, **When** I list the project directory, **Then** backups are sortable chronologically by name
+2. **Given** a backup directory name, **When** I parse the timestamp, **Then** it clearly indicates the date and time of the backup
+
+---
+
+### Edge Cases
+
+- **What happens when** two upgrades occur within the same second? → Timestamp includes seconds, collisions extremely unlikely; if collision occurs, append counter.
+- **How does system handle** timezone differences? → Use local system time consistently.
+- **What happens with** non-ASCII file systems? → Format uses only ASCII characters (digits, hyphens), universally compatible.
+
+---
+
+## 3. DVF+V Risk Assessment
+
+### Value Risk (Desirability)
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Users don't need multiple backups | Low | Existing pattern in git (reflog) proves value |
+| Disk space concerns | Medium | Document cleanup guidance for old backups |
+
+**Validation Plan**: User feedback on current overwrite behavior confirms pain point.
+
+### Usability Risk (Experience)
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Timestamp format confusing | Low | Use ISO 8601-inspired format (familiar) |
+| Directory clutter | Medium | Consider future --cleanup flag |
+
+**Validation Plan**: Format aligns with common conventions (git stash, backup tools).
+
+### Feasibility Risk (Technical)
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Cross-platform timestamp issues | Low | Python datetime is cross-platform |
+| Timezone handling | Low | Use local time, document behavior |
+
+**Validation Plan**: Minimal code change (~5 lines), well-understood Python APIs.
+
+### Business Viability Risk (Organizational)
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Breaking change concerns | None | Additive change, backwards compatible |
+| Documentation updates | Low | Minimal doc changes required |
+
+**Validation Plan**: No breaking changes, purely additive improvement.
+
+---
+
+## 4. Functional Requirements
+
+### Core Features and Capabilities
+
+- **FR-001**: System MUST generate backup directory names with format `.specify-backup-YYYYMMDD-HHMMSS`
+- **FR-002**: System MUST use local system time for timestamp generation
+- **FR-003**: System MUST NOT overwrite existing backup directories
+- **FR-004**: System MUST display the full timestamped backup path in console output
+- **FR-005**: System MUST preserve all existing backup functionality (what gets backed up)
+
+### Timestamp Format Specification
+
+| Component | Format | Example |
+|-----------|--------|---------|
+| Year | YYYY | 2025 |
+| Month | MM | 12 |
+| Day | DD | 07 |
+| Hour (24h) | HH | 14 |
+| Minute | mm | 30 |
+| Second | SS | 52 |
+| **Full Format** | `.specify-backup-YYYYMMDD-HHMMSS` | `.specify-backup-20251207-143052` |
+
+### File System Safety
+
+The format uses only:
+- ASCII digits (0-9)
+- Hyphens (-)
+- Period prefix (.)
+
+This ensures compatibility across:
+- Windows (NTFS, FAT32)
+- macOS (APFS, HFS+)
+- Linux (ext4, btrfs, etc.)
+
+---
+
+## 5. Non-Functional Requirements
+
+### Performance Requirements
+
+- **NFR-001**: Timestamp generation MUST add < 1ms to backup operation
+- **NFR-002**: No additional I/O beyond current backup implementation
+
+### Compatibility Requirements
+
+- **NFR-003**: Works on Python 3.11+ (existing requirement)
+- **NFR-004**: Works on Windows, macOS, Linux
+- **NFR-005**: Directory name under 255 characters (filesystem limit)
+
+### Maintainability Requirements
+
+- **NFR-006**: Timestamp format documented in code comments
+- **NFR-007**: Existing test patterns followed
+
+---
+
+## 6. Task Breakdown (Backlog Tasks)
+
+**Implementation task created:**
+
+- **task-300**: Add file-friendly timestamp to specify-backup directory path
+  - Priority: Medium
+  - Labels: backend, implement, size-s
+  - Assignee: @pm-planner
+
+**Acceptance Criteria** (from task-300):
+1. Backup directory includes ISO 8601-like timestamp (YYYYMMDD-HHMMSS format)
+2. Timestamp is file-system safe (no colons or special characters)
+3. Multiple consecutive upgrades create separate backup directories
+4. Backup directory name displayed correctly in console output
+5. Existing tests pass and new tests cover timestamp format
+6. Documentation updated to reflect new backup naming
+
+---
+
+## 7. Discovery and Validation Plan
+
+### Learning Goals and Hypotheses
+
+| Hypothesis | Validation Method | Success Criteria |
+|------------|-------------------|------------------|
+| Users need backup history | Feedback from issue/feature request | User confirms pain point |
+| Timestamp format is intuitive | Code review | Reviewers understand format |
+| Implementation is minimal | LoC count | < 10 lines changed |
+
+### Go/No-Go Decision Points
+
+- **Go**: If implementation fits within existing backup flow
+- **No-Go**: If timestamp generation causes platform-specific issues (unlikely)
+
+---
+
+## 8. Acceptance Criteria and Testing
+
+### Acceptance Test Scenarios
+
+| # | Scenario | Expected Result |
+|---|----------|-----------------|
+| 1 | Fresh project upgrade | `.specify-backup-YYYYMMDD-HHMMSS/` created |
+| 2 | Second upgrade | New timestamped backup, first preserved |
+| 3 | Console output | Shows full timestamped path |
+| 4 | Failed upgrade | Error message shows correct backup path |
+
+### Definition of Done
+
+- [ ] Implementation complete
+- [ ] Unit tests pass
+- [ ] Existing tests unaffected
+- [ ] Console output updated
+- [ ] Code reviewed
+- [ ] Documentation updated (CHANGELOG.md minimum)
+
+### Test Coverage Requirements
+
+- New timestamp format helper function: 100% coverage
+- Backup path generation: existing tests + new timestamp tests
+
+---
+
+## 9. Dependencies and Constraints
+
+### Technical Dependencies
+
+| Dependency | Purpose |
+|------------|---------|
+| Python `datetime` module | Timestamp generation (stdlib, no new deps) |
+| `pathlib.Path` | Directory path construction (already used) |
+
+### Risk Factors
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Timezone edge cases | Low | Low | Document local time usage |
+| Filename length limits | None | Low | Total length well under 255 |
+
+---
+
+## 10. Success Metrics (Outcome-Focused)
+
+### North Star Metric
+
+**Backup Preservation Rate**: Percentage of upgrade operations that preserve previous backups.
+
+| Current | Target | Measurement |
+|---------|--------|-------------|
+| 0% (overwrites) | 100% (all preserved) | Count unique backup directories after multiple upgrades |
+
+### Leading Indicators
+
+- Console output shows timestamped path
+- No test regressions
+
+### Lagging Indicators
+
+- Zero user complaints about lost backups
+- Users successfully performing rollbacks
+
+### Measurement Approach
+
+- Manual verification during code review
+- Automated tests verify multiple backup directories created
+
+---
+
+## Implementation Notes
+
+### Code Location
+
+`src/specify_cli/__init__.py` line ~3675:
+
+```python
+# Current implementation
+backup_dir = project_path / ".specify-backup"
+
+# New implementation
+from datetime import datetime
+timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+backup_dir = project_path / f".specify-backup-{timestamp}"
+```
+
+### Affected Console Messages
+
+Update messages at lines ~3686, ~3710, ~3715 to reference `backup_dir.name` (already dynamic).
+
+---
+
+*PRD created by PM Planner agent via /jpspec:specify*


### PR DESCRIPTION
## Summary
- Mark task-308 as Done with implementation notes (version flag feature)
- Add task-300 for backup timestamp feature
- Add jpspec-copilot-slash-commands documentation
- Add backup-timestamp PRD

## Bug Fixes
- Fixed `MM` -> `mm` for minute format in PRD timestamp table
- Fixed nested markdown code blocks in copilot slash commands doc

## Test plan
- [x] All tests pass locally (2769 passed)
- [x] Linting passes
- [ ] CI checks pass