### PR TITLE
ci(copilot): add CI check for Copilot agent sync drift

### DIFF
--- a/.github/agents/jpspec.validate.md
+++ b/.github/agents/jpspec.validate.md
@@ -1,6 +1,5 @@
 ---
 description: Execute validation and quality assurance using QA, security, documentation, and release management agents.
-mode: jpspec:validate
 ---
 
 # /jpspec:validate - Enhanced Phased Validation Workflow

--- a/.github/agents/speckit.analyze.md
+++ b/.github/agents/speckit.analyze.md
@@ -186,4 +186,3 @@ Ask the user: "Would you like me to suggest concrete remediation edits for the t
 ## Context
 
 {ARGS}
-

--- a/.github/agents/speckit.checklist.md
+++ b/.github/agents/speckit.checklist.md
@@ -289,4 +289,3 @@ Sample items:
 - Correct: Validation of requirement quality
 - Wrong: "Does it do X?" 
 - Correct: "Is X clearly specified?"
-

--- a/.github/agents/speckit.clarify.md
+++ b/.github/agents/speckit.clarify.md
@@ -178,4 +178,3 @@ Behavior rules:
  - If quota reached with unresolved high-impact categories remaining, explicitly flag them under Deferred with rationale.
 
 Context for prioritization: {ARGS}
-

--- a/.github/agents/speckit.constitution.md
+++ b/.github/agents/speckit.constitution.md
@@ -1,5 +1,4 @@
 ---
-mode: speckit:constitution
 description: Analyze repository and create customized constitution.md based on detected tech stack
 ---
 

--- a/.github/agents/speckit.implement.md
+++ b/.github/agents/speckit.implement.md
@@ -130,4 +130,3 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Report final status with summary of completed work
 
 Note: This command assumes a complete task breakdown exists in tasks.md. If tasks are incomplete or missing, suggest running `/tasks` first to regenerate the task list.
-

--- a/.github/agents/speckit.plan.md
+++ b/.github/agents/speckit.plan.md
@@ -85,4 +85,3 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 - Use absolute paths
 - ERROR on gate failures or unresolved clarifications
-

--- a/.github/agents/speckit.specify.md
+++ b/.github/agents/speckit.specify.md
@@ -231,4 +231,3 @@ Success criteria must be:
 - "Database can handle 1000 TPS" (implementation detail, use user-facing metric)
 - "React components render efficiently" (framework-specific)
 - "Redis cache hit rate above 80%" (technology-specific)
-

--- a/.github/agents/speckit.tasks.md
+++ b/.github/agents/speckit.tasks.md
@@ -140,5 +140,3 @@ Every task MUST strictly follow this format:
   - Within each story: Tests (if requested) → Models → Services → Endpoints → Integration
   - Each phase should be a complete, independently testable increment
 - **Final Phase**: Polish & Cross-Cutting Concerns
-
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,15 @@ jobs:
           name: dist
           path: dist/
 
+  copilot-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check Copilot agents are in sync
+        run: ./scripts/bash/sync-copilot-agents.sh --check
+
   security:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/bash/sync-copilot-agents.sh
+++ b/scripts/bash/sync-copilot-agents.sh
@@ -2,48 +2,92 @@
 # Sync Claude Code commands to GitHub Copilot agents format
 # Converts .claude/commands/{namespace}/*.md -> .github/agents/{namespace}.{command}.md
 # Changes frontmatter: mode: agent -> mode: {namespace}:{command}
+#
+# Usage:
+#   ./sync-copilot-agents.sh          # Sync files (default)
+#   ./sync-copilot-agents.sh --check  # Check for drift without modifying (CI mode)
 
 set -e
 
 CLAUDE_DIR=".claude/commands"
 COPILOT_DIR=".github/agents"
+CHECK_MODE=false
+DRIFT_FOUND=false
 
-# Create target directory
-mkdir -p "$COPILOT_DIR"
+# Parse arguments
+if [[ "$1" == "--check" ]]; then
+    CHECK_MODE=true
+fi
+
+# Create target directory (skip in check mode)
+if [[ "$CHECK_MODE" == false ]]; then
+    mkdir -p "$COPILOT_DIR"
+fi
 
 # Track counts
 converted=0
 skipped=0
+drifted=0
 
 # Process each namespace (jpspec, speckit)
 for namespace_dir in "$CLAUDE_DIR"/*/; do
     namespace=$(basename "$namespace_dir")
-    
+
     # Skip if not a directory
     [[ ! -d "$namespace_dir" ]] && continue
-    
+
     # Process each command file (skip underscore-prefixed files - they're includes)
     for cmd_file in "$namespace_dir"*.md; do
         [[ ! -f "$cmd_file" ]] && continue
-        
+
         cmd_name=$(basename "$cmd_file" .md)
-        
+
         # Skip underscore-prefixed files (includes/partials)
         if [[ "$cmd_name" == _* ]]; then
-            ((skipped++))
+            ((skipped++)) || true
             continue
         fi
-        
+
         target_file="$COPILOT_DIR/${namespace}.${cmd_name}.md"
         mode_value="${namespace}:${cmd_name}"
-        
-        # Convert the file: change mode: agent -> mode: {namespace}:{command}
-        sed 's/^mode: agent$/mode: '"$mode_value"'/' "$cmd_file" > "$target_file"
-        
-        echo "✓ Converted: $cmd_file -> $target_file"
-        ((converted++))
+
+        # Generate expected content
+        expected_content=$(sed 's/^mode: agent$/mode: '"$mode_value"'/' "$cmd_file")
+
+        if [[ "$CHECK_MODE" == true ]]; then
+            # Check mode: compare with existing file
+            if [[ ! -f "$target_file" ]]; then
+                echo "❌ Missing: $target_file"
+                DRIFT_FOUND=true
+                ((drifted++)) || true
+            elif ! diff -q <(echo "$expected_content") "$target_file" > /dev/null 2>&1; then
+                echo "❌ Drift detected: $target_file"
+                DRIFT_FOUND=true
+                ((drifted++)) || true
+            else
+                ((converted++)) || true
+            fi
+        else
+            # Sync mode: write the file
+            echo "$expected_content" > "$target_file"
+            echo "✓ Converted: $cmd_file -> $target_file"
+            ((converted++)) || true
+        fi
     done
 done
 
 echo ""
-echo "Sync complete: $converted files converted, $skipped partials skipped"
+
+if [[ "$CHECK_MODE" == true ]]; then
+    if [[ "$DRIFT_FOUND" == true ]]; then
+        echo "❌ Sync check FAILED: $drifted files out of sync"
+        echo ""
+        echo "Run './scripts/bash/sync-copilot-agents.sh' to fix"
+        exit 1
+    else
+        echo "✅ Sync check passed: $converted files in sync, $skipped partials skipped"
+        exit 0
+    fi
+else
+    echo "Sync complete: $converted files converted, $skipped partials skipped"
+fi


### PR DESCRIPTION
## Summary

- Add `--check` flag to `sync-copilot-agents.sh` for CI validation mode
- Add `copilot-sync` job to CI workflow that fails if agents are out of sync
- Re-sync agent files to fix trailing newline differences

## How it works

The sync script now supports two modes:

```bash
# Sync mode (default) - updates .github/agents/
./scripts/bash/sync-copilot-agents.sh

# Check mode (CI) - validates sync, exits 1 if drift detected
./scripts/bash/sync-copilot-agents.sh --check
```

## CI Integration

The new `copilot-sync` job runs on every PR and push to main:

```yaml
copilot-sync:
  runs-on: ubuntu-latest
  steps:
    - uses: actions/checkout@v4
    - run: ./scripts/bash/sync-copilot-agents.sh --check
```

If someone modifies `.claude/commands/` without running the sync script, CI will fail with:

```
❌ Sync check FAILED: 2 files out of sync

Run './scripts/bash/sync-copilot-agents.sh' to fix
```

## Test plan

- [x] `./scripts/bash/sync-copilot-agents.sh --check` passes locally
- [ ] CI workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)