### PR TITLE
fix(ci): use v prefix strip instead of regex for branch naming

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,8 @@ jobs:
           echo "⚠️ Direct push failed (branch protection). Creating PR instead..."
 
           # Create a branch and PR for the version bump
-          BRANCH_NAME="chore/version-bump-${NEW_VERSION//[^0-9.]/-}"
+          VERSION_NUM="${NEW_VERSION#v}"
+          BRANCH_NAME="chore/version-bump-${VERSION_NUM}"
           git checkout -b "$BRANCH_NAME"
           git push origin "$BRANCH_NAME"
 
@@ -108,7 +109,7 @@ jobs:
           else
             echo "⚠️ Could not create PR automatically."
             echo "📌 Manual action needed: Sync pyproject.toml and __init__.py to version ${NEW_VERSION#v}"
-            echo "   Branch 'chore/version-bump-${NEW_VERSION//[^0-9.]/-}' has been pushed with the changes."
+            echo "   Branch '$BRANCH_NAME' has been pushed with the changes."
             echo ""
             echo "   The release was created successfully - this is just a version sync issue."
           fi


### PR DESCRIPTION
## Summary
- Fixes double-dash bug in version-bump branch names
- Before: `chore/version-bump--0.2.332` (double dash)
- After: `chore/version-bump-0.2.332` (single dash)

## Changes
- Replace regex `${NEW_VERSION//[^0-9.]/-}` with simple v prefix strip `${NEW_VERSION#v}`
- Updated error message to use `$BRANCH_NAME` variable

## Test plan
- [x] Verified with shell test: `NEW_VERSION="v0.2.332"; VERSION_NUM="${NEW_VERSION#v}"; echo "chore/version-bump-${VERSION_NUM}"` outputs `chore/version-bump-0.2.332`
- [ ] Monitor next release for correct branch naming

Fixes task-311.01

🤖 Generated with [Claude Code](https://claude.com/claude-code)