### PR TITLE
fix(cli): trust install version instead of re-detecting after upgrade

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -4004,10 +4004,9 @@ def _upgrade_jp_spec_kit(
             text=True,
             check=True,
         )
-        new_version = _get_installed_jp_spec_kit_version()
-        if new_version:
-            return True, f"Installed version {new_version} (was: {current_version})"
-        return True, f"Installed version {install_version}"
+        # After successful install, trust the version we just installed
+        # rather than re-detecting which may return stale results due to shell caching
+        return True, f"Installed version {install_version} (was: {current_version})"
     except subprocess.CalledProcessError as e:
         return False, f"Install failed: {e.stderr}"
     except FileNotFoundError:


### PR DESCRIPTION
## Summary
- Fixes stale version detection after `uv tool install --force`
- Trust the known `install_version` directly instead of re-running `specify version`
- Eliminates reliance on shell PATH cache

## Changes
- Removed call to `_get_installed_jp_spec_kit_version()` after successful install
- Directly return the known `install_version` with explanatory comment

## Test plan
- [x] All 38 upgrade-related tests pass
- [ ] Manual test: run `specify upgrade-tools` and verify correct version reported

Fixes task-310.01

🤖 Generated with [Claude Code](https://claude.com/claude-code)