### PR TITLE
fix(ci): update version files before creating git tag (v2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
               --base main \
               --head "$BRANCH_NAME"; then
               echo "✅ Created PR for version bump"
-              echo "version_committed=pr_created" >> $GITHUB_OUTPUT
+              echo "version_committed=false" >> $GITHUB_OUTPUT
             else
               echo "❌ Could not create PR. Cleaning up branch..."
               git push origin --delete "$BRANCH_NAME" || true


### PR DESCRIPTION
## Summary
Refactors release workflow to ensure version consistency:

- Move version file update **BEFORE** tag creation
- Tag now points to commit with updated version files
- Remove `continue-on-error` to fail loudly on sync issues
- Add proper output variables for step coordination
- **Fixed**: All release steps now depend on `version_committed == 'true'`

## Problem
- Current: Tags created at v0.2.343, pyproject.toml stuck at 0.2.328
- Cause: Version files updated AFTER tag creation
- When branch protection blocks push, version files never sync

## v2 Fix (from closed PR #632)
Previous PR had a bug: release packages/notes/release would still be created even when the PR path was taken. Now ALL release steps require `version_committed == 'true'`.

## Flow Diagrams

**Direct Push (happy path):**
```
1. Update version files
2. Commit [skip ci]
3. Push to main ✓
4. Create tag (points to version commit)
5. Create release packages
6. Create GitHub Release
```

**Branch Protection (PR path):**
```
1. Update version files
2. Commit [skip ci]
3. Push fails → Create PR
4. EXIT (no tag, no release yet)
---
After PR merge, workflow runs again:
5. Detect no version changes needed
6. version_committed=true
7. Create tag
8. Create release
```

## Test plan
- [x] Workflow structure validated
- [x] Step ordering verified
- [x] All release steps depend on version_committed
- [ ] Test with `act` locally
- [ ] Monitor first release after merge

Fixes task-313

🤖 Generated with [Claude Code](https://claude.com/claude-code)