### PR TITLE
fix(ci): update version files before creating git tag (v3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
             # Try to create PR - may fail if Actions can't create PRs
             if gh pr create \
               --title "chore: bump version to $NEW_VERSION" \
-              --body "Automated version bump to $NEW_VERSION after release. This PR was created because main branch is protected and requires PRs." \
+              --body "Automated version bump to $NEW_VERSION for upcoming release. This PR was created because main branch is protected and requires PRs." \
               --base main \
               --head "$BRANCH_NAME"; then
               echo "✅ Created PR for version bump - release will complete after PR merge"


### PR DESCRIPTION
## Summary
Refactors release workflow to ensure version consistency.

## Review Fixes (v3)
All review comments from PR #633 addressed:

1. **Line 51** - `git diff --cached --quiet` now specifies version files explicitly
2. **Line 79** - PR path sets `version_committed=false` (clearer than `pr_created`)
3. **Lines 93-97** - Fetch latest main and tags before creating tag
4. **Line 96-97** - Checkout main after fetch to ensure tagging correct commit

## Changes
- Move version file update **BEFORE** tag creation
- Tag now points to commit with updated version files
- Remove `continue-on-error` to fail loudly on sync issues
- All release steps depend on `version_committed == 'true'`

## Flow Diagrams

**Direct Push (happy path):**
```
1. Update version files
2. Commit [skip ci]
3. Push to main ✓
4. Fetch origin main + tags
5. Checkout main (ensure correct commit)
6. Create tag (points to version commit)
7. Create release
```

**Branch Protection (PR path):**
```
1. Update version files
2. Commit [skip ci]
3. Push fails → Create PR
4. version_committed=false → EXIT
---
After PR merge, workflow runs again → completes release
```

## Test plan
- [x] All review comments addressed
- [x] Workflow structure validated
- [ ] Test with `act` locally
- [ ] Monitor first release after merge

Fixes task-313

🤖 Generated with [Claude Code](https://claude.com/claude-code)