### PR TITLE
chore: sync version to 0.2.343 to match latest tag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "specify-cli"
 
-version = "0.2.328"
+version = "0.2.343"
 
 
 

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -595,7 +595,7 @@ BANNER = """
 """
 
 # Version - keep in sync with pyproject.toml
-__version__ = "0.2.328"
+__version__ = "0.2.343"
 
 # Constitution template version
 CONSTITUTION_VERSION = "1.0.0"


### PR DESCRIPTION
## Summary
One-time sync to resolve version desync after workflow fix (task-313).

## Changes
- `pyproject.toml`: 0.2.328 → 0.2.343
- `__init__.py`: 0.2.328 → 0.2.343

## Context
The release workflow was creating tags before updating version files, causing a 15-version gap. Now that task-313 is merged, this sync aligns the source files with the latest tag.

## Test plan
- [x] Version format valid (0.2.343)
- [x] Both files updated consistently
- [ ] `specify --version` returns 0.2.343 after merge

Fixes task-314

🤖 Generated with [Claude Code](https://claude.com/claude-code)