### PR TITLE
feat(docker): add Docker Hub publishing for specflow-agents image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,91 @@
+# JP Spec Kit / SpecFlow Agents Development Container
+# Published to Docker Hub: jpoley/specflow-agents
+#
+# This Dockerfile builds a pre-configured development environment with:
+# - Python 3.11 + uv package manager
+# - Node.js 20 + pnpm
+# - AI coding assistant CLIs (Claude, Codex, Gemini, Copilot)
+# - Task management (backlog.md)
+# - Common development tools
+#
+# Usage:
+#   docker pull jpoley/specflow-agents:latest
+#   Or reference in devcontainer.json: "image": "jpoley/specflow-agents:latest"
+
+FROM mcr.microsoft.com/devcontainers/python:3.11-bullseye
+
+# Install Node.js 20 and pnpm
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    && npm install -g pnpm \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update \
+    && apt-get install -y gh \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Switch to vscode user for remaining setup
+USER vscode
+WORKDIR /home/vscode
+
+# Set up environment variables
+ENV PNPM_HOME="/home/vscode/.local/share/pnpm"
+ENV PATH="/home/vscode/.local/bin:${PNPM_HOME}:${PATH}"
+
+# Install uv (installs to ~/.local/bin, NOT ~/.cargo/bin)
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Configure pnpm global bin directory
+RUN pnpm config set global-bin-dir "$PNPM_HOME"
+
+# Install AI coding assistant CLIs
+# Note: These are best-effort installs; some may not be available in all regions
+RUN pnpm install -g @anthropic-ai/claude-code || echo "claude-code install skipped" \
+    && pnpm install -g @githubnext/github-copilot-cli || echo "copilot-cli install skipped" \
+    && pnpm install -g @openai/codex || echo "codex install skipped" \
+    && pnpm install -g @google/gemini-cli || echo "gemini-cli install skipped"
+
+# Install task management tools
+RUN pnpm install -g backlog.md || echo "backlog.md install skipped"
+
+# Install Python development tools via uv
+RUN /home/vscode/.local/bin/uv tool install ruff \
+    && /home/vscode/.local/bin/uv tool install pytest
+
+# Create shell configuration for PATH
+RUN mkdir -p /home/vscode/.config/claude \
+    && echo '# SpecFlow Agents PATH setup' > /home/vscode/.zshenv \
+    && echo 'export PNPM_HOME="/home/vscode/.local/share/pnpm"' >> /home/vscode/.zshenv \
+    && echo 'export PATH="/home/vscode/.local/bin:$PNPM_HOME:$PATH"' >> /home/vscode/.zshenv
+
+# Add YOLO aliases (commented out by default for safety)
+RUN echo '' >> /home/vscode/.zshrc \
+    && echo '# AI coding agent YOLO aliases (uncomment at your own risk)' >> /home/vscode/.zshrc \
+    && echo '# alias claude-yolo="claude --dangerously-skip-permissions"' >> /home/vscode/.zshrc \
+    && echo '# alias codex-yolo="codex --dangerously-bypass-approvals-and-sandbox"' >> /home/vscode/.zshrc \
+    && echo '# alias gemini-yolo="gemini --yolo"' >> /home/vscode/.zshrc \
+    && echo '# alias copilot-yolo="copilot --allow-all-tools"' >> /home/vscode/.zshrc
+
+# Labels for Docker Hub
+LABEL org.opencontainers.image.title="SpecFlow Agents"
+LABEL org.opencontainers.image.description="Development container with AI coding assistants (Claude, Codex, Gemini, Copilot) and task management tools"
+LABEL org.opencontainers.image.source="https://github.com/jpoley/jp-spec-kit"
+LABEL org.opencontainers.image.vendor="jpoley"
+LABEL org.opencontainers.image.licenses="MIT"
+
+# Verify installations
+RUN echo "=== Installation Verification ===" \
+    && echo "Node: $(node --version)" \
+    && echo "pnpm: $(pnpm --version)" \
+    && echo "uv: $(/home/vscode/.local/bin/uv --version)" \
+    && echo "gh: $(gh --version | head -1)" \
+    && echo "PATH: $PATH"
+
+# Default command
+CMD ["zsh"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
         run: uv sync
 
       - name: Run tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: uv run pytest tests/ -v --cov=src/specify_cli --cov-report=term-missing
 
   build:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,96 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.devcontainer/Dockerfile'
+      - '.devcontainer/post-create.sh'
+      - '.github/workflows/docker-publish.yml'
+  workflow_dispatch:
+    inputs:
+      force_build:
+        description: 'Force rebuild even if no changes'
+        required: false
+        default: 'false'
+        type: boolean
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: jpoley/specflow-agents
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_SECRET }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-
+            type=ref,event=branch
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .devcontainer
+          file: .devcontainer/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+        continue-on-error: true
+
+      - name: Upload Trivy scan results
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'
+        continue-on-error: true
+
+  verify:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull and verify image
+        run: |
+          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest zsh -c "
+            echo '=== Verification ===' &&
+            node --version &&
+            pnpm --version &&
+            /home/vscode/.local/bin/uv --version &&
+            gh --version | head -1 &&
+            echo 'All checks passed!'
+          "

--- a/docs/platform/dockerhub-devcontainer-architecture.md
+++ b/docs/platform/dockerhub-devcontainer-architecture.md
@@ -1,0 +1,175 @@
+# Docker Hub Devcontainer Architecture
+
+## Overview
+
+This document describes the architecture for publishing the JP Spec Kit devcontainer to Docker Hub as `jpoley/specflow-agents`, enabling reuse across any project.
+
+## Architecture Decision Records
+
+### ADR-001: Docker Hub as Distribution Registry
+
+**Status**: Accepted
+
+**Context**: Need to distribute the devcontainer image for easy adoption by external projects.
+
+**Decision**: Use Docker Hub (`docker.io/jpoley/specflow-agents`) as the primary registry.
+
+**Consequences**:
+- Familiar pull experience for developers
+- Free tier supports public images
+- Requires Docker Hub account and access token for CI/CD
+
+### ADR-002: Multi-Platform Build Strategy
+
+**Status**: Accepted
+
+**Context**: Developers use both Intel/AMD (amd64) and Apple Silicon (arm64) machines.
+
+**Decision**: Build multi-platform images using `docker buildx` with QEMU emulation.
+
+**Consequences**:
+- Supports both amd64 and arm64 architectures
+- Longer build times due to cross-compilation
+- Manifest lists enable automatic platform selection
+
+### ADR-003: Tag Strategy
+
+**Status**: Accepted
+
+**Context**: Need versioning strategy that supports both latest and specific versions.
+
+**Decision**: Use three tag types:
+- `latest` - Always points to latest main branch build
+- `sha-<commit>` - Specific commit for reproducibility
+- `<branch>` - Branch name for development builds
+
+**Consequences**:
+- Users can pin to specific commits for reproducibility
+- Latest tag provides easy adoption
+- Branch tags enable testing pre-release builds
+
+### ADR-004: AI CLI Installation Strategy
+
+**Status**: Accepted
+
+**Context**: AI coding CLIs may fail to install due to regional restrictions or package availability.
+
+**Decision**: Use best-effort installation with `|| echo "skipped"` fallback.
+
+**Consequences**:
+- Build never fails due to optional tools
+- Users may need to manually install unavailable tools
+- Image always builds successfully
+
+### ADR-005: Security Scanning Integration
+
+**Status**: Accepted
+
+**Context**: Need to identify vulnerabilities in the published image.
+
+**Decision**: Integrate Trivy scanner in CI/CD with SARIF output to GitHub Security.
+
+**Consequences**:
+- Automated vulnerability detection
+- Results visible in GitHub Security tab
+- Non-blocking (continue-on-error) to prevent build failures
+
+## Component Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Docker Hub Registry                       │
+│                  jpoley/specflow-agents                      │
+├─────────────────────────────────────────────────────────────┤
+│  Tags: latest, sha-<commit>, main                           │
+│  Platforms: linux/amd64, linux/arm64                        │
+└─────────────────────────────────────────────────────────────┘
+                              ▲
+                              │ push
+                              │
+┌─────────────────────────────────────────────────────────────┐
+│                   GitHub Actions CI/CD                       │
+│               .github/workflows/docker-publish.yml           │
+├─────────────────────────────────────────────────────────────┤
+│  Triggers: push to main (Dockerfile changes), manual         │
+│  Jobs: build-and-push, verify                               │
+│  Security: Trivy scan → GitHub Security                      │
+└─────────────────────────────────────────────────────────────┘
+                              ▲
+                              │ build
+                              │
+┌─────────────────────────────────────────────────────────────┐
+│                     Source Files                             │
+│                  .devcontainer/Dockerfile                    │
+├─────────────────────────────────────────────────────────────┤
+│  Base: mcr.microsoft.com/devcontainers/python:3.11-bullseye │
+│  + Node.js 20 + pnpm                                        │
+│  + GitHub CLI                                                │
+│  + uv (Python package manager)                              │
+│  + AI CLIs (Claude, Codex, Gemini, Copilot)                 │
+│  + backlog.md                                                │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## User Adoption Flow
+
+```
+User Project                        Docker Hub
+    │                                   │
+    │ 1. Copy template                  │
+    │    devcontainer.json              │
+    ▼                                   │
+.devcontainer/                          │
+devcontainer.json ─────────────────────►│
+    │                     2. Pull image │
+    │◄──────────────────────────────────│
+    │   jpoley/specflow-agents:latest   │
+    │                                   │
+    ▼                                   │
+Container starts with:                  │
+- All AI CLIs pre-installed             │
+- Development tools ready               │
+- Shell configured                      │
+```
+
+## Required Secrets
+
+| Secret | Purpose | Where to Create |
+|--------|---------|-----------------|
+| `DOCKERHUB_USER` | Docker Hub login | GitHub repo → Settings → Secrets |
+| `DOCKERHUB_SECRET` | Docker Hub access token | Docker Hub → Account Settings → Security |
+
+## File Structure
+
+```
+jp-spec-kit/
+├── .devcontainer/
+│   ├── Dockerfile              # Image definition
+│   ├── devcontainer.json       # Local development config
+│   └── post-create.sh          # Local setup script
+├── .github/workflows/
+│   └── docker-publish.yml      # CI/CD pipeline
+├── templates/devcontainer/
+│   ├── devcontainer.json       # User template
+│   └── README.md               # Adoption guide
+└── docs/platform/
+    └── dockerhub-devcontainer-architecture.md  # This file
+```
+
+## Maintenance
+
+### Updating the Image
+
+1. Modify `.devcontainer/Dockerfile`
+2. Push to main branch
+3. CI/CD automatically builds and publishes
+
+### Manual Rebuild
+
+Use GitHub Actions → Docker Publish → Run workflow → force_build: true
+
+### Monitoring
+
+- Docker Hub: View pull counts and image details
+- GitHub Security: Review Trivy scan results
+- GitHub Actions: Monitor build status

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -61,8 +61,12 @@ client = httpx.Client(verify=ssl_context)
 
 
 def _github_token(cli_token: str | None = None) -> str | None:
-    """Return sanitized GitHub token (cli arg takes precedence) or None."""
-    return ((cli_token or os.getenv("GITHUB_JPSPEC") or "").strip()) or None
+    """Return sanitized GitHub token (cli arg takes precedence) or None.
+
+    Checks in order: cli_token, GITHUB_TOKEN env var, GITHUB_JPSPEC env var.
+    """
+    token = cli_token or os.getenv("GITHUB_TOKEN") or os.getenv("GITHUB_JPSPEC") or ""
+    return token.strip() or None
 
 
 def _github_headers(cli_token: str | None = None, *, skip_auth: bool = False) -> dict:

--- a/templates/devcontainer/README.md
+++ b/templates/devcontainer/README.md
@@ -1,0 +1,118 @@
+# SpecFlow Agents Devcontainer Template
+
+This template provides a pre-configured development environment with AI coding assistants.
+
+## Quick Start
+
+1. Copy the `devcontainer.json` file to your project's `.devcontainer/` directory:
+
+```bash
+mkdir -p .devcontainer
+cp devcontainer.json .devcontainer/
+```
+
+2. Open your project in VS Code and click "Reopen in Container" when prompted.
+
+## What's Included
+
+The `jpoley/specflow-agents` Docker image includes:
+
+### AI Coding Assistants
+- **Claude Code** (`claude`) - Anthropic's AI coding assistant
+- **GitHub Copilot CLI** (`github-copilot-cli`) - GitHub's AI pair programmer
+- **OpenAI Codex** (`codex`) - OpenAI's code generation model
+- **Google Gemini CLI** (`gemini`) - Google's AI coding assistant
+
+### Development Tools
+- **Python 3.11** with uv package manager
+- **Node.js 20** with pnpm
+- **GitHub CLI** (`gh`)
+- **Ruff** - Python linter and formatter
+- **pytest** - Python testing framework
+- **backlog.md** - Task management CLI
+
+## Environment Variables
+
+Set these in your shell or `.env` file before opening the container:
+
+| Variable | Purpose |
+|----------|---------|
+| `GITHUB_TOKEN` | GitHub API access |
+| `ANTHROPIC_API_KEY` | Claude Code authentication |
+| `OPENAI_API_KEY` | OpenAI Codex authentication |
+| `GOOGLE_API_KEY` | Google Gemini authentication |
+
+## Customization
+
+### Adding Project-Specific Setup
+
+Create a `postCreateCommand` to install your project's dependencies:
+
+```json
+{
+  "postCreateCommand": "uv sync && npm install"
+}
+```
+
+### Adding More VS Code Extensions
+
+Add to the `extensions` array:
+
+```json
+{
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "your.extension-id"
+      ]
+    }
+  }
+}
+```
+
+### Mounting Additional Directories
+
+Add to the `mounts` array for additional credential or config directories:
+
+```json
+{
+  "mounts": [
+    "source=${localEnv:HOME}/.aws,target=/home/vscode/.aws,type=bind,readonly"
+  ]
+}
+```
+
+## YOLO Mode Aliases
+
+The image includes commented-out aliases for bypassing AI agent safety features. These are disabled by default. To enable them, add to your `.zshrc` inside the container:
+
+```bash
+alias claude-yolo='claude --dangerously-skip-permissions'
+alias codex-yolo='codex --dangerously-bypass-approvals-and-sandbox'
+alias gemini-yolo='gemini --yolo'
+alias copilot-yolo='copilot --allow-all-tools'
+```
+
+⚠️ **Warning**: Using these aliases bypasses security features designed to protect your environment. Use only in isolated, trusted environments.
+
+## Troubleshooting
+
+### Tools not in PATH
+Open a new terminal - PATH is configured in `.zshenv` which runs for all shells.
+
+### Permission issues with mounted directories
+Ensure the source directories exist on your host machine before starting the container.
+
+### AI CLI not working
+Check that the corresponding API key environment variable is set.
+
+## Image Tags
+
+- `latest` - Latest stable build from main branch
+- `sha-<commit>` - Specific commit build
+- `main` - Latest build from main branch (same as latest)
+
+## Support
+
+Report issues at: https://github.com/jpoley/jp-spec-kit/issues

--- a/templates/devcontainer/devcontainer.json
+++ b/templates/devcontainer/devcontainer.json
@@ -1,0 +1,63 @@
+{
+  "name": "SpecFlow Agents Dev Environment",
+  "image": "jpoley/specflow-agents:latest",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "charliermarsh.ruff",
+        "tamasfe.even-better-toml",
+        "redhat.vscode-yaml",
+        "yzhang.markdown-all-in-one",
+        "eamodio.gitlens",
+        "usernamehw.errorlens"
+      ],
+      "settings": {
+        "python.testing.pytestEnabled": true,
+        "python.testing.unittestEnabled": false,
+        "python.linting.enabled": false,
+        "python.formatting.provider": "none",
+        "[python]": {
+          "editor.formatOnSave": true,
+          "editor.defaultFormatter": "charliermarsh.ruff",
+          "editor.codeActionsOnSave": {
+            "source.organizeImports": "explicit",
+            "source.fixAll": "explicit"
+          }
+        },
+        "ruff.enable": true,
+        "ruff.organizeImports": true,
+        "ruff.fixAll": true,
+        "editor.rulers": [88],
+        "files.trimTrailingWhitespace": true,
+        "files.insertFinalNewline": true,
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "git.autofetch": true
+      }
+    }
+  },
+
+  "mounts": [
+    "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig-host,type=bind,readonly,platform=linux",
+    "source=${localEnv:USERPROFILE}/.gitconfig,target=/home/vscode/.gitconfig-host,type=bind,readonly,platform=win32",
+    "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,readonly,platform=linux",
+    "source=${localEnv:USERPROFILE}/.ssh,target=/home/vscode/.ssh,type=bind,readonly,platform=win32",
+    "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached,platform=linux",
+    "source=${localEnv:USERPROFILE}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached,platform=win32"
+  ],
+
+  "remoteEnv": {
+    "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}",
+    "OPENAI_API_KEY": "${localEnv:OPENAI_API_KEY}",
+    "GOOGLE_API_KEY": "${localEnv:GOOGLE_API_KEY}",
+    "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}",
+    "PYTHONUNBUFFERED": "1"
+  },
+
+  "postStartCommand": "cp /home/vscode/.gitconfig-host /home/vscode/.gitconfig 2>/dev/null || true; git config --global --add safe.directory ${containerWorkspaceFolder}",
+  "postAttachCommand": "echo '--- SpecFlow Agents Dev Environment Ready ---'",
+
+  "remoteUser": "vscode"
+}

--- a/tests/test_github_auth.py
+++ b/tests/test_github_auth.py
@@ -45,10 +45,24 @@ class TestGitHubToken:
         with patch.dict("os.environ", {"GITHUB_JPSPEC": "env_token"}):
             assert _github_token("cli_token") == "cli_token"
 
-    def test_uses_env_var_when_no_cli_token(self):
+    def test_uses_github_jpspec_env_var_when_no_cli_token(self):
         """Should use GITHUB_JPSPEC env var when no CLI token."""
         with patch.dict("os.environ", {"GITHUB_JPSPEC": "env_token"}, clear=True):
             assert _github_token(None) == "env_token"
+
+    def test_uses_github_token_env_var_when_no_cli_token(self):
+        """Should use GITHUB_TOKEN env var when no CLI token."""
+        with patch.dict("os.environ", {"GITHUB_TOKEN": "gh_token"}, clear=True):
+            assert _github_token(None) == "gh_token"
+
+    def test_github_token_takes_precedence_over_github_jpspec(self):
+        """GITHUB_TOKEN should take precedence over GITHUB_JPSPEC."""
+        with patch.dict(
+            "os.environ",
+            {"GITHUB_TOKEN": "gh_token", "GITHUB_JPSPEC": "jpspec_token"},
+            clear=True,
+        ):
+            assert _github_token(None) == "gh_token"
 
     def test_env_var_stripped(self):
         """Should strip whitespace from env var."""
@@ -71,6 +85,7 @@ class TestGitHubHeaders:
 
     def test_headers_without_token(self, monkeypatch):
         """Should return headers without Authorization when no token."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
         monkeypatch.delenv("GITHUB_JPSPEC", raising=False)
         headers = _github_headers(None)
         assert "Authorization" not in headers
@@ -86,12 +101,14 @@ class TestGitHubHeaders:
 
     def test_headers_with_empty_token(self, monkeypatch):
         """Should not include Authorization header for empty token."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
         monkeypatch.delenv("GITHUB_JPSPEC", raising=False)
         headers = _github_headers("")
         assert "Authorization" not in headers
 
     def test_headers_with_none_token(self, monkeypatch):
         """Should not include Authorization header for None token."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
         monkeypatch.delenv("GITHUB_JPSPEC", raising=False)
         headers = _github_headers(None)
         assert "Authorization" not in headers


### PR DESCRIPTION
## Summary

- Add Dockerfile with correct uv path (`~/.local/bin`, not `~/.cargo/bin`)
- Add docker-publish.yml workflow with multi-platform builds (amd64/arm64)
- Add templates/devcontainer for easy user adoption from Docker Hub
- Add platform architecture documentation with 5 ADRs
- Fix CI to pass `GITHUB_TOKEN` to tests (prevents rate limiting)
- Fix CLI to check `GITHUB_TOKEN` env var (not just `GITHUB_JPSPEC`)
- Fix tests to clear both `GITHUB_TOKEN` and `GITHUB_JPSPEC` env vars

## Docker Hub Publishing

Image will be published to: `jpoley/specflow-agents`

Tags:
- `latest` - Latest stable build from main branch
- `sha-<commit>` - Specific commit for reproducibility
- `main` - Branch tag (same as latest)

## Required Secrets (already configured ✓)

- `DOCKERHUB_USER` - Docker Hub username
- `DOCKERHUB_SECRET` - Docker Hub access token

## User Adoption

Users can adopt the image by copying `templates/devcontainer/devcontainer.json` to their project's `.devcontainer/` directory.

## Test plan

- [x] Tests pass locally (2772 passed)
- [x] Linting passes
- [ ] CI passes
- [x] Docker Hub secrets configured
- [ ] Manual test of Docker workflow trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)