### PR TITLE
fix(docker): restore OpenAI Codex CLI support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,7 @@
 # This Dockerfile builds a pre-configured development environment with:
 # - Python 3.11 + uv package manager
 # - Node.js 20 + pnpm
-# - AI coding assistant CLIs (Claude Code, Gemini, GitHub Copilot)
+# - AI coding assistant CLIs (Claude Code, Codex, Gemini, GitHub Copilot)
 # - Task management (backlog.md)
 # - Common development tools
 #
@@ -47,6 +47,7 @@ RUN pnpm config set global-bin-dir "$PNPM_HOME"
 # Install AI coding assistant CLIs
 # Note: These are best-effort installs; some may not be available in all regions
 RUN pnpm install -g @anthropic-ai/claude-code || echo "claude-code install skipped" \
+    && pnpm install -g @openai/codex || echo "codex install skipped" \
     && pnpm install -g @githubnext/github-copilot-cli || echo "copilot-cli install skipped" \
     && pnpm install -g @google/gemini-cli || echo "gemini-cli install skipped"
 
@@ -67,11 +68,12 @@ RUN mkdir -p /home/vscode/.config/claude \
 RUN echo '' >> /home/vscode/.zshrc \
     && echo '# AI coding agent YOLO aliases (uncomment at your own risk)' >> /home/vscode/.zshrc \
     && echo '# alias claude-yolo="claude --dangerously-skip-permissions"' >> /home/vscode/.zshrc \
+    && echo '# alias codex-yolo="codex --full-auto"' >> /home/vscode/.zshrc \
     && echo '# alias gemini-yolo="gemini --yolo"' >> /home/vscode/.zshrc
 
 # Labels for Docker Hub
 LABEL org.opencontainers.image.title="SpecFlow Agents"
-LABEL org.opencontainers.image.description="Development container with AI coding assistants (Claude Code, Gemini, GitHub Copilot) and task management tools"
+LABEL org.opencontainers.image.description="Development container with AI coding assistants (Claude Code, Codex, Gemini, GitHub Copilot) and task management tools"
 LABEL org.opencontainers.image.source="https://github.com/jpoley/jp-spec-kit"
 LABEL org.opencontainers.image.vendor="jpoley"
 LABEL org.opencontainers.image.licenses="MIT"

--- a/docs/platform/dockerhub-devcontainer-architecture.md
+++ b/docs/platform/dockerhub-devcontainer-architecture.md
@@ -106,7 +106,7 @@ This document describes the architecture for publishing the JP Spec Kit devconta
 │  + Node.js 20 + pnpm                                        │
 │  + GitHub CLI                                                │
 │  + uv (Python package manager)                              │
-│  + AI CLIs (Claude Code, Gemini, GitHub Copilot)            │
+│  + AI CLIs (Claude Code, Codex, Gemini, GitHub Copilot)     │
 │  + backlog.md                                                │
 └─────────────────────────────────────────────────────────────┘
 ```

--- a/templates/devcontainer/README.md
+++ b/templates/devcontainer/README.md
@@ -19,6 +19,7 @@ The `jpoley/specflow-agents` Docker image includes:
 
 ### AI Coding Assistants
 - **Claude Code** (`claude`) - Anthropic's AI coding assistant
+- **Codex** (`codex`) - OpenAI's coding agent
 - **GitHub Copilot CLI** (`github-copilot-cli`) - GitHub's AI pair programmer
 - **Google Gemini CLI** (`gemini`) - Google's AI coding assistant
 
@@ -39,6 +40,8 @@ Set these in your shell or `.env` file before opening the container:
 | `GITHUB_TOKEN` | GitHub API access |
 | `ANTHROPIC_API_KEY` | Claude Code authentication |
 | `GOOGLE_API_KEY` | Google Gemini authentication |
+
+> **Note**: Codex authenticates via ChatGPT subscription (Plus, Pro, Business, Edu, or Enterprise). Run `codex` and sign in with your ChatGPT account.
 
 ## Customization
 
@@ -87,6 +90,7 @@ The image includes commented-out aliases for bypassing AI agent safety features.
 
 ```bash
 alias claude-yolo='claude --dangerously-skip-permissions'
+alias codex-yolo='codex --full-auto'
 alias gemini-yolo='gemini --yolo'
 ```
 


### PR DESCRIPTION
## Summary
Restores OpenAI Codex CLI support that was incorrectly removed in PR #665.

**What happened**: Copilot reviewer confused the deprecated Codex *model* (March 2023) with the active Codex *CLI* (`@openai/codex`), which is OpenAI's coding agent released in 2025.

## Changes
- Add `@openai/codex` to Dockerfile AI CLI installs
- Add `codex-yolo` alias (`codex --full-auto`)
- Update README with Codex documentation
- Note: Codex uses ChatGPT subscription auth (Plus/Pro/Business/Edu/Enterprise), not API key

## Test plan
- [ ] Verify Dockerfile builds successfully
- [ ] Verify `codex` command is available in container

🤖 Generated with [Claude Code](https://claude.com/claude-code)