### PR TITLE
fix(ci): switch to tag-based releases with release.py script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,124 +2,103 @@ name: Create Release
 
 on:
   push:
-    branches: [ main ]
+    tags:
+      - 'v*'
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., v1.0.0). Only use if tag was not pushed.'
+        required: false
+        type: string
 
 jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Get version from pyproject.toml
-        id: get_tag
-        run: |
-          chmod +x .github/workflows/scripts/get-next-version.sh
-          .github/workflows/scripts/get-next-version.sh
-      - name: Check if release already exists
-        id: check_release
-        run: |
-          chmod +x .github/workflows/scripts/check-release-exists.sh
-          .github/workflows/scripts/check-release-exists.sh ${{ steps.get_tag.outputs.new_version }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Update version in source files
-        if: steps.check_release.outputs.exists == 'false'
-        env:
-          NEW_VERSION: ${{ steps.get_tag.outputs.new_version }}
-        run: |
-          chmod +x .github/workflows/scripts/update-version.sh
-          .github/workflows/scripts/update-version.sh "$NEW_VERSION"
-      - name: Commit and push version bump
-        if: steps.check_release.outputs.exists == 'false'
-        id: commit_version
-        env:
-          NEW_VERSION: ${{ steps.get_tag.outputs.new_version }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml src/specify_cli/__init__.py
 
-          # Check if there are changes to commit (only version files)
-          if git diff --cached --quiet pyproject.toml src/specify_cli/__init__.py; then
-            echo "No version changes needed"
-            echo "version_committed=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
-
-          # Try direct push first
-          if git push origin main; then
-            echo "✅ Version files updated directly on main"
-            echo "version_committed=true" >> $GITHUB_OUTPUT
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            VERSION="${GITHUB_REF#refs/tags/}"
           else
-            echo "⚠️ Direct push failed (branch protection). Creating PR instead..."
-
-            # Create a branch and PR for the version bump
-            VERSION_NUM="${NEW_VERSION#v}"
-            BRANCH_NAME="chore/version-bump-${VERSION_NUM}"
-            git checkout -b "$BRANCH_NAME"
-            git push origin "$BRANCH_NAME"
-
-            # Try to create PR - may fail if Actions can't create PRs
-            if gh pr create \
-              --title "chore: bump version to $NEW_VERSION" \
-              --body "Automated version bump to $NEW_VERSION for upcoming release. This PR was created because main branch is protected and requires PRs." \
-              --base main \
-              --head "$BRANCH_NAME"; then
-              echo "✅ Created PR for version bump - release will complete after PR merge"
-              echo "version_committed=false" >> $GITHUB_OUTPUT
-            else
-              echo "❌ Could not create PR. Cleaning up branch..."
-              git push origin --delete "$BRANCH_NAME" || true
-              echo "version_committed=false" >> $GITHUB_OUTPUT
-              exit 1  # Fail workflow - don't create tag without version sync
-            fi
+            echo "::error::No version specified. Push a tag or provide version input."
+            exit 1
           fi
-      - name: Create git tag on version commit
-        if: steps.check_release.outputs.exists == 'false' && steps.commit_version.outputs.version_committed == 'true'
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version_num=${VERSION#v}" >> $GITHUB_OUTPUT
+          echo "📦 Releasing version: $VERSION"
+
+      - name: Verify version matches source files
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          TAG_VERSION="${{ steps.version.outputs.version_num }}"
+          TOML_VERSION=$(grep -Po '(?<=^version = ")[^"]*' pyproject.toml || echo "")
+          INIT_VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' src/specify_cli/__init__.py || echo "")
 
-          # Fetch latest state from remote (version commit was just pushed)
-          git fetch origin main
-          git fetch --tags
-          git checkout main
-          git reset --hard origin/main
+          echo "Tag version: $TAG_VERSION"
+          echo "pyproject.toml: $TOML_VERSION"
+          echo "__init__.py: $INIT_VERSION"
 
-          # Tag the current commit (which has the version update)
-          if ! git rev-parse ${{ steps.get_tag.outputs.new_version }} >/dev/null 2>&1; then
-            git tag ${{ steps.get_tag.outputs.new_version }}
-            git push origin ${{ steps.get_tag.outputs.new_version }}
-            echo "Created tag ${{ steps.get_tag.outputs.new_version }}"
-          else
-            echo "Tag ${{ steps.get_tag.outputs.new_version }} already exists"
+          if [ "$TAG_VERSION" != "$TOML_VERSION" ]; then
+            echo "::error::Version mismatch! Tag: $TAG_VERSION, pyproject.toml: $TOML_VERSION"
+            echo "Run: ./scripts/release.py $TAG_VERSION"
+            exit 1
           fi
-      - name: Create release package variants
-        if: steps.check_release.outputs.exists == 'false' && steps.commit_version.outputs.version_committed == 'true'
+
+          if [ -n "$INIT_VERSION" ] && [ "$TAG_VERSION" != "$INIT_VERSION" ]; then
+            echo "::error::Version mismatch! Tag: $TAG_VERSION, __init__.py: $INIT_VERSION"
+            exit 1
+          fi
+
+          echo "✅ Version files are in sync with tag"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Build package
+        run: uv build
+
+      - name: Create release packages
         run: |
           chmod +x .github/workflows/scripts/create-release-packages.sh
-          .github/workflows/scripts/create-release-packages.sh ${{ steps.get_tag.outputs.new_version }}
+          .github/workflows/scripts/create-release-packages.sh ${{ steps.version.outputs.version }}
+
+      - name: Get previous tag
+        id: prev_tag
+        run: |
+          PREV_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]' | sed -n '2p' || echo "")
+          echo "tag=$PREV_TAG" >> $GITHUB_OUTPUT
+          echo "Previous tag: $PREV_TAG"
+
       - name: Generate release notes
-        if: steps.check_release.outputs.exists == 'false' && steps.commit_version.outputs.version_committed == 'true'
         id: release_notes
         run: |
           chmod +x .github/workflows/scripts/generate-release-notes.sh
-          .github/workflows/scripts/generate-release-notes.sh ${{ steps.get_tag.outputs.new_version }} ${{ steps.get_tag.outputs.latest_tag }}
+          .github/workflows/scripts/generate-release-notes.sh ${{ steps.version.outputs.version }} "${{ steps.prev_tag.outputs.tag }}"
+
       - name: Create GitHub Release
-        if: steps.check_release.outputs.exists == 'false' && steps.commit_version.outputs.version_committed == 'true'
         run: |
           chmod +x .github/workflows/scripts/create-github-release.sh
-          .github/workflows/scripts/create-github-release.sh ${{ steps.get_tag.outputs.new_version }}
+          .github/workflows/scripts/create-github-release.sh ${{ steps.version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ steps.version.outputs.version }}
+          path: dist/

--- a/docs/guides/release-workflow-fix.md
+++ b/docs/guides/release-workflow-fix.md
@@ -1,0 +1,450 @@
+# Release Workflow Fix Guide
+
+## Problem Summary
+
+The current release workflow is broken due to multiple interconnected issues:
+
+1. **Create Release workflow fails** - GitHub Actions cannot create PRs
+2. **Deploy Documentation fails** - GitHub Pages not enabled
+3. **Excessive releases** - Every push to main creates a release (343+ versions)
+4. **Two-commit problem** - CI tries to bump version (commit 1) then tag (commit 2)
+
+### Root Cause Analysis
+
+```
+Push to main
+    ↓
+Release workflow triggers
+    ↓
+Tries to bump version in pyproject.toml
+    ↓
+Cannot push directly to main (branch protection)
+    ↓
+Falls back to creating PR
+    ↓
+FAILS: "GitHub Actions is not permitted to create or approve pull requests"
+```
+
+## Recommended Solution: Dynamic Version from Git Tags
+
+**The cleanest approach**: Remove hardcoded version entirely. Version is derived from git tags at build time using `hatch-vcs`.
+
+**Benefits:**
+- **Zero version files to sync** - no pyproject.toml version, no __init__.py version
+- **Tag IS the version** - single source of truth
+- **No CI commits needed** - workflow just builds and publishes
+- **Industry standard** - used by pip, setuptools, hatch, and many major projects
+
+---
+
+## Option A: Dynamic Version with hatch-vcs (Recommended)
+
+### Step 1: Update pyproject.toml
+
+```toml
+[project]
+name = "specify-cli"
+dynamic = ["version"]  # Version comes from git tags
+description = "..."
+
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/specify_cli/_version.py"
+```
+
+### Step 2: Update __init__.py
+
+```python
+# src/specify_cli/__init__.py
+try:
+    from ._version import __version__
+except ImportError:
+    __version__ = "0.0.0.dev0"  # Fallback for editable installs without build
+```
+
+### Step 3: Add _version.py to .gitignore
+
+```
+# Generated version file
+src/specify_cli/_version.py
+```
+
+### Step 4: Update release.yml (Tag-Based)
+
+```yaml
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., v1.0.0)'
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for hatch-vcs to work
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Releasing version: $VERSION"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Create release packages
+        run: |
+          chmod +x .github/workflows/scripts/create-release-packages.sh
+          .github/workflows/scripts/create-release-packages.sh ${{ steps.version.outputs.version }}
+
+      - name: Generate release notes
+        run: |
+          chmod +x .github/workflows/scripts/generate-release-notes.sh
+          PREV_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]' | sed -n '2p' || echo "")
+          .github/workflows/scripts/generate-release-notes.sh ${{ steps.version.outputs.version }} "$PREV_TAG"
+
+      - name: Create GitHub Release
+        run: |
+          chmod +x .github/workflows/scripts/create-github-release.sh
+          .github/workflows/scripts/create-github-release.sh ${{ steps.version.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Release Process with hatch-vcs
+
+```bash
+# That's it! Just tag and push.
+git tag v1.0.0
+git push origin main --tags
+
+# The build system automatically:
+# - Detects the tag
+# - Generates _version.py with "1.0.0"
+# - Builds the package with correct version
+```
+
+---
+
+## Option B: Simple Tag-Based (Manual Version Sync)
+
+If you prefer to keep explicit version in pyproject.toml:
+
+### Single-Commit Release Flow
+
+```bash
+# 1. Update version (one commit, everything in sync)
+sed -i 's/version = ".*"/version = "1.0.0"/' pyproject.toml
+sed -i 's/__version__ = ".*"/__version__ = "1.0.0"/' src/specify_cli/__init__.py
+
+# 2. Commit with the version change
+git add pyproject.toml src/specify_cli/__init__.py
+git commit -m "chore: release v1.0.0"
+
+# 3. Tag THAT commit (tag points to commit with correct version)
+git tag v1.0.0
+
+# 4. Push both together
+git push origin main --tags
+```
+
+**Key insight**: The tag points to the commit that contains the version. No second commit needed.
+
+### Release Script (scripts/release.py)
+
+A comprehensive Python script is provided at `scripts/release.py`:
+
+```bash
+# Auto-increment patch version (0.2.343 → 0.2.344)
+./scripts/release.py
+
+# Specific version
+./scripts/release.py 1.0.0
+
+# Bump minor (0.2.343 → 0.3.0)
+./scripts/release.py --minor
+
+# Bump major (0.2.343 → 1.0.0)
+./scripts/release.py --major
+
+# Preview without making changes
+./scripts/release.py --dry-run
+
+# Skip confirmation prompts
+./scripts/release.py --push
+```
+
+The script automatically:
+1. Validates you're on main branch
+2. Checks for uncommitted changes
+3. Updates pyproject.toml and __init__.py
+4. Creates a single commit with the version
+5. Tags that commit
+6. Pushes everything to origin
+
+**Example output:**
+```
+🚀 JP Spec Kit Release Script
+==================================================
+
+📋 Current state:
+  Version in pyproject.toml: 0.2.343
+  Latest git tag: v0.2.343
+
+📦 New version: 0.2.344
+   Tag name: v0.2.344
+
+🔍 Safety checks:
+  ✓ On main branch
+  ✓ Tag v0.2.344 does not exist
+  ✓ Working directory is clean
+
+⚠️  This will release v0.2.344
+   Continue? [y/N]: y
+
+📝 Updating version files:
+  pyproject.toml: updated to 0.2.344
+  src/specify_cli/__init__.py: updated to 0.2.344
+
+📦 Creating commit and tag:
+  $ git add pyproject.toml src/specify_cli/__init__.py
+  $ git commit -m "chore: release v0.2.344"
+  $ git tag v0.2.344
+
+🚀 Pushing to origin:
+  $ git push origin main --tags
+
+✅ Successfully released v0.2.344!
+   GitHub Actions will create the release automatically.
+```
+
+### Workflow for Option B
+
+```yaml
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Verify version sync
+        run: |
+          TAG_VER="${{ steps.version.outputs.version }}"
+          TAG_VER="${TAG_VER#v}"
+          TOML_VER=$(grep -Po '(?<=^version = ")[^"]*' pyproject.toml)
+          if [ "$TAG_VER" != "$TOML_VER" ]; then
+            echo "::error::Tag ($TAG_VER) doesn't match pyproject.toml ($TOML_VER)"
+            exit 1
+          fi
+
+      # ... rest of release steps
+```
+
+---
+
+## GitHub Repository Settings Required
+
+### 1. Enable GitHub Pages
+
+**Path**: Repository → Settings → Pages
+
+1. Go to https://github.com/jpoley/jp-spec-kit/settings/pages
+2. Under "Build and deployment":
+   - Source: **GitHub Actions**
+3. Save
+
+### 2. (Optional) Allow Actions to Create PRs
+
+Only needed if you want to keep the current workflow pattern.
+
+**Path**: Repository → Settings → Actions → General
+
+1. Go to https://github.com/jpoley/jp-spec-kit/settings/actions
+2. Scroll to "Workflow permissions"
+3. Check: **Allow GitHub Actions to create and approve pull requests**
+4. Save
+
+### 3. (Optional) Bypass Branch Protection for Releases
+
+Only needed if you want the workflow to push directly to main.
+
+**Path**: Repository → Settings → Branches → main → Edit
+
+1. Go to https://github.com/jpoley/jp-spec-kit/settings/branches
+2. Click "Edit" on the main branch rule
+3. Under "Bypass list", add the GitHub Actions bot
+4. Save
+
+---
+
+## Comparison: Option A vs Option B
+
+| Aspect | Option A (hatch-vcs) | Option B (Manual) |
+|--------|---------------------|-------------------|
+| Version source | Git tag only | pyproject.toml + tag |
+| Files to update | None | 2 files per release |
+| Sync issues possible | No | Yes (if tag != toml) |
+| Local dev version | `0.0.0.dev0+g<hash>` | Static version |
+| Release command | `git tag v1.0.0 && git push --tags` | `./scripts/release.sh` |
+| Complexity | Lower | Higher |
+| Industry adoption | pip, setuptools, hatch | Many projects |
+
+**Recommendation**: Option A (hatch-vcs) is cleaner but requires a one-time migration. Option B works if you prefer explicit version control.
+
+---
+
+## Migration Checklist
+
+### For Option A (hatch-vcs)
+
+- [ ] Enable GitHub Pages in repository settings (see above)
+- [ ] Add `hatch-vcs` to build dependencies in pyproject.toml
+- [ ] Change `version = "X.Y.Z"` to `dynamic = ["version"]`
+- [ ] Add `[tool.hatch.version]` and `[tool.hatch.build.hooks.vcs]` sections
+- [ ] Update `__init__.py` to import from `_version.py`
+- [ ] Add `src/specify_cli/_version.py` to `.gitignore`
+- [ ] Update `.github/workflows/release.yml` to tag-based trigger
+- [ ] Remove old version bump scripts
+- [ ] Test: `uv build` should show version from latest tag
+- [ ] Test release: `git tag v0.3.0 && git push --tags`
+
+### For Option B (Manual Sync)
+
+- [ ] Enable GitHub Pages in repository settings (see above)
+- [ ] Update `.github/workflows/release.yml` to tag-based trigger
+- [ ] Create `scripts/release.sh` helper script
+- [ ] Remove CI version bump logic
+- [ ] Update CONTRIBUTING.md with new release process
+- [ ] Test: `./scripts/release.sh 0.2.345`
+
+---
+
+## FAQ
+
+**Q: What about the 343+ existing releases?**
+A: They can stay. Future releases will be intentional and meaningful.
+
+**Q: How does hatch-vcs handle dev versions?**
+A: Between tags, version is `0.2.343.dev5+g1234abc` (5 commits after v0.2.343, hash 1234abc). On a tag, it's clean `0.2.343`.
+
+**Q: What if I forget to tag before releasing?**
+A: Use `workflow_dispatch` to manually trigger with a version, or just create the tag.
+
+**Q: Can I release from GitHub UI?**
+A: Yes, use `workflow_dispatch` - go to Actions → Create Release → Run workflow.
+
+**Q: What happens if I create a tag without a PR?**
+A: Works fine! Tags don't require PRs. You can tag any commit on main.
+
+**Q: How do I do a hotfix release?**
+A: Same process - make your fix, merge to main, then `git tag v0.2.344 && git push --tags`.
+
+---
+
+## Quick Start: Implementing the Fix
+
+### Step 1: Enable GitHub Pages (Manual - Repository Settings)
+
+1. Go to https://github.com/jpoley/jp-spec-kit/settings/pages
+2. Set Source to **GitHub Actions**
+3. Save
+
+### Step 2: Replace the Release Workflow
+
+```bash
+# Replace the old workflow with the new tag-based one
+mv .github/workflows/release.yml .github/workflows/release.yml.old
+mv .github/workflows/release.yml.new .github/workflows/release.yml
+
+# Commit the changes
+git add .github/workflows/
+git commit -m "fix(ci): switch to tag-based releases
+
+- Trigger releases only on tag push (v*)
+- Remove CI version bumping (avoids branch protection issues)
+- Add version sync verification
+- Support manual workflow_dispatch for emergency releases
+
+Resolves release workflow failures caused by:
+- Branch protection blocking direct pushes
+- GitHub Actions unable to create PRs"
+
+git push origin main
+```
+
+### Step 3: Test a Release
+
+```bash
+# Do a dry run first
+./scripts/release.py --dry-run
+
+# When ready, create a real release
+./scripts/release.py
+```
+
+### Files Changed
+
+| File | Action |
+|------|--------|
+| `.github/workflows/release.yml` | Replace with tag-based workflow |
+| `scripts/release.py` | New release helper script |
+| `docs/guides/release-workflow-fix.md` | This documentation |
+
+### Cleanup (Optional)
+
+After verifying the new workflow works:
+
+```bash
+# Remove old workflow scripts that are no longer needed
+rm .github/workflows/scripts/get-next-version.sh
+rm .github/workflows/scripts/update-version.sh
+rm .github/workflows/scripts/check-release-exists.sh
+rm .github/workflows/release.yml.old
+```

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""
+release.py - One-command release script for jp-spec-kit
+
+Usage:
+    ./scripts/release.py                    # Auto-increment patch (0.2.343 → 0.2.344)
+    ./scripts/release.py 0.3.0              # Specific version
+    ./scripts/release.py --minor            # Bump minor (0.2.343 → 0.3.0)
+    ./scripts/release.py --major            # Bump major (0.2.343 → 1.0.0)
+    ./scripts/release.py --dry-run          # Show what would happen
+    ./scripts/release.py --push             # Auto-push without confirmation
+
+This script:
+1. Determines the new version (auto-increment or specified)
+2. Updates pyproject.toml and src/specify_cli/__init__.py
+3. Commits the version bump
+4. Creates a git tag
+5. Pushes to origin (with confirmation)
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run(
+    cmd: list[str], check: bool = True, capture: bool = False
+) -> subprocess.CompletedProcess:
+    """Run a command and optionally capture output."""
+    print(f"  $ {' '.join(cmd)}")
+    return subprocess.run(
+        cmd,
+        check=check,
+        capture_output=capture,
+        text=True,
+    )
+
+
+def get_current_version() -> str:
+    """Read current version from pyproject.toml."""
+    pyproject = Path("pyproject.toml")
+    if not pyproject.exists():
+        print("Error: pyproject.toml not found. Run from project root.")
+        sys.exit(1)
+
+    content = pyproject.read_text()
+    match = re.search(r'^version\s*=\s*"([^"]+)"', content, re.MULTILINE)
+    if not match:
+        print("Error: Could not find version in pyproject.toml")
+        sys.exit(1)
+
+    return match.group(1)
+
+
+def get_latest_tag() -> str | None:
+    """Get the latest git tag."""
+    result = run(
+        ["git", "tag", "-l", "v*", "--sort=-v:refname"],
+        capture=True,
+        check=False,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    return result.stdout.strip().split("\n")[0]
+
+
+def parse_version(version: str) -> tuple[int, int, int]:
+    """Parse a version string into (major, minor, patch)."""
+    version = version.lstrip("v")
+    parts = version.split(".")
+    if len(parts) != 3:
+        print(f"Error: Invalid version format: {version}")
+        sys.exit(1)
+    try:
+        return int(parts[0]), int(parts[1]), int(parts[2])
+    except ValueError:
+        print(f"Error: Invalid version numbers: {version}")
+        sys.exit(1)
+
+
+def bump_version(current: str, bump_type: str) -> str:
+    """Bump version based on type: patch, minor, or major."""
+    major, minor, patch = parse_version(current)
+
+    if bump_type == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    elif bump_type == "minor":
+        return f"{major}.{minor + 1}.0"
+    elif bump_type == "major":
+        return f"{major + 1}.0.0"
+    else:
+        print(f"Error: Unknown bump type: {bump_type}")
+        sys.exit(1)
+
+
+def update_version_files(new_version: str, dry_run: bool = False) -> None:
+    """Update version in pyproject.toml and __init__.py."""
+    files = [
+        ("pyproject.toml", r'^version\s*=\s*"[^"]+"', f'version = "{new_version}"'),
+        (
+            "src/specify_cli/__init__.py",
+            r'__version__\s*=\s*"[^"]+"',
+            f'__version__ = "{new_version}"',
+        ),
+    ]
+
+    for filepath, pattern, replacement in files:
+        path = Path(filepath)
+        if not path.exists():
+            print(f"  Warning: {filepath} not found, skipping")
+            continue
+
+        content = path.read_text()
+        new_content = re.sub(pattern, replacement, content, flags=re.MULTILINE)
+
+        if content == new_content:
+            print(f"  {filepath}: no change needed")
+        elif dry_run:
+            print(f"  {filepath}: would update to {new_version}")
+        else:
+            path.write_text(new_content)
+            print(f"  {filepath}: updated to {new_version}")
+
+
+def check_git_status() -> bool:
+    """Check if working directory is clean (except version files)."""
+    result = run(["git", "status", "--porcelain"], capture=True)
+    if result.returncode != 0:
+        return False
+
+    # Allow only version file changes
+    allowed_files = {"pyproject.toml", "src/specify_cli/__init__.py"}
+    for line in result.stdout.strip().split("\n"):
+        if not line:
+            continue
+        # Parse git status output (e.g., " M pyproject.toml")
+        filepath = line[3:].strip()
+        if filepath not in allowed_files:
+            print(f"  Warning: Uncommitted changes in {filepath}")
+            return False
+    return True
+
+
+def check_on_main_branch() -> bool:
+    """Verify we're on main branch."""
+    result = run(["git", "branch", "--show-current"], capture=True)
+    branch = result.stdout.strip()
+    if branch != "main":
+        print(f"  Warning: Not on main branch (currently on: {branch})")
+        return False
+    return True
+
+
+def tag_exists(tag: str) -> bool:
+    """Check if a tag already exists."""
+    result = run(["git", "tag", "-l", tag], capture=True, check=False)
+    return bool(result.stdout.strip())
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Create a new release with version bump, commit, and tag",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s                    Auto-increment patch version
+  %(prog)s 1.0.0              Set specific version
+  %(prog)s --minor            Bump minor version
+  %(prog)s --major            Bump major version
+  %(prog)s --dry-run          Preview changes without making them
+  %(prog)s --push             Skip confirmation and push immediately
+        """,
+    )
+    parser.add_argument(
+        "version", nargs="?", help="Specific version to release (e.g., 1.0.0)"
+    )
+    parser.add_argument(
+        "--major", action="store_true", help="Bump major version (X.0.0)"
+    )
+    parser.add_argument(
+        "--minor", action="store_true", help="Bump minor version (0.X.0)"
+    )
+    parser.add_argument(
+        "--patch", action="store_true", help="Bump patch version (0.0.X) [default]"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Show what would be done"
+    )
+    parser.add_argument("--push", action="store_true", help="Push without confirmation")
+    parser.add_argument("--force", action="store_true", help="Skip safety checks")
+
+    args = parser.parse_args()
+
+    # Determine bump type
+    if sum([args.major, args.minor, args.patch]) > 1:
+        print("Error: Can only specify one of --major, --minor, --patch")
+        sys.exit(1)
+
+    print("\n🚀 JP Spec Kit Release Script\n")
+    print("=" * 50)
+
+    # Get current version
+    print("\n📋 Current state:")
+    current_version = get_current_version()
+    print(f"  Version in pyproject.toml: {current_version}")
+
+    latest_tag = get_latest_tag()
+    if latest_tag:
+        print(f"  Latest git tag: {latest_tag}")
+
+    # Determine new version
+    if args.version:
+        new_version = args.version.lstrip("v")
+    elif args.major:
+        new_version = bump_version(current_version, "major")
+    elif args.minor:
+        new_version = bump_version(current_version, "minor")
+    else:
+        new_version = bump_version(current_version, "patch")
+
+    tag_name = f"v{new_version}"
+    print(f"\n📦 New version: {new_version}")
+    print(f"   Tag name: {tag_name}")
+
+    # Safety checks
+    print("\n🔍 Safety checks:")
+    if not args.force:
+        if not check_on_main_branch():
+            print("\n❌ Not on main branch. Use --force to override.")
+            sys.exit(1)
+
+        if tag_exists(tag_name):
+            print(f"\n❌ Tag {tag_name} already exists!")
+            sys.exit(1)
+        print(f"  ✓ Tag {tag_name} does not exist")
+
+        if not check_git_status():
+            print(
+                "\n❌ Working directory has uncommitted changes. Commit or stash first."
+            )
+            sys.exit(1)
+        print("  ✓ Working directory is clean")
+    else:
+        print("  ⚠️  Safety checks skipped (--force)")
+
+    # Dry run stops here
+    if args.dry_run:
+        print("\n🔍 Dry run - would perform these actions:")
+        print(f'  1. Update pyproject.toml: version = "{new_version}"')
+        print(f'  2. Update __init__.py: __version__ = "{new_version}"')
+        print(f'  3. Commit: "chore: release v{new_version}"')
+        print(f"  4. Create tag: {tag_name}")
+        print("  5. Push: git push origin main --tags")
+        print("\nNo changes made.")
+        sys.exit(0)
+
+    # Confirm
+    if not args.push:
+        print(f"\n⚠️  This will release v{new_version}")
+        response = input("   Continue? [y/N]: ").strip().lower()
+        if response != "y":
+            print("\n❌ Aborted.")
+            sys.exit(1)
+
+    # Update files
+    print("\n📝 Updating version files:")
+    update_version_files(new_version)
+
+    # Git operations
+    print("\n📦 Creating commit and tag:")
+    run(["git", "add", "pyproject.toml", "src/specify_cli/__init__.py"])
+    run(["git", "commit", "-m", f"chore: release v{new_version}"])
+    run(["git", "tag", tag_name])
+
+    # Push
+    print("\n🚀 Pushing to origin:")
+    if not args.push:
+        response = input("   Push now? [Y/n]: ").strip().lower()
+        if response == "n":
+            print(f"\n✅ Release v{new_version} created locally.")
+            print("   To push: git push origin main --tags")
+            print(f"   To undo: git reset --hard HEAD~1 && git tag -d {tag_name}")
+            sys.exit(0)
+
+    run(["git", "push", "origin", "main", "--tags"])
+
+    print(f"\n✅ Successfully released v{new_version}!")
+    print("   GitHub Actions will create the release automatically.")
+    print(f"   View at: https://github.com/jpoley/jp-spec-kit/releases/tag/{tag_name}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fixes the broken release workflow by switching from push-to-main triggers to tag-based releases.

**Problems solved:**
- Release workflow failing due to branch protection (can't push version bump)
- GitHub Actions unable to create PRs for version bumps
- Excessive releases (343+ versions from every push)

**Changes:**
- `release.yml`: Triggers only on `v*` tags or manual dispatch
- `scripts/release.py`: One-command release script
- `docs/guides/release-workflow-fix.md`: Comprehensive documentation

## New Release Process

```bash
./scripts/release.py              # auto-increment patch
./scripts/release.py 1.0.0        # specific version
./scripts/release.py --dry-run    # preview
```

## Manual Step Required

After merging, enable GitHub Pages:
1. Go to https://github.com/jpoley/jp-spec-kit/settings/pages
2. Set Source → **GitHub Actions**

🤖 Generated with [Claude Code](https://claude.com/claude-code)