### PR TITLE
docs: rename to Specflow and fix repo links

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -56,13 +56,13 @@
     "cleanupCacheHistory": false,
     "disableGitFeatures": false,
     "globalMetadata": {
-      "_appTitle": "Spec Kit Documentation",
-      "_appName": "Spec Kit",
-      "_appFooter": "Spec Kit - A specification-driven development toolkit",
+      "_appTitle": "Specflow Documentation",
+      "_appName": "Specflow",
+      "_appFooter": "Specflow - Specification-driven development for AI-augmented teams",
       "_enableSearch": true,
       "_disableContribution": false,
       "_gitContribute": {
-        "repo": "https://github.com/github/spec-kit",
+        "repo": "https://github.com/jpoley/jp-spec-kit",
         "branch": "main"
       }
     }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
-# Spec Kit
+# Specflow
 
-*Build high-quality software faster.*
+*Specification-driven development for AI-augmented teams.*
 
 **An effort to allow organizations to focus on product scenarios rather than writing undifferentiated code with the help of Spec-Driven Development.**
 
@@ -84,9 +84,9 @@ Our research and experimentation focus on:
 
 ## Contributing
 
-Please see our [Contributing Guide](https://github.com/github/spec-kit/blob/main/CONTRIBUTING.md) for information on how to contribute to this project.
+Please see our [Contributing Guide](https://github.com/jpoley/jp-spec-kit/blob/main/CONTRIBUTING.md) for information on how to contribute to this project.
 
 ## Support
 
-For support, please check our [Support Guide](https://github.com/github/spec-kit/blob/main/SUPPORT.md) or open an issue on GitHub.
+For support, please check our [Support Guide](https://github.com/jpoley/jp-spec-kit/blob/main/SUPPORT.md) or open an issue on GitHub.
 


### PR DESCRIPTION
## Summary

Updates documentation site branding from "Spec Kit" to "Specflow" and fixes incorrect GitHub repo links.

**Changes:**
- `docs/docfx.json`: Update `_appTitle`, `_appName`, `_appFooter` to Specflow
- `docs/docfx.json`: Fix `_gitContribute.repo` to point to jpoley/jp-spec-kit
- `docs/index.md`: Update title and tagline
- `docs/index.md`: Fix Contributing and Support links

🤖 Generated with [Claude Code](https://claude.com/claude-code)