### PR TITLE
docs: rename site to Specflow and fix repo link

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -56,13 +56,13 @@
     "cleanupCacheHistory": false,
     "disableGitFeatures": false,
     "globalMetadata": {
-      "_appTitle": "Spec Kit Documentation",
-      "_appName": "Spec Kit",
-      "_appFooter": "Spec Kit - A specification-driven development toolkit",
+      "_appTitle": "Specflow Documentation",
+      "_appName": "Specflow",
+      "_appFooter": "Specflow - Specification-driven development for AI-augmented teams",
       "_enableSearch": true,
       "_disableContribution": false,
       "_gitContribute": {
-        "repo": "https://github.com/github/spec-kit",
+        "repo": "https://github.com/jpoley/jp-spec-kit",
         "branch": "main"
       }
     }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
-# Spec Kit
+# Specflow
 
-*Build high-quality software faster.*
+*Specification-driven development for AI-augmented teams.*
 
 **An effort to allow organizations to focus on product scenarios rather than writing undifferentiated code with the help of Spec-Driven Development.**
 


### PR DESCRIPTION
## Summary

Updates documentation site branding to Specflow (this project's name) and fixes the contribute repo link.

**Changes:**
- `docs/docfx.json`: Site title/name → "Specflow"
- `docs/docfx.json`: Repo link → jpoley/jp-spec-kit
- `docs/index.md`: Page title → "Specflow"

Note: References to upstream "Spec Kit" (github/spec-kit) are intentionally preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)