### PR TITLE
docs: fix broken links, add logo, rename to Specflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-## Contributing to Spec Kit
+## Contributing to Specflow
 
-Hi there! We're thrilled that you'd like to contribute to Spec Kit. Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE).
+Hi there! We're thrilled that you'd like to contribute to Specflow. Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE).
 
 Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -3,8 +3,12 @@
     "content": [
       {
         "files": [
-          "*.md",
-          "toc.yml"
+          "**/*.md",
+          "**/toc.yml"
+        ],
+        "exclude": [
+          "obj/**",
+          "_site/**"
         ]
       },
       {
@@ -58,6 +62,7 @@
     "globalMetadata": {
       "_appTitle": "Specflow Documentation",
       "_appName": "Specflow",
+      "_appLogoPath": "media/logo_small.webp",
       "_appFooter": "Specflow - Specification-driven development for AI-augmented teams",
       "_enableSearch": true,
       "_disableContribution": false,

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,9 +84,9 @@ Our research and experimentation focus on:
 
 ## Contributing
 
-Please see our [Contributing Guide](https://github.com/github/spec-kit/blob/main/CONTRIBUTING.md) for information on how to contribute to this project.
+Please see our [Contributing Guide](CONTRIBUTING.md) for information on how to contribute to this project.
 
 ## Support
 
-For support, please check our [Support Guide](https://github.com/github/spec-kit/blob/main/SUPPORT.md) or open an issue on GitHub.
+For support, please check our [Support Guide](SUPPORT.md) or open an issue on [GitHub](https://github.com/jpoley/jp-spec-kit/issues).
 


### PR DESCRIPTION
## Summary

Fixes documentation site issues:

1. **Broken links** - DocFX was only building root-level `.md` files, not subdirectories
2. **Logo** - Add custom logo instead of default "D"
3. **Links** - Fix Contributing/Support to use local files

**Changes:**
- `docs/docfx.json`: Change `*.md` to `**/*.md` to include all subdirectories
- `docs/docfx.json`: Add `_appLogoPath` pointing to `media/logo_small.webp`
- `docs/index.md`: Fix Contributing/Support links
- `CONTRIBUTING.md`: Update title to "Specflow"

🤖 Generated with [Claude Code](https://claude.com/claude-code)