### PR TITLE
docs(task-410.01): update core pages for Specflow branding

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,9 +10,9 @@
 
 ## Installation
 
-### Initialize a New Project (Layered: base + extension)
+### Initialize a New Project
 
-The easiest way to get started is to initialize a new project with the layered model: base spec-kit plus jp-spec-kit overlay.
+The easiest way to get started is to initialize a new project with Specflow.
 
 ```bash
 uvx --from git+https://github.com/jpoley/jp-spec-kit.git specify init <PROJECT_NAME>
@@ -70,30 +70,18 @@ uvx --from git+https://github.com/jpoley/jp-spec-kit.git specify init <project_n
 ## Verification
 
 After initialization, you should see the following commands available in your AI agent:
-- `/speckit.specify` - Create specifications
-- `/speckit.plan` - Generate implementation plans  
-- `/speckit.tasks` - Break down into actionable tasks
+- `/jpspec:specify` - Create specifications
+- `/jpspec:plan` - Generate implementation plans
+- `/jpspec:implement` - Execute implementation with code review
+- `/jpspec:validate` - QA and security validation
 
-The `.specify/scripts` directory will contain both `.sh` and `.ps1` scripts.
+The `scripts/bash` directory will contain both `.sh` and `.ps1` scripts.
 
 ### VS Code / GitHub Copilot Setup
 
-If you're using GitHub Copilot in VS Code, the initialization process automatically configures `.vscode/settings.json` with the required settings for prompt files. The key settings are:
+If you're using GitHub Copilot in VS Code, the initialization process automatically configures `.vscode/settings.json` with the required settings for prompt files. The key settings enable Copilot to discover and use the workflow commands.
 
-```json
-{
-    "chat.promptFiles": true,
-    "chat.promptFilesRecommendations": {
-        "speckit.constitution": true,
-        "speckit.specify": true,
-        "speckit.plan": true,
-        "speckit.tasks": true,
-        "speckit.implement": true
-    }
-}
-```
-
-**Prompt files location:** After initialization, prompt files are created in `.github/prompts/` with the `.prompt.md` extension.
+**Prompt files location:** After initialization, command files are created in `.claude/commands/` (for Claude Code) or `.github/prompts/` (for GitHub Copilot) depending on which AI agent you selected during initialization.
 
 **If prompts don't appear in Copilot Chat:**
 1. Ensure VS Code is version 1.96 or later (VS Code Insiders may have newer features)
@@ -105,7 +93,7 @@ If you're using GitHub Copilot in VS Code, the initialization process automatica
 
 ### Private assets or API rate limits (authenticated downloads)
 
-If the jp-spec-kit repository or its release assets are private, or you’re operating behind corporate restrictions/rate limits, provide a GitHub token so the CLI can authenticate when resolving releases and downloading assets.
+If the Specflow repository or its release assets are private, or you're operating behind corporate restrictions/rate limits, provide a GitHub token so the CLI can authenticate when resolving releases and downloading assets.
 
 Supported methods:
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -7,8 +7,8 @@ This guide shows how to iterate on the `specify` CLI locally without publishing 
 ## 1. Clone and Switch Branches
 
 ```bash
-git clone https://github.com/github/spec-kit.git
-cd spec-kit
+git clone https://github.com/jpoley/jp-spec-kit.git
+cd jp-spec-kit
 # Work on a feature branch
 git checkout -b your-feature-branch
 ```
@@ -60,7 +60,7 @@ You can also point uvx at a specific branch without merging:
 ```bash
 # Push your working branch first
 git push origin your-feature-branch
-uvx --from git+https://github.com/github/spec-kit.git@your-feature-branch specify init demo-branch-test --script ps
+uvx --from git+https://github.com/jpoley/jp-spec-kit.git@your-feature-branch specify init demo-branch-test --script ps
 ```
 
 ### 4a. Absolute Path uvx (Run From Anywhere)
@@ -68,19 +68,19 @@ uvx --from git+https://github.com/github/spec-kit.git@your-feature-branch specif
 If you're in another directory, use an absolute path instead of `.`:
 
 ```bash
-uvx --from /mnt/c/GitHub/spec-kit specify --help
-uvx --from /mnt/c/GitHub/spec-kit specify init demo-anywhere --ai copilot --ignore-agent-tools --script sh
+uvx --from /path/to/jp-spec-kit specify --help
+uvx --from /path/to/jp-spec-kit specify init demo-anywhere --ai copilot --ignore-agent-tools --script sh
 ```
 
 Set an environment variable for convenience:
 ```bash
-export SPEC_KIT_SRC=/mnt/c/GitHub/spec-kit
-uvx --from "$SPEC_KIT_SRC" specify init demo-env --ai copilot --ignore-agent-tools --script ps
+export SPECFLOW_SRC=/path/to/jp-spec-kit
+uvx --from "$SPECFLOW_SRC" specify init demo-env --ai copilot --ignore-agent-tools --script ps
 ```
 
 (Optional) Define a shell function:
 ```bash
-specify-dev() { uvx --from /mnt/c/GitHub/spec-kit specify "$@"; }
+specify-dev() { uvx --from /path/to/jp-spec-kit specify "$@"; }
 # Then
 specify-dev --help
 ```
@@ -139,7 +139,7 @@ specify init demo --skip-tls --ai gemini --ignore-agent-tools --script ps
 | Run CLI directly | `python -m src.specify_cli --help` |
 | Editable install | `uv pip install -e .` then `specify ...` |
 | Local uvx run (repo root) | `uvx --from . specify ...` |
-| Local uvx run (abs path) | `uvx --from /mnt/c/GitHub/spec-kit specify ...` |
+| Local uvx run (abs path) | `uvx --from /path/to/jp-spec-kit specify ...` |
 | Git branch uvx | `uvx --from git+URL@branch specify ...` |
 | Build wheel | `uv build` |
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quick Start Guide
 
-This guide will help you get started with Spec-Driven Development using Spec Kit.
+This guide will help you get started with Spec-Driven Development using Specflow.
 
 > NEW: All automation scripts now provide both Bash (`.sh`) and PowerShell (`.ps1`) variants. The `specify` CLI auto-selects based on OS unless you pass `--script sh|ps`.
 
@@ -36,29 +36,29 @@ Or pass inline: --github-token ghp_your_token_here
 
 ### 2. Create the Spec
 
-Use the `/speckit.specify` command to describe what you want to build. Focus on the **what** and **why**, not the tech stack.
+Use the `/jpspec:specify` command to describe what you want to build. Focus on the **what** and **why**, not the tech stack.
 
 ```bash
-/speckit.specify Build an application that can help me organize my photos in separate photo albums. Albums are grouped by date and can be re-organized by dragging and dropping on the main page. Albums are never in other nested albums. Within each album, photos are previewed in a tile-like interface.
+/jpspec:specify Build an application that can help me organize my photos in separate photo albums. Albums are grouped by date and can be re-organized by dragging and dropping on the main page. Albums are never in other nested albums. Within each album, photos are previewed in a tile-like interface.
 ```
 
 ### 3. Create a Technical Implementation Plan
 
-Use the `/speckit.plan` command to provide your tech stack and architecture choices.
+Use the `/jpspec:plan` command to provide your tech stack and architecture choices.
 
 ```bash
-/speckit.plan The application uses Vite with minimal number of libraries. Use vanilla HTML, CSS, and JavaScript as much as possible. Images are not uploaded anywhere and metadata is stored in a local SQLite database.
+/jpspec:plan The application uses Vite with minimal number of libraries. Use vanilla HTML, CSS, and JavaScript as much as possible. Images are not uploaded anywhere and metadata is stored in a local SQLite database.
 ```
 
 ### 4. Break Down and Implement
 
-Use `/speckit.tasks` to create an actionable task list, then ask your agent to implement the feature.
+Use `/jpspec:implement` to execute the implementation with automated code review and quality checks.
 
 ## Detailed Example: Building Taskify
 
 Here's a complete example of building a team productivity platform:
 
-### Step 1: Define Requirements with `/speckit.specify`
+### Step 1: Define Requirements with `/jpspec:specify`
 
 ```text
 Develop Taskify, a team productivity platform. It should allow users to create projects, add team members,
@@ -95,7 +95,7 @@ Also validate the specification checklist:
 Read the review and acceptance checklist, and check off each item in the checklist if the feature spec meets the criteria. Leave it empty if it does not.
 ```
 
-### Step 3: Generate Technical Plan with `/speckit.plan`
+### Step 3: Generate Technical Plan with `/jpspec:plan`
 
 Be specific about your tech stack and technical requirements:
 


### PR DESCRIPTION
Updates core documentation pages (index, installation, quickstart, local-development) for Specflow branding.

Part of task-410 documentation overhaul.

🤖 Generated with [Claude Code](https://claude.com/claude-code)