### PR TITLE
docs(task-410.02): update guides/ for Specflow branding

### DIFF
--- a/docs/guides/backlog-migration.md
+++ b/docs/guides/backlog-migration.md
@@ -1,6 +1,6 @@
 # Migrating from tasks.md to Backlog.md
 
-Complete guide for migrating existing jp-spec-kit projects from tasks.md format to Backlog.md task management.
+Complete guide for migrating existing Specflow projects from tasks.md format to Backlog.md task management.
 
 ## Table of Contents
 
@@ -538,7 +538,7 @@ For hybrid: Use tasks.md as blueprint, Backlog.md for execution (no sync).
 
 ### Q: What about tasks.md in the template?
 
-**A**: jp-spec-kit templates will eventually generate both:
+**A**: Specflow templates will eventually generate both:
 
 - `tasks.md` - Reference blueprint (optional)
 - Backlog.md tasks - Execution tracker (primary)

--- a/docs/guides/backlog-quickstart.md
+++ b/docs/guides/backlog-quickstart.md
@@ -1,10 +1,10 @@
 # Backlog.md Quick Start Guide
 
-Get started with Backlog.md task management integration in jp-spec-kit in under 5 minutes.
+Get started with Backlog.md task management integration in Specflow in under 5 minutes.
 
 ## What is Backlog.md Integration?
 
-Backlog.md integration extends jp-spec-kit's spec-driven development workflow with powerful task lifecycle management:
+Backlog.md integration extends Specflow's spec-driven development workflow with powerful task lifecycle management:
 
 - **Visual Task Boards**: Kanban boards in terminal and web UI
 - **AI-Powered Management**: Claude Code and other AI assistants can manage tasks via MCP
@@ -16,7 +16,7 @@ Backlog.md integration extends jp-spec-kit's spec-driven development workflow wi
 
 ## Prerequisites
 
-- jp-spec-kit installed and initialized (`specify init`)
+- Specflow installed and initialized (`specify init`)
 - Node.js 18+ (for Backlog.md CLI)
 - Claude Code (optional, for AI integration)
 
@@ -244,8 +244,8 @@ backlog init
 
 ## FAQ
 
-### Q: Can I use Backlog.md without jp-spec-kit?
-**A**: Yes! Backlog.md is a standalone tool. jp-spec-kit integration adds automatic task generation from specs.
+### Q: Can I use Backlog.md without Specflow?
+**A**: Yes! Backlog.md is a standalone tool. Specflow integration adds automatic task generation from specs.
 
 ### Q: Do I need Claude Code?
 **A**: No, you can use Backlog.md CLI and web UI manually. MCP integration just adds AI-powered task management.

--- a/docs/guides/backlog-troubleshooting.md
+++ b/docs/guides/backlog-troubleshooting.md
@@ -1,6 +1,6 @@
 # Backlog.md Troubleshooting Guide
 
-Comprehensive troubleshooting for common issues with Backlog.md integration in jp-spec-kit.
+Comprehensive troubleshooting for common issues with Backlog.md integration in Specflow.
 
 ## Table of Contents
 
@@ -836,7 +836,7 @@ Report if you encounter:
 **For Backlog.md tool issues**:
 https://github.com/MrLesk/Backlog.md/issues
 
-**For jp-spec-kit integration issues**:
+**For Specflow integration issues**:
 https://github.com/jpoley/jp-spec-kit/issues
 
 **Include in report**:
@@ -864,9 +864,9 @@ tail -50 ~/.local/state/claude-code/logs/mcp-backlog.log
 
 ### Community Help
 
-- **Discord**: [jp-spec-kit community](https://discord.gg/...)
+- **Discord**: [Specflow community](https://discord.gg/...)
 - **GitHub Discussions**: https://github.com/jpoley/jp-spec-kit/discussions
-- **Stack Overflow**: Tag with `jp-spec-kit` and `backlog-md`
+- **Stack Overflow**: Tag with `specflow` and `backlog-md`
 
 ### Quick Diagnostic
 

--- a/docs/guides/backlog-user-guide.md
+++ b/docs/guides/backlog-user-guide.md
@@ -1,6 +1,6 @@
-# Backlog.md User Guide for jp-spec-kit
+# Backlog.md User Guide for Specflow
 
-Comprehensive guide to using Backlog.md task management with jp-spec-kit's spec-driven development workflow.
+Comprehensive guide to using Backlog.md task management with Specflow's spec-driven development workflow.
 
 ## Table of Contents
 
@@ -18,7 +18,7 @@ Comprehensive guide to using Backlog.md task management with jp-spec-kit's spec-
 
 ### What is Backlog.md Integration?
 
-Backlog.md integration enhances jp-spec-kit with a robust task lifecycle management layer that bridges the gap between specification and execution.
+Backlog.md integration enhances Specflow with a robust task lifecycle management layer that bridges the gap between specification and execution.
 
 **The Integration Flow**:
 ```
@@ -46,7 +46,7 @@ Completed Feature
 
 ```
 ┌─────────────────────────────────────────┐
-│          jp-spec-kit Layer              │
+│           Specflow Layer                │
 │  /jpspec:specify → spec.md              │
 │  /jpspec:plan → plan.md                 │
 │  /jpspec:tasks → Generate Tasks         │
@@ -74,7 +74,7 @@ Completed Feature
 
 ### Prerequisites
 
-- jp-spec-kit installed: `uv tool install specify-cli --from git+https://github.com/jpoley/jp-spec-kit.git`
+- Specflow installed: `uv tool install specify-cli --from git+https://github.com/jpoley/jp-spec-kit.git`
 - Node.js 18+ or npm/pnpm
 - Git repository initialized
 - Claude Code (optional, for AI integration)
@@ -99,7 +99,7 @@ backlog --version
 ### Step 2: Initialize Backlog in Your Project
 
 ```bash
-# Navigate to your jp-spec-kit project
+# Navigate to your Specflow project
 cd your-project
 
 # Initialize Backlog.md
@@ -199,7 +199,7 @@ specify tasks generate --format backlog-md
 
 ### Task Format Mapping
 
-jp-spec-kit tasks map to Backlog.md like this:
+Specflow tasks map to Backlog.md like this:
 
 **tasks.md format**:
 ```markdown
@@ -233,7 +233,7 @@ Create User model in src/models/user.py
 
 ### Understanding Labels and Dependencies
 
-**Labels** encode the structure from jp-spec-kit:
+**Labels** encode the structure from Specflow:
 
 - **User Story Labels**: `US1`, `US2`, `US3` (from `[US1]` markers)
 - **Phase Labels**: `setup`, `foundational`, `implementation`, `polish`
@@ -950,12 +950,12 @@ backlog board --filter US1  # Instead of viewing all tasks
 
 **Resources**:
 - [Backlog.md Documentation](https://github.com/MrLesk/Backlog.md)
-- [jp-spec-kit Issues](https://github.com/jpoley/jp-spec-kit/issues)
+- [Specflow Issues](https://github.com/jpoley/jp-spec-kit/issues)
 - [MCP Protocol Docs](https://modelcontextprotocol.io)
 
 **Report Issues**:
 ```bash
-# For jp-spec-kit integration issues
+# For Specflow integration issues
 # Open issue at: https://github.com/jpoley/jp-spec-kit/issues
 
 # For Backlog.md tool issues

--- a/docs/guides/codeql-setup.md
+++ b/docs/guides/codeql-setup.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-CodeQL is GitHub's semantic code analysis engine that provides deep dataflow analysis for detecting complex security vulnerabilities. This guide covers installation, database creation, query execution, and integration with jp-spec-kit.
+CodeQL is GitHub's semantic code analysis engine that provides deep dataflow analysis for detecting complex security vulnerabilities. This guide covers installation, database creation, query execution, and integration with Specflow.
 
 **Prerequisites**:
 - Review [CodeQL Licensing](../legal/codeql-licensing-review.md) before proceeding
@@ -13,7 +13,7 @@ CodeQL is GitHub's semantic code analysis engine that provides deep dataflow ana
 
 ### Method 1: Automated Setup (Recommended)
 
-jp-spec-kit provides a setup script that handles CodeQL CLI installation:
+Specflow provides a setup script that handles CodeQL CLI installation:
 
 ```bash
 # Download and install CodeQL CLI
@@ -281,11 +281,11 @@ codeql database analyze mydb --format=json --output=results.json
 codeql database analyze mydb --format=text
 ```
 
-## Integration with jp-spec-kit
+## Integration with Specflow
 
 ### Using specify CLI
 
-jp-spec-kit integrates CodeQL through the `specify security scan` command:
+Specflow integrates CodeQL through the `specify security scan` command:
 
 ```bash
 # Scan with CodeQL (requires --codeql flag)
@@ -332,7 +332,7 @@ scanners:
 
 ### Unified Finding Format (UFFormat)
 
-jp-spec-kit converts CodeQL SARIF output to UFFormat:
+Specflow converts CodeQL SARIF output to UFFormat:
 
 ```python
 # CodeQL SARIF result
@@ -646,7 +646,7 @@ codeql database create db \
 - [Security Lab](https://securitylab.github.com/)
 - [CodeQL Slack](https://codeql.slack.com)
 
-### jp-spec-kit Resources
+### Specflow Resources
 - [CodeQL Licensing Review](../legal/codeql-licensing-review.md)
 - [Security CI/CD Integration](./security-cicd-integration.md)
 - [Dataflow Analysis Patterns](../../memory/security/dataflow-analysis.md)
@@ -665,4 +665,4 @@ After setting up CodeQL:
 ---
 
 **Last Updated**: 2025-12-04
-**Maintained By**: JP Spec Kit Security Team
+**Maintained By**: Specflow Security Team

--- a/docs/guides/constitution-distribution.md
+++ b/docs/guides/constitution-distribution.md
@@ -31,7 +31,7 @@ The constitution lives at `memory/constitution.md` in your project and serves as
 
 ### Why Tier Selection Matters
 
-JP Spec Kit provides **three constitution tiers** to match different project needs:
+Specflow provides **three constitution tiers** to match different project needs:
 
 | Tier | Best For | Enforcement Level | Key Characteristics |
 |------|----------|-------------------|---------------------|
@@ -267,7 +267,7 @@ specify init --here --constitution heavy
 ```
 
 **Detection logic:**
-- JP Spec Kit detects existing project if any of these exist:
+- Specflow detects existing project if any of these exist:
   - `.git/` directory
   - `package.json` (Node.js)
   - `pyproject.toml` (Python)
@@ -279,10 +279,10 @@ specify init --here --constitution heavy
 
 ### Project Upgrade
 
-Update existing JP Spec Kit installation:
+Update existing Specflow installation:
 
 ```bash
-# Upgrade JP Spec Kit
+# Upgrade Specflow
 specify upgrade
 
 # If constitution missing, you'll be prompted:
@@ -338,7 +338,7 @@ specify init my-project --constitution medium
 **When to use manual customization:**
 - After adding new languages/frameworks
 - When automatic detection failed
-- After upgrading JP Spec Kit
+- After upgrading Specflow
 - To refresh constitution with latest repo state
 
 ### What Gets Detected
@@ -709,7 +709,7 @@ echo "✅ Constitution validated"
 
 ### How Enforcement Works
 
-Before executing `/jpspec` commands, JP Spec Kit checks:
+Before executing `/jpspec` commands, Specflow checks:
 
 1. **Constitution exists** - Is `memory/constitution.md` present?
 2. **Constitution validated** - Are there NEEDS_VALIDATION markers?
@@ -907,11 +907,11 @@ specify constitution version
 
 ### `specify upgrade`
 
-Upgrade JP Spec Kit and handle constitution detection.
+Upgrade Specflow and handle constitution detection.
 
 **Usage:**
 ```bash
-# Upgrade JP Spec Kit
+# Upgrade Specflow
 specify upgrade
 
 # If constitution missing:
@@ -994,7 +994,7 @@ Constitution versions follow **semantic versioning**:
 
 ### Handling Upgrades
 
-When JP Spec Kit releases new constitution templates:
+When Specflow releases new constitution templates:
 
 **Future feature:**
 ```bash
@@ -1227,7 +1227,7 @@ Signed-off-by: Your Name <you@example.com>"
 - [Constitution Distribution PRD](../prd/constitution-distribution-prd.md) - Full feature specification
 - [Tiered Constitution Templates](../../templates/constitutions/) - Template source files
 - [Case Study: Constitution Templates](../case-studies/02-constitution-templates.md) - Implementation story
-- [JP Spec Kit CLI Reference](../reference/cli-commands.md) - All CLI commands
+- [Specflow CLI Reference](../reference/cli-commands.md) - All CLI commands
 
 ---
 
@@ -1251,7 +1251,7 @@ specify constitution validate --json
 # Run LLM customization
 /speckit:constitution
 
-# Upgrade JP Spec Kit (detects missing constitutions)
+# Upgrade Specflow (detects missing constitutions)
 specify upgrade
 ```
 

--- a/docs/guides/constitution-troubleshooting.md
+++ b/docs/guides/constitution-troubleshooting.md
@@ -472,12 +472,12 @@ Medium tier uses warnings + confirmation prompts but allows proceeding after ack
 ### Problem: Constitution version mismatch after `specify upgrade`
 
 **Symptoms**:
-- Upgraded JP Spec Kit to new version
+- Upgraded Specflow to new version
 - Constitution feels outdated compared to new templates
 - New features reference constitution sections that don't exist
 
 **Cause**:
-JP Spec Kit upgraded but constitution template not updated. Constitutions are never automatically overwritten to preserve customizations.
+Specflow upgraded but constitution template not updated. Constitutions are never automatically overwritten to preserve customizations.
 
 **Resolution**:
 
@@ -563,7 +563,7 @@ specify constitution upgrade --interactive
 ```
 
 **Prevention**:
-- Review release notes when upgrading JP Spec Kit
+- Review release notes when upgrading Specflow
 - Schedule quarterly constitution review
 - Track constitution template versions in your project docs
 
@@ -814,7 +814,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install JP Spec Kit
+      - name: Install Specflow
         run: |
           pip install uv
           uv tool install jp-spec-kit
@@ -960,7 +960,7 @@ Please analyze my project and customize memory/constitution.md:
 - [Constitution Validation Workflow](./constitution-validation.md) - Validation process details
 - [Constitution Distribution PRD](../prd/constitution-distribution-prd.md) - Feature specification
 - [Tiered Constitution Templates](../../templates/constitutions/) - Template source files
-- [JP Spec Kit CLI Reference](../reference/cli-commands.md) - All CLI commands
+- [Specflow CLI Reference](../reference/cli-commands.md) - All CLI commands
 
 ---
 
@@ -982,7 +982,7 @@ specify init --here                             # Add to existing project
 /speckit:constitution                           # Run LLM detection
 
 # Upgrade
-specify upgrade                                 # Upgrade JP Spec Kit
+specify upgrade                                 # Upgrade Specflow
 
 # Search for issues
 grep -i "NEEDS_VALIDATION" memory/constitution.md   # Find markers
@@ -1019,7 +1019,7 @@ templates/constitutions/                # Template source files
 
 2. **Review related guides:**
    - [Constitution Distribution Guide](./constitution-distribution.md)
-   - [JP Spec Kit Troubleshooting](./troubleshooting.md)
+   - [Specflow Troubleshooting](./troubleshooting.md)
    - [Backlog Troubleshooting](./backlog-troubleshooting.md)
 
 3. **Search existing issues:**

--- a/docs/guides/hooks-quickstart.md
+++ b/docs/guides/hooks-quickstart.md
@@ -1,8 +1,8 @@
-# JP Spec Kit Hooks Quick Start
+# Specflow Hooks Quick Start
 
 ## Overview
 
-Hooks allow you to run custom scripts when workflow events occur in your JP Spec Kit project. This enables automation of tasks like running tests, updating documentation, quality gates, and integration with external tools.
+Hooks allow you to run custom scripts when workflow events occur in your Specflow project. This enables automation of tasks like running tests, updating documentation, quality gates, and integration with external tools.
 
 ## Getting Started
 

--- a/docs/guides/jpspec-workflow-guide.md
+++ b/docs/guides/jpspec-workflow-guide.md
@@ -1,4 +1,4 @@
-# JP Spec Kit /jpspec Workflow Guide
+# Specflow /jpspec Workflow Guide
 
 Comprehensive guide to using the /jpspec command orchestration system for specification-driven development with AI-powered agents.
 
@@ -25,7 +25,7 @@ Comprehensive guide to using the /jpspec command orchestration system for specif
 
 ### What is the /jpspec Workflow System?
 
-The /jpspec workflow system is JP Spec Kit's **AI-powered command orchestration layer** that coordinates specialized agents through the complete software development lifecycle. It transforms specification-driven development from a manual process into an automated, traceable workflow.
+The /jpspec workflow system is Specflow's **AI-powered command orchestration layer** that coordinates specialized agents through the complete software development lifecycle. It transforms specification-driven development from a manual process into an automated, traceable workflow.
 
 **Value Proposition**:
 - **Reduce Planning Time**: Automated PRD generation, architecture design, and task breakdown (50-70% time savings)
@@ -2433,4 +2433,4 @@ The following diagram shows the complete /jpspec workflow with agent coordinatio
 
 **Last Updated**: 2025-11-29
 **Version**: 1.0
-**Maintained By**: JP Spec Kit Project
+**Maintained By**: Specflow Project

--- a/docs/guides/release-workflow-fix.md
+++ b/docs/guides/release-workflow-fix.md
@@ -216,7 +216,7 @@ The script automatically:
 
 **Example output:**
 ```
-🚀 JP Spec Kit Release Script
+🚀 Specflow Release Script
 ==================================================
 
 📋 Current state:

--- a/docs/guides/security-mcp-guide.md
+++ b/docs/guides/security-mcp-guide.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The JP Spec Kit Security Scanner MCP Server exposes security scanning capabilities through the Model Context Protocol (MCP). This enables AI agents, IDEs, and dashboards to query security findings and trigger scans programmatically.
+The Specflow Security Scanner MCP Server exposes security scanning capabilities through the Model Context Protocol (MCP). This enables AI agents, IDEs, and dashboards to query security findings and trigger scans programmatically.
 
 **CRITICAL ARCHITECTURE NOTE:** The MCP server does NOT make LLM API calls. It:
 1. Exposes security data as resources (read-only queries)
@@ -36,7 +36,7 @@ See [ADR-008: Security MCP Server Architecture](../adr/ADR-008-security-mcp-serv
 ### Prerequisites
 
 - Python 3.11+
-- JP Spec Kit installed (`uv tool install . --force`)
+- Specflow installed (`uv tool install . --force`)
 - MCP-compatible client (Claude Desktop, MCP Inspector, etc.)
 
 ### Install MCP Python SDK
@@ -66,7 +66,7 @@ Add the security scanner server to your `.mcp.json` configuration:
       "command": "python",
       "args": ["-m", "specify_cli.security.mcp_server"],
       "env": {},
-      "description": "JP Spec Kit Security Scanner: scan, triage, and fix security findings"
+      "description": "Specflow Security Scanner: scan, triage, and fix security findings"
     }
   }
 }
@@ -569,7 +569,7 @@ For issues or questions:
 
 1. Check the [Troubleshooting](#troubleshooting) section
 2. Review [ADR-008](../adr/ADR-008-security-mcp-server-architecture.md) for architecture details
-3. Open an issue on the JP Spec Kit repository
+3. Open an issue on the Specflow repository
 
 ---
 

--- a/docs/guides/security-personas.md
+++ b/docs/guides/security-personas.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-JP Spec Kit includes four specialized security expert personas that provide on-demand expertise for vulnerability analysis, fix validation, dynamic testing, and exploit research. These personas follow the progressive disclosure pattern - they are only loaded when needed, minimizing token usage while providing deep specialized knowledge.
+Specflow includes four specialized security expert personas that provide on-demand expertise for vulnerability analysis, fix validation, dynamic testing, and exploit research. These personas follow the progressive disclosure pattern - they are only loaded when needed, minimizing token usage while providing deep specialized knowledge.
 
 ## Available Personas
 
@@ -646,4 +646,4 @@ gh pr create
 
 **Version:** 1.0.0
 **Last Updated:** 2025-12-05
-**Maintained By:** JP Spec Kit Security Team
+**Maintained By:** Specflow Security Team

--- a/docs/guides/security-workflow-integration.md
+++ b/docs/guides/security-workflow-integration.md
@@ -712,7 +712,7 @@ specify security scan --format sarif --output security-results.sarif
     {
       "tool": {
         "driver": {
-          "name": "JP Spec Kit Security Scanner",
+          "name": "Specflow Security Scanner",
           "version": "1.0.0",
           "informationUri": "https://github.com/jpoley/jp-spec-kit",
           "rules": [

--- a/docs/guides/team-mode-workflow.md
+++ b/docs/guides/team-mode-workflow.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-JP Spec Kit supports both **Solo Mode** (single developer) and **Team Mode** (multiple developers). This guide explains how to configure and work with Team Mode properly to avoid conflicts and ensure smooth collaboration.
+Specflow supports both **Solo Mode** (single developer) and **Team Mode** (multiple developers). This guide explains how to configure and work with Team Mode properly to avoid conflicts and ensure smooth collaboration.
 
 ## Solo vs Team Mode
 

--- a/docs/guides/vscode-role-integration.md
+++ b/docs/guides/vscode-role-integration.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-JP Spec Kit integrates with VS Code Copilot to provide role-based agent suggestions and command visibility. By configuring your primary role, VS Code will prioritize agents and commands relevant to your work.
+Specflow integrates with VS Code Copilot to provide role-based agent suggestions and command visibility. By configuring your primary role, VS Code will prioritize agents and commands relevant to your work.
 
 ## Quick Start
 

--- a/docs/guides/workflow-architecture.md
+++ b/docs/guides/workflow-architecture.md
@@ -1,8 +1,8 @@
-# JP Spec Kit Workflow Architecture
+# Specflow Workflow Architecture
 
 ## Overview
 
-The JP Spec Kit workflow synchronizes the `/jpspec` command interface with the backlog.md task management system. This document defines the architecture, design decisions, and implementation approach.
+The Specflow workflow synchronizes the `/jpspec` command interface with the backlog.md task management system. This document defines the architecture, design decisions, and implementation approach.
 
 ## Problem Statement
 
@@ -183,7 +183,7 @@ New command: `specify workflow validate`
 
 ```yaml
 version: "1.0"
-description: "Default JP Spec Kit specification-driven development workflow"
+description: "Default Specflow specification-driven development workflow"
 
 # Custom backlog.md states
 states:

--- a/docs/guides/workflow-customization.md
+++ b/docs/guides/workflow-customization.md
@@ -1,6 +1,6 @@
 # Workflow Customization Guide
 
-This guide explains how to customize the JP Spec Kit workflow by modifying `jpspec_workflow.yml`.
+This guide explains how to customize the Specflow workflow by modifying `jpspec_workflow.yml`.
 
 ## Overview
 
@@ -537,7 +537,7 @@ Custom agents will generate warnings but won't block execution:
 [WARNING] UNKNOWN_AGENT: Workflow 'validate' references unknown agent 'compliance-officer'.
 ```
 
-This is by design - you can use custom agents without modifying JP Spec Kit code.
+This is by design - you can use custom agents without modifying Specflow code.
 
 ### Breaking Changes
 
@@ -553,7 +553,7 @@ Removing states or workflows can break existing tasks:
 Check the `version` field in `jpspec_workflow.yml`:
 
 ```yaml
-version: "1.1"  # Must match JP Spec Kit's expected schema version
+version: "1.1"  # Must match Specflow's expected schema version
 ```
 
 Incompatible versions will cause validation errors.
@@ -696,7 +696,7 @@ vim jpspec_workflow.yml
 If all else fails, restore the default configuration:
 
 ```bash
-# Copy from template (JP Spec Kit installation)
+# Copy from template (Specflow installation)
 cp ~/.local/share/specify-cli/templates/jpspec_workflow.yml ./jpspec_workflow.yml
 ```
 

--- a/docs/guides/workflow-state-mapping.md
+++ b/docs/guides/workflow-state-mapping.md
@@ -1,10 +1,10 @@
 # Workflow State Mapping Guide
 
-This guide explains how backlog.md task states map to `/jpspec` workflow commands in the JP Spec Kit Spec-Driven Development (SDD) workflow.
+This guide explains how backlog.md task states map to `/jpspec` workflow commands in the Specflow Spec-Driven Development (SDD) workflow.
 
 ## Overview
 
-JP Spec Kit uses a state machine to coordinate task progression through the SDD lifecycle. Each task state corresponds to a workflow phase, and each phase is executed by running a `/jpspec` command.
+Specflow uses a state machine to coordinate task progression through the SDD lifecycle. Each task state corresponds to a workflow phase, and each phase is executed by running a `/jpspec` command.
 
 **Key Concept**: Task states represent **where you are** in the development lifecycle, while `/jpspec` commands represent **how to move forward**.
 

--- a/docs/guides/workflow-troubleshooting.md
+++ b/docs/guides/workflow-troubleshooting.md
@@ -1,6 +1,6 @@
 # Workflow Troubleshooting Guide
 
-This guide provides solutions for common issues when working with JP Spec Kit workflow configuration.
+This guide provides solutions for common issues when working with Specflow workflow configuration.
 
 ## Quick Diagnostics
 
@@ -46,7 +46,7 @@ Searched locations:
 
 **Solution 1: Create default configuration**
 ```bash
-# Copy from JP Spec Kit templates
+# Copy from Specflow templates
 cp ~/.local/share/specify-cli/templates/jpspec_workflow.yml ./jpspec_workflow.yml
 
 # Or create in memory/ directory
@@ -132,7 +132,7 @@ grep -A 20 "^states:" jpspec_workflow.yml
 
 **Solution 4: Check schema version**
 ```yaml
-# Ensure version matches JP Spec Kit's expected version
+# Ensure version matches Specflow's expected version
 version: "1.1"  # Current version
 ```
 
@@ -517,13 +517,13 @@ specify workflow validate
 ```
 
 **Causes**:
-1. JP Spec Kit not installed
+1. Specflow not installed
 2. Old version without workflow commands
 3. Path issue
 
 **Solutions**:
 
-**Solution 1: Install/update JP Spec Kit**
+**Solution 1: Install/update Specflow**
 ```bash
 # Install latest version
 uv tool install . --force
@@ -740,7 +740,7 @@ If none of these solutions work:
 3. Report via GitHub Issues with:
    - Error message
    - Minimal jpspec_workflow.yml
-   - JP Spec Kit version (`specify --version`)
+   - Specflow version (`specify --version`)
    - Steps to reproduce
 
 ---


### PR DESCRIPTION
Updates 19 files in docs/guides/ for Specflow branding.

Part of task-410 documentation overhaul.

🤖 Generated with [Claude Code](https://claude.com/claude-code)