### PR TITLE
docs(task-410.03): update reference/ for Specflow branding

### DIFF
--- a/docs/reference/agent-architecture-diagrams.md
+++ b/docs/reference/agent-architecture-diagrams.md
@@ -1,6 +1,6 @@
 # Agent Architecture Diagrams
 
-This document provides visual representations of the JP Spec Kit agent ecosystem, showing all 16 workflow agents, 13 AI coding platforms, 9 MCP servers, and how they interconnect across the SDD workflow.
+This document provides visual representations of the Specflow agent ecosystem, showing all 16 workflow agents, 13 AI coding platforms, 9 MCP servers, and how they interconnect across the SDD workflow.
 
 ## Quick Reference
 
@@ -723,7 +723,7 @@ Legend: ● = Uses this MCP server
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────────┐
-│                         JP SPEC KIT - QUICK REFERENCE                           │
+│                         SPECFLOW - QUICK REFERENCE                              │
 ├─────────────────────────────────────────────────────────────────────────────────┤
 │                                                                                 │
 │  WORKFLOW AGENTS: 16 total                                                      │

--- a/docs/reference/agent-mcp-integrations.md
+++ b/docs/reference/agent-mcp-integrations.md
@@ -1,6 +1,6 @@
 # Agent & MCP Server Integrations
 
-This document provides a comprehensive overview of all agents in JP Spec Kit and their configured MCP (Model Context Protocol) server integrations.
+This document provides a comprehensive overview of all agents in Specflow and their configured MCP (Model Context Protocol) server integrations.
 
 ## Architecture Overview
 

--- a/docs/reference/backlog-commands.md
+++ b/docs/reference/backlog-commands.md
@@ -1,6 +1,6 @@
-# Backlog.md Command Reference for jp-spec-kit
+# Backlog.md Command Reference for Specflow
 
-Complete reference for all Backlog.md commands available in jp-spec-kit projects.
+Complete reference for all Backlog.md commands available in Specflow projects.
 
 ## Table of Contents
 

--- a/docs/reference/dev-setup-consistency.md
+++ b/docs/reference/dev-setup-consistency.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This guide explains the **single-source-of-truth architecture** for command files in JP Spec Kit, ensuring consistency between development and distribution. The dev-setup system eliminates content divergence by establishing `templates/commands/` as the canonical source for all command files.
+This guide explains the **single-source-of-truth architecture** for command files in Specflow, ensuring consistency between development and distribution. The dev-setup system eliminates content divergence by establishing `templates/commands/` as the canonical source for all command files.
 
 **Key Principle**: What developers test is exactly what users receive.
 
@@ -65,7 +65,7 @@ All command development occurs in `templates/commands/`:
 
 ### Directory Structure
 
-**Source Repository** (jp-spec-kit):
+**Source Repository** (Specflow):
 ```
 jp-spec-kit/
 ├── templates/commands/              ◄─── CANONICAL SOURCE

--- a/docs/reference/workflow-step-principles.md
+++ b/docs/reference/workflow-step-principles.md
@@ -1,14 +1,14 @@
 # Workflow Step Tracking - Constitutional Principles
 
 **Authority:** Architectural Governance
-**Scope:** JP Spec Kit workflow integration
+**Scope:** Specflow workflow integration
 **Related:** [ADR-002](../adr/ADR-002-workflow-step-tracking-architecture.md)
 
 ---
 
 ## Purpose
 
-This document defines the non-negotiable principles governing workflow step tracking in JP Spec Kit. These principles ensure consistency, reliability, and maintainability of the workflow state machine integration.
+This document defines the non-negotiable principles governing workflow step tracking in Specflow. These principles ensure consistency, reliability, and maintainability of the workflow state machine integration.
 
 **Principle Source:** Gregor Hohpe's architectural philosophy applied to workflow orchestration.
 


### PR DESCRIPTION
Updates 5 files in docs/reference/ for Specflow branding.

Part of task-410 documentation overhaul.

🤖 Generated with [Claude Code](https://claude.com/claude-code)