### PR TITLE
docs(task-410.04): update adr/ for Specflow branding

### DIFF
--- a/docs/adr/ADR-001-backlog-md-integration.md
+++ b/docs/adr/ADR-001-backlog-md-integration.md
@@ -9,7 +9,7 @@
 
 ## Context and Problem Statement
 
-JP Spec Kit's `/jpspec:*` commands orchestrate 15+ specialized AI agents across 6 workflows (specify, plan, research, implement, validate, operate). Currently, all task management is manual and ad-hoc with no standardized lifecycle tracking.
+Specflow's `/jpspec:*` commands orchestrate 15+ specialized AI agents across 6 workflows (specify, plan, research, implement, validate, operate). Currently, all task management is manual and ad-hoc with no standardized lifecycle tracking.
 
 **Problems**:
 - No automated task activation when agents start work

--- a/docs/adr/ADR-001-task-memory-storage.md
+++ b/docs/adr/ADR-001-task-memory-storage.md
@@ -205,7 +205,7 @@ Use Git's native notes feature for task metadata.
 
 - [Gregor Hohpe - Architecture as Selling Options](https://architectelevator.com/architecture/architecture-options/)
 - [Task Memory System Architecture](../architecture/task-memory-system.md)
-- [JP Spec Kit Constitution](../../memory/constitution.md)
+- [Specflow Constitution](../../memory/constitution.md)
 - [Backlog.md Specification](https://github.com/jpoley/backlog.md)
 
 ## Notes

--- a/docs/adr/ADR-002-SUMMARY.md
+++ b/docs/adr/ADR-002-SUMMARY.md
@@ -10,7 +10,7 @@
 
 ## Executive Summary
 
-JP Spec Kit orchestrates software development through `/jpspec` workflow commands (assess, specify, research, plan, implement, validate, operate). Currently, backlog.md tasks use simple statuses ("To Do", "In Progress", "Done") that don't reflect which workflow phase a task is in.
+Specflow orchestrates software development through `/jpspec` workflow commands (assess, specify, research, plan, implement, validate, operate). Currently, backlog.md tasks use simple statuses ("To Do", "In Progress", "Done") that don't reflect which workflow phase a task is in.
 
 **Solution:** Hybrid two-level state model combining board statuses for visual organization with workflow step metadata for precise lifecycle tracking.
 

--- a/docs/adr/ADR-002-workflow-step-tracking-architecture.md
+++ b/docs/adr/ADR-002-workflow-step-tracking-architecture.md
@@ -11,7 +11,7 @@
 
 ### Business Problem
 
-JP Spec Kit orchestrates complex software development workflows through `/jpspec` commands (assess, specify, research, plan, implement, validate, operate). Currently, backlog.md tasks use simple statuses ("To Do", "In Progress", "Done") that don't reflect **which workflow phase** a task is in.
+Specflow orchestrates complex software development workflows through `/jpspec` commands (assess, specify, research, plan, implement, validate, operate). Currently, backlog.md tasks use simple statuses ("To Do", "In Progress", "Done") that don't reflect **which workflow phase** a task is in.
 
 **The Core Tension:** Developers need visibility into workflow progression without cluttering their task board with 9+ status columns.
 

--- a/docs/adr/ADR-003-mcp-health-check-design.md
+++ b/docs/adr/ADR-003-mcp-health-check-design.md
@@ -6,7 +6,7 @@ Accepted
 
 ## Context
 
-JP Spec Kit integrates with 8 Model Context Protocol (MCP) servers that provide critical capabilities including GitHub API access, code understanding, security scanning, and browser automation. When MCP servers fail to start or become unresponsive, development workflows are blocked with unclear error messages.
+Specflow integrates with 8 Model Context Protocol (MCP) servers that provide critical capabilities including GitHub API access, code understanding, security scanning, and browser automation. When MCP servers fail to start or become unresponsive, development workflows are blocked with unclear error messages.
 
 **Problems with current state:**
 - No systematic way to verify MCP server availability

--- a/docs/adr/ADR-003-stop-hook-quality-gate.md
+++ b/docs/adr/ADR-003-stop-hook-quality-gate.md
@@ -9,7 +9,7 @@
 
 ## Context and Problem Statement
 
-JP Spec Kit uses backlog.md to track tasks through workflows with clear acceptance criteria. When creating PRs, developers should ensure tasks are marked "Done" with all acceptance criteria complete. However, it's easy to forget this quality gate in the flow of creating a PR.
+Specflow uses backlog.md to track tasks through workflows with clear acceptance criteria. When creating PRs, developers should ensure tasks are marked "Done" with all acceptance criteria complete. However, it's easy to forget this quality gate in the flow of creating a PR.
 
 **Problems**:
 - PRs created while backlog tasks still marked "In Progress"

--- a/docs/adr/ADR-004-workflow-validation-cli.md
+++ b/docs/adr/ADR-004-workflow-validation-cli.md
@@ -9,7 +9,7 @@
 
 ## Context and Problem Statement
 
-JP Spec Kit's workflow configuration (`jpspec_workflow.yml`) is a critical file that defines:
+Specflow's workflow configuration (`jpspec_workflow.yml`) is a critical file that defines:
 - Task lifecycle states (To Do, Specified, Planned, etc.)
 - Workflow commands (`/jpspec:specify`, `/jpspec:implement`, etc.)
 - State transitions and their valid paths

--- a/docs/adr/ADR-005-event-model-architecture.md
+++ b/docs/adr/ADR-005-event-model-architecture.md
@@ -9,7 +9,7 @@
 
 ## Context
 
-JP Spec Kit operates as a **linear, synchronous workflow system** where each /jpspec command executes agents in isolation. This creates critical automation gaps:
+Specflow operates as a **linear, synchronous workflow system** where each /jpspec command executes agents in isolation. This creates critical automation gaps:
 
 1. **No automated quality gates**: Tests must be run manually after implementation
 2. **No workflow orchestration**: Documentation updates and code reviews require manual coordination
@@ -334,7 +334,7 @@ class EventEmitter:
 ```json
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "JP Spec Kit Base Event",
+  "title": "Specflow Base Event",
   "type": "object",
   "required": ["event_type", "event_id", "schema_version", "timestamp", "project_root"],
   "properties": {

--- a/docs/adr/ADR-007-hook-configuration-schema.md
+++ b/docs/adr/ADR-007-hook-configuration-schema.md
@@ -256,7 +256,7 @@ Hook runs if EITHER event matches.
 ```json
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "JP Spec Kit Hooks Configuration",
+  "title": "Specflow Hooks Configuration",
   "type": "object",
   "required": ["version", "hooks"],
   "properties": {

--- a/docs/adr/ADR-008-security-mcp-server-architecture.md
+++ b/docs/adr/ADR-008-security-mcp-server-architecture.md
@@ -47,7 +47,7 @@ Security scanning currently operates in **isolation**:
 
 **Option Value:**
 - **Composability Premium:** MCP enables exponential value (N agents × M tools = N×M integrations)
-- **Platform Play:** Security MCP server positions JP Spec Kit as security platform, not just CLI
+- **Platform Play:** Security MCP server positions Specflow as security platform, not just CLI
 - **Competitive Moat:** First SDD toolkit with MCP-based security integration
 
 **Cost:**

--- a/docs/adr/ADR-009-codeql-mcp-integration.md
+++ b/docs/adr/ADR-009-codeql-mcp-integration.md
@@ -7,7 +7,7 @@
 
 ## Context
 
-JP Spec Kit currently integrates two SAST tools via MCP servers:
+Specflow currently integrates two SAST tools via MCP servers:
 - **Semgrep** (`@returntocorp/semgrep-mcp`) - Fast pattern-based scanning
 - **Trivy** (`@aquasecurity/trivy-mcp`) - Container/IaC security and SBOM
 
@@ -36,7 +36,7 @@ Integrate CodeQL via MCP server using the existing [codeql-mcp](https://github.c
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                      JP Spec Kit Agents                          │
+│                      Specflow Agents                          │
 ├─────────────────────────────────────────────────────────────────┤
 │  secure-by-design-engineer  │  backend-code-reviewer  │  ...    │
 │         ↓                   │           ↓             │         │

--- a/docs/adr/ADR-role-selection-during-initialization.md
+++ b/docs/adr/ADR-role-selection-during-initialization.md
@@ -145,7 +145,7 @@ specify init
 
 # Output:
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ JP Spec Kit - Project Initialization                        ┃
+┃ Specflow - Project Initialization                        ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 Select your primary role for command suggestions:

--- a/docs/adr/adr-session-start-hook.md
+++ b/docs/adr/adr-session-start-hook.md
@@ -7,7 +7,7 @@
 
 ## Context and Problem Statement
 
-Claude Code users working on JP Spec Kit projects need immediate context when starting or resuming a session. Without this context:
+Claude Code users working on Specflow projects need immediate context when starting or resuming a session. Without this context:
 
 1. Users don't know if critical dependencies (uv, backlog CLI) are available
 2. Users don't see which backlog tasks are actively in progress
@@ -90,7 +90,7 @@ Claude Code users working on JP Spec Kit projects need immediate context when st
 **Chosen Option**: SessionStart Hook (Option 1)
 
 **Rationale**:
-- Aligns with existing hook patterns in JP Spec Kit
+- Aligns with existing hook patterns in Specflow
 - Automatic execution provides best UX
 - Fail-open design ensures sessions never block
 - Fast performance meets timeout constraints
@@ -199,6 +199,6 @@ Comprehensive test suite at `.claude/hooks/test-session-start.sh`:
 ## References
 
 - [Claude Code Hooks Documentation](https://docs.anthropic.com/claude-code/hooks)
-- [JP Spec Kit CLAUDE.md](../../CLAUDE.md)
+- [Specflow CLAUDE.md](../../CLAUDE.md)
 - [Backlog User Guide](../guides/backlog-user-guide.md)
 - [Hook Test Patterns](.claude/hooks/test-hooks.sh)

--- a/docs/adr/constitution-role-based-command-standards.md
+++ b/docs/adr/constitution-role-based-command-standards.md
@@ -10,7 +10,7 @@
 
 ## Purpose
 
-This document defines the **constitutional standards** for role-based command namespaces in JP Spec Kit. These principles are intended to be incorporated into `/speckit.constitution` as authoritative rules that govern command creation, organization, and evolution.
+This document defines the **constitutional standards** for role-based command namespaces in Specflow. These principles are intended to be incorporated into `/speckit.constitution` as authoritative rules that govern command creation, organization, and evolution.
 
 ## What is speckit.constitution?
 
@@ -21,7 +21,7 @@ The **speckit.constitution** is the living document that defines:
 - Command and workflow conventions
 - Extensibility guidelines
 
-It serves as the **single source of truth** for how JP Spec Kit should be built and extended.
+It serves as the **single source of truth** for how Specflow should be built and extended.
 
 ---
 

--- a/docs/adr/design-command-migration-path.md
+++ b/docs/adr/design-command-migration-path.md
@@ -481,13 +481,13 @@ def migrate_commands(
 
 ### Announcement Template
 
-**Subject**: JP Spec Kit v2.0 - Role-Based Command Namespaces (Action Required)
+**Subject**: Specflow v2.0 - Role-Based Command Namespaces (Action Required)
 
 **Body**:
 ```
-Hi JP Spec Kit users,
+Hi Specflow users,
 
-We're excited to announce JP Spec Kit v2.0 with role-based command
+We're excited to announce Specflow v2.0 with role-based command
 namespaces for improved discoverability and developer experience.
 
 What's Changing:
@@ -510,7 +510,7 @@ Timeline:
 Migration Guide: https://jpspec.dev/docs/migration
 Questions? support@jpspec.dev
 
-Thanks for using JP Spec Kit!
+Thanks for using Specflow!
 The JP Spec Team
 ```
 


### PR DESCRIPTION
Updates 15 ADR files in docs/adr/ for Specflow branding.

Part of task-410 documentation overhaul.

🤖 Generated with [Claude Code](https://claude.com/claude-code)