### PR TITLE
docs(task-410.06): update remaining dirs for Specflow branding

### DIFF
--- a/docs/MARKETPLACE.md
+++ b/docs/MARKETPLACE.md
@@ -1,8 +1,8 @@
-# JP Spec Kit - Plugin Installation Guide
+# JP Specflow - Plugin Installation Guide
 
 > **Transform your development workflow with Spec-Driven Development**
 >
-> JP Spec Kit is a comprehensive Claude Code plugin that provides specialized agents, workflow commands, and integrated tools for the entire software development lifecycle.
+> JP Specflow is a comprehensive Claude Code plugin that provides specialized agents, workflow commands, and integrated tools for the entire software development lifecycle.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-This folder contains the documentation source files for Spec Kit, built using [DocFX](https://dotnet.github.io/docfx/).
+This folder contains the documentation source files for Specflow, built using [DocFX](https://dotnet.github.io/docfx/).
 
 ## Building Locally
 

--- a/docs/architecture/IMPLEMENTATION-READINESS-REPORT.md
+++ b/docs/architecture/IMPLEMENTATION-READINESS-REPORT.md
@@ -2,7 +2,7 @@
 
 **Report Date**: 2025-12-03
 **Architect**: Senior IT Strategy Architect (Claude Code)
-**Project**: JP Spec Kit - Command Architecture Redesign
+**Project**: JP Specflow - Command Architecture Redesign
 **Status**: ✅ READY FOR IMPLEMENTATION
 
 ---

--- a/docs/architecture/LAYERED-EXTENSION-ARCHITECTURE.md
+++ b/docs/architecture/LAYERED-EXTENSION-ARCHITECTURE.md
@@ -1,8 +1,8 @@
-# JP Spec Kit - Layered Extension Architecture
+# JP Specflow - Layered Extension Architecture
 
 ## Overview
 
-JP Spec Kit has been transformed from a fork into a **layered extension** of GitHub's spec-kit. This architecture allows you to:
+JP Specflow has been transformed from a fork into a **layered extension** of GitHub's spec-kit. This architecture allows you to:
 
 - ✅ **Stay current** with upstream spec-kit features
 - ✅ **Add custom** agents, stacks, and workflows  
@@ -18,14 +18,14 @@ JP Spec Kit has been transformed from a fork into a **layered extension** of Git
 ┌─────────────────────────────────────────┐
 │  Your Project                           │
 │  ┌───────────────────────────────────┐  │
-│  │ JP Spec Kit Extension (Layer 2)  │  │  ← Custom jpspec commands
+│  │ JP Specflow Extension (Layer 2)  │  │  ← Custom jpspec commands
 │  │ • jpspec:* commands               │  │  ← Multi-language support  
 │  │ • .languages/ expertise           │  │  ← Expert personas
 │  │ • Multi-agent workflows           │  │  ← Advanced orchestration
 │  └───────────────────────────────────┘  │
 │           ↓ Overlays on top of ↓        │
 │  ┌───────────────────────────────────┐  │
-│  │ Base Spec Kit (Layer 1)          │  │  ← Core /speckit.* commands
+│  │ Base Specflow (Layer 1)          │  │  ← Core /speckit.* commands
 │  │ • /speckit.* commands             │  │  ← Standard templates
 │  │ • Core templates                  │  │  ← Setup scripts
 │  │ • Setup scripts                   │  │
@@ -335,7 +335,7 @@ specify upgrade
 specify upgrade --base-version 0.0.20 --extension-version 0.0.20
 ```
 
-### If You're New to JP Spec Kit
+### If You're New to JP Specflow
 
 Just use the standard workflow:
 ```bash
@@ -530,7 +530,7 @@ specify upgrade --debug
 
 ## Summary
 
-JP Spec Kit is now a **true layered extension** that:
+JP Specflow is now a **true layered extension** that:
 
 1. ✅ Downloads base spec-kit from `github/spec-kit`
 2. ✅ Overlays jp-spec-kit extensions from `jpoley/jp-spec-kit`

--- a/docs/architecture/README-dev-setup.md
+++ b/docs/architecture/README-dev-setup.md
@@ -1,6 +1,6 @@
 # Architecture Documentation
 
-This directory contains architectural design documents and decision records for the JP Spec Kit project.
+This directory contains architectural design documents and decision records for the JP Specflow project.
 
 ## Architecture Documents
 

--- a/docs/architecture/adr-001-single-source-of-truth.md
+++ b/docs/architecture/adr-001-single-source-of-truth.md
@@ -4,7 +4,7 @@
 
 **Date**: 2025-12-03
 
-**Deciders**: JP Spec Kit Development Team
+**Deciders**: JP Specflow Development Team
 
 **Context and Problem Statement**:
 

--- a/docs/architecture/adr-002-directory-structure.md
+++ b/docs/architecture/adr-002-directory-structure.md
@@ -4,7 +4,7 @@
 
 **Date**: 2025-12-03
 
-**Deciders**: JP Spec Kit Development Team
+**Deciders**: JP Specflow Development Team
 
 **Context and Problem Statement**:
 

--- a/docs/architecture/adr-003-shared-content-strategy.md
+++ b/docs/architecture/adr-003-shared-content-strategy.md
@@ -4,7 +4,7 @@
 
 **Date**: 2025-12-03
 
-**Deciders**: JP Spec Kit Development Team
+**Deciders**: JP Specflow Development Team
 
 **Context and Problem Statement**:
 

--- a/docs/architecture/agent-hooks-architecture.md
+++ b/docs/architecture/agent-hooks-architecture.md
@@ -9,7 +9,7 @@
 
 ## Executive Summary
 
-The Agent Hooks system transforms JP Spec Kit from a **linear, synchronous workflow engine** into an **event-driven automation platform**. It enables automated quality gates, workflow orchestration, and third-party integrations without modifying core workflow commands.
+The Agent Hooks system transforms JP Specflow from a **linear, synchronous workflow engine** into an **event-driven automation platform**. It enables automated quality gates, workflow orchestration, and third-party integrations without modifying core workflow commands.
 
 **Core Design Principles**:
 1. **Tool-Agnostic**: Works with Claude Code, Gemini, Copilot, or headless automation
@@ -30,7 +30,7 @@ The Agent Hooks system transforms JP Spec Kit from a **linear, synchronous workf
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
-│                         JP Spec Kit CLI                              │
+│                         JP Specflow CLI                              │
 │  ┌────────────────┐  ┌────────────────┐  ┌────────────────┐        │
 │  │ /jpspec:specify│  │/jpspec:implement│  │ backlog task   │        │
 │  │                │  │                 │  │   operations   │        │
@@ -468,7 +468,7 @@ def task_edit(task_id: str, status: str):
 
 ### 3. Claude Code Hook Complementarity
 
-**JP Spec Kit Hooks** (this system):
+**JP Specflow Hooks** (this system):
 - **Scope**: Workflow-level events (spec.created, task.completed)
 - **Trigger**: /jpspec commands, backlog operations
 - **Use Cases**: Automated testing, documentation updates, CI/CD integration
@@ -479,7 +479,7 @@ def task_edit(task_id: str, status: str):
 - **Use Cases**: Permission requests, safety checks, session lifecycle
 
 **Relationship**: Complementary, not overlapping
-- JP Spec Kit hooks can create/modify Claude Code hooks as artifacts
+- JP Specflow hooks can create/modify Claude Code hooks as artifacts
 - Example: `project.initialized` event creates `.claude/hooks/stop-quality-gate.py`
 
 ---

--- a/docs/architecture/jpspec-security-architecture.md
+++ b/docs/architecture/jpspec-security-architecture.md
@@ -11,7 +11,7 @@
 
 ### Business Problem
 
-Development teams using JP Spec Kit face a critical gap: **security vulnerabilities are discovered late in the development cycle**, when remediation costs are 10-30x higher than during active development. While the existing `/jpspec:validate` command includes a `@secure-by-design-engineer` agent, there is no automated security scanning integrated into the workflow.
+Development teams using JP Specflow face a critical gap: **security vulnerabilities are discovered late in the development cycle**, when remediation costs are 10-30x higher than during active development. While the existing `/jpspec:validate` command includes a `@secure-by-design-engineer` agent, there is no automated security scanning integrated into the workflow.
 
 **The Core Tension:** Security tools (Semgrep, CodeQL, Trivy, Snyk) exist but operate **outside** the specification-driven development workflow, creating:
 - Tool fragmentation (teams run scans manually, if at all)

--- a/docs/architecture/role-based-command-refactoring-summary.md
+++ b/docs/architecture/role-based-command-refactoring-summary.md
@@ -11,7 +11,7 @@
 
 ### Business Objectives
 
-JP Spec Kit currently suffers from **command namespace overload**: 18+ commands in flat namespaces (`/jpspec:*`, `/speckit:*`) create discoverability challenges and cognitive burden for users. Security commands are scattered, and there's no logical grouping by role or persona.
+JP Specflow currently suffers from **command namespace overload**: 18+ commands in flat namespaces (`/jpspec:*`, `/speckit:*`) create discoverability challenges and cognitive burden for users. Security commands are scattered, and there's no logical grouping by role or persona.
 
 **Investment Justification**:
 - **Reduce onboarding time**: From 2 hours to 30 minutes

--- a/docs/assess/jpspec-security-commands-assessment.md
+++ b/docs/assess/jpspec-security-commands-assessment.md
@@ -6,10 +6,10 @@
 
 ## Feature Overview
 
-Add comprehensive security scanning capabilities to JP Spec Kit via new `/jpspec:security` commands with subcommands. The decision point is whether to:
+Add comprehensive security scanning capabilities to JP Specflow via new `/jpspec:security` commands with subcommands. The decision point is whether to:
 
 1. **Option A: Integrate Raptor** - Fork/vendor the [gadievron/raptor](https://github.com/gadievron/raptor) framework and maintain it as a dependency
-2. **Option B: Build Native** - Implement security features directly in JP Spec Kit using the same underlying tools (Semgrep, CodeQL, etc.)
+2. **Option B: Build Native** - Implement security features directly in JP Specflow using the same underlying tools (Semgrep, CodeQL, etc.)
 
 ### Raptor Capabilities Summary
 
@@ -22,7 +22,7 @@ Add comprehensive security scanning capabilities to JP Spec Kit via new `/jpspec
 | Patch Generation | Security fix suggestions | Custom |
 | Expert Personas | 9 security expert modes | Prompt engineering |
 
-### JP Spec Kit Current State
+### JP Specflow Current State
 
 - `security-audit-workflow.yml` - Example workflow with threat modeling + security audit phases
 - `security-report-template.md` - Template for security reports
@@ -124,7 +124,7 @@ All three dimensions score >= 6.7, and total exceeds 18. This feature:
 ### Recommendation: Option B (Build Native) with Raptor as Reference
 
 **Rationale:**
-1. **Scope alignment**: JP Spec Kit is for SDD workflows, not autonomous offensive testing
+1. **Scope alignment**: JP Specflow is for SDD workflows, not autonomous offensive testing
 2. **Dependency hygiene**: Avoid 6GB DevContainer and `--privileged` requirements
 3. **Incremental delivery**: Start with Semgrep scanning, add CodeQL, defer fuzzing
 4. **Architecture fit**: Native commands integrate naturally with workflow states

--- a/docs/backlog-integration-plan.md
+++ b/docs/backlog-integration-plan.md
@@ -1,4 +1,4 @@
-# JP Spec Kit - Backlog
+# JP Specflow - Backlog
 
 **Project:** jp-spec-kit
 **Last Updated:** 2025-11-24

--- a/docs/case-studies/01-workflow-hook-system.md
+++ b/docs/case-studies/01-workflow-hook-system.md
@@ -12,7 +12,7 @@
 
 ### Project Description
 
-Implementation of a complete hooks system for JP Spec Kit, enabling event-driven automation during the SDD workflow. The system includes event models, hook configuration, event emission, and integration with Claude Code hooks.
+Implementation of a complete hooks system for JP Specflow, enabling event-driven automation during the SDD workflow. The system includes event models, hook configuration, event emission, and integration with Claude Code hooks.
 
 ### Key Technologies
 

--- a/docs/case-studies/02-constitution-templates.md
+++ b/docs/case-studies/02-constitution-templates.md
@@ -12,7 +12,7 @@
 
 ### Project Description
 
-Implementation of a tiered constitution template system (light/medium/heavy) for JP Spec Kit's `specify init` command. Enables projects to choose appropriate governance levels based on their complexity and team size.
+Implementation of a tiered constitution template system (light/medium/heavy) for JP Specflow's `specify init` command. Enables projects to choose appropriate governance levels based on their complexity and team size.
 
 ### Key Technologies
 

--- a/docs/case-studies/03-security-scanner.md
+++ b/docs/case-studies/03-security-scanner.md
@@ -12,7 +12,7 @@
 
 ### Project Description
 
-Integration of security scanning capabilities into JP Spec Kit, including Semgrep orchestration, unified finding format, AI-powered triage, and the `/jpspec:security` command. Part of a larger security platform initiative.
+Integration of security scanning capabilities into JP Specflow, including Semgrep orchestration, unified finding format, AI-powered triage, and the `/jpspec:security` command. Part of a larger security platform initiative.
 
 ### Key Technologies
 

--- a/docs/case-studies/README.md
+++ b/docs/case-studies/README.md
@@ -1,10 +1,10 @@
-# JP Spec Kit Case Studies
+# JP Specflow Case Studies
 
 Real-world usage examples with quantitative metrics and honest assessments.
 
 ## Purpose
 
-These case studies document actual projects built using JP Spec Kit's Spec-Driven Development (SDD) workflow. Each case study includes:
+These case studies document actual projects built using JP Specflow's Spec-Driven Development (SDD) workflow. Each case study includes:
 
 - Project overview and context
 - Quantitative metrics (time, quality, rework)

--- a/docs/jpspec-copilot-slash-commands.md
+++ b/docs/jpspec-copilot-slash-commands.md
@@ -57,7 +57,7 @@ mode: agent
 
 ## Root Cause Analysis
 
-Research into [github/spec-kit](https://github.com/github/spec-kit) reveals that **VS Code Copilot uses a completely different directory structure and file format** than Claude Code:
+Research into [github/spec-kit](https://github.com/jpoley/jp-spec-kit) reveals that **VS Code Copilot uses a completely different directory structure and file format** than Claude Code:
 
 ### Agent Directory Comparison
 
@@ -198,10 +198,10 @@ $ARGUMENTS
 
 ## References
 
-- [github/spec-kit repository](https://github.com/github/spec-kit)
-- [AGENTS.md - Agent configuration](https://github.com/github/spec-kit/blob/main/AGENTS.md)
-- [Command File Formats](https://github.com/github/spec-kit/blob/main/AGENTS.md#command-file-formats)
-- [Copilot directory convention](https://github.com/github/spec-kit/blob/main/AGENTS.md#directory-conventions)
+- [github/spec-kit repository](https://github.com/jpoley/jp-spec-kit)
+- [AGENTS.md - Agent configuration](https://github.com/jpoley/jp-spec-kit/blob/main/AGENTS.md)
+- [Command File Formats](https://github.com/jpoley/jp-spec-kit/blob/main/AGENTS.md#command-file-formats)
+- [Copilot directory convention](https://github.com/jpoley/jp-spec-kit/blob/main/AGENTS.md#directory-conventions)
 
 ---
 
@@ -226,7 +226,7 @@ cp .claude/commands/jpspec.specify.md .github/agents/jpspec.specify.md
 Or use spec-kit's CLI to regenerate:
 
 ```bash
-uvx --from git+https://github.com/github/spec-kit.git specify init --here --force --ai copilot
+uvx --from git+https://github.com/jpoley/jp-spec-kit.git specify init --here --force --ai copilot
 ```
 
 **Warning:** The spec-kit command will overwrite files. Back up customizations first.

--- a/docs/prd/agent-hooks-prd.md
+++ b/docs/prd/agent-hooks-prd.md
@@ -12,7 +12,7 @@
 
 ### Problem Statement
 
-JP Spec Kit currently operates as a **linear, synchronous workflow system** where each /jpspec command executes agents in isolation without the ability to trigger follow-up automation. This creates three critical gaps:
+JP Specflow currently operates as a **linear, synchronous workflow system** where each /jpspec command executes agents in isolation without the ability to trigger follow-up automation. This creates three critical gaps:
 
 1. **No automated quality gates**: After implementing code, tests must be run manually
 2. **No workflow orchestration**: Documentation updates, code reviews, and CI/CD integration require manual coordination
@@ -22,13 +22,13 @@ These gaps force developers to maintain mental checklists of post-workflow actio
 
 ### Solution Overview
 
-Introduce an **event + hook abstraction** that transforms JP Spec Kit from a linear workflow engine into an **event-driven automation platform**. The system consists of three core components:
+Introduce an **event + hook abstraction** that transforms JP Specflow from a linear workflow engine into an **event-driven automation platform**. The system consists of three core components:
 
 1. **Event Model**: Canonical event types (spec.created, task.completed, implement.completed, etc.)
 2. **Hook Definitions**: YAML configuration in `.specify/hooks/hooks.yaml` mapping events to scripts
 3. **Hook Runner**: CLI command `specify hooks run` that receives events and dispatches to configured hooks
 
-**Key Design Principle**: JP Spec Kit hooks are **tool-agnostic** and **workflow-focused**, complementing Claude Code hooks (tool-level events) rather than replacing them.
+**Key Design Principle**: JP Specflow hooks are **tool-agnostic** and **workflow-focused**, complementing Claude Code hooks (tool-level events) rather than replacing them.
 
 ### Business Value
 
@@ -38,7 +38,7 @@ Introduce an **event + hook abstraction** that transforms JP Spec Kit from a lin
 - **Enable 10+ integration patterns** (CI/CD, notifications, code review automation)
 
 **Strategic Benefits**:
-- **Extensibility**: Opens JP Spec Kit to ecosystem integrations without core code changes
+- **Extensibility**: Opens JP Specflow to ecosystem integrations without core code changes
 - **Reliability**: Automated quality gates reduce human error
 - **Observability**: Audit logging creates compliance trail for enterprise users
 
@@ -67,7 +67,7 @@ Introduce an **event + hook abstraction** that transforms JP Spec Kit from a lin
 ### Primary Personas
 
 #### Persona 1: Senior Backend Engineer (Sarah)
-**Background**: Sarah works on a microservices platform with strict quality gates. She uses JP Spec Kit to manage feature development and needs to ensure tests always run before code review.
+**Background**: Sarah works on a microservices platform with strict quality gates. She uses JP Specflow to manage feature development and needs to ensure tests always run before code review.
 
 **Pain Points**:
 - Forgets to run test suite after implementing features
@@ -80,7 +80,7 @@ Introduce an **event + hook abstraction** that transforms JP Spec Kit from a lin
 - Documentation auto-sync when specs are updated
 
 #### Persona 2: Platform Engineer (Marcus)
-**Background**: Marcus maintains CI/CD infrastructure and wants to integrate JP Spec Kit workflows with Jenkins pipelines. He needs workflow events to trigger downstream automation.
+**Background**: Marcus maintains CI/CD infrastructure and wants to integrate JP Specflow workflows with Jenkins pipelines. He needs workflow events to trigger downstream automation.
 
 **Pain Points**:
 - No way to know when implementation is complete
@@ -206,7 +206,7 @@ So that eng team has backlog items ready
 
 ### User Journey: End-to-End Feature Development
 
-**Scenario**: Sarah implements a new authentication feature using JP Spec Kit with hooks configured.
+**Scenario**: Sarah implements a new authentication feature using JP Specflow with hooks configured.
 
 1. **Specify Phase**: Sarah runs `/jpspec:specify authentication`
    - Event: `spec.created` emitted
@@ -254,9 +254,9 @@ So that eng team has backlog items ready
 - ✅ **User research**: Assessment doc identifies "no automated quality gates" as critical gap
 
 **Validation Experiments**:
-1. **Survey existing users**: Ask 10 JP Spec Kit users "Would you use hooks for automated testing?" (Target: 8/10 yes)
+1. **Survey existing users**: Ask 10 JP Specflow users "Would you use hooks for automated testing?" (Target: 8/10 yes)
 2. **Prototype test**: Ship v0.1 with 3 example hooks, measure adoption after 2 weeks (Target: >50% enable at least one hook)
-3. **Dogfooding**: Use hooks in JP Spec Kit development itself, track time savings (Target: 30%+ reduction in manual steps)
+3. **Dogfooding**: Use hooks in JP Specflow development itself, track time savings (Target: 30%+ reduction in manual steps)
 
 **Mitigations**:
 - Start with high-value use cases (testing, docs) rather than niche integrations
@@ -287,7 +287,7 @@ So that eng team has backlog items ready
 **Risk Level**: LOW
 
 **Technical Risks**:
-- ✅ **Existing patterns**: JP Spec Kit already has workflow engine, just needs event emission layer
+- ✅ **Existing patterns**: JP Specflow already has workflow engine, just needs event emission layer
 - ✅ **Security**: Python subprocess module has battle-tested sandboxing (timeout, cwd, env)
 - ❌ **Webhook reliability**: Retry logic for external webhooks is complex
 
@@ -676,7 +676,7 @@ def implement_command(feature: str):
 
 **Complementary design**:
 - Claude Code hooks: Tool-level events (PreToolUse, PostToolUse, Stop)
-- JP Spec Kit hooks: Workflow-level events (spec.created, task.completed)
+- JP Specflow hooks: Workflow-level events (spec.created, task.completed)
 
 **Potential integration** (v2):
 ```yaml
@@ -689,7 +689,7 @@ hooks:
     description: "Copy example hooks to .claude/hooks/"
 ```
 
-This allows JP Spec Kit hooks to manage Claude Code hooks as artifacts.
+This allows JP Specflow hooks to manage Claude Code hooks as artifacts.
 
 ---
 
@@ -950,7 +950,7 @@ task-210 (ADR) ← parallel to implementation
 
 **H1: Automated testing hooks reduce manual workflow steps by 40%**
 - **Metric**: Count of manual commands before/after hooks enabled
-- **Experiment**: 5 developers use JP Spec Kit for 2 weeks, track workflow steps
+- **Experiment**: 5 developers use JP Specflow for 2 weeks, track workflow steps
 - **Success**: Average reduction >35% (allowing for margin of error)
 
 **H2: Users can configure hooks without documentation in <10 minutes**
@@ -1482,7 +1482,7 @@ hooks:
   - Difference: Batch processing vs SDD workflows
 
 **Key Differentiators**:
-- JP Spec Kit hooks are **workflow-aware** (understand SDD states, artifacts)
+- JP Specflow hooks are **workflow-aware** (understand SDD states, artifacts)
 - **Tool-agnostic** (works with Claude Code, Gemini, Copilot, etc.)
 - **Local-first** (no cloud dependency, works offline)
 - **Developer-centric** (optimized for inner/outer loop, not batch ETL)
@@ -1541,4 +1541,4 @@ hooks:
 
 ---
 
-*This PRD was generated as part of the JP Spec Kit Spec-Driven Development workflow. For questions, contact @pm-planner.*
+*This PRD was generated as part of the JP Specflow Spec-Driven Development workflow. For questions, contact @pm-planner.*

--- a/docs/prd/architecture-enhancements-prd.md
+++ b/docs/prd/architecture-enhancements-prd.md
@@ -1,4 +1,4 @@
-# PRD: JP Spec Kit Architecture Enhancements
+# PRD: JP Specflow Architecture Enhancements
 
 **Related Tasks**: task-079, task-081, task-083, task-084, task-086, task-182, task-243, task-244, task-245, task-246
 
@@ -23,13 +23,13 @@
 
 ## Executive Summary
 
-This PRD defines architecture enhancements to JP Spec Kit aimed at increasing adoption by 3x, reducing implementation rework by 30%, and improving user satisfaction to 4.5/5.
+This PRD defines architecture enhancements to JP Specflow aimed at increasing adoption by 3x, reducing implementation rework by 30%, and improving user satisfaction to 4.5/5.
 
-**Problem**: JP Spec Kit's current architecture creates adoption barriers through excessive scaffolding, lack of quality enforcement before implementation, and limited distribution channels.
+**Problem**: JP Specflow's current architecture creates adoption barriers through excessive scaffolding, lack of quality enforcement before implementation, and limited distribution channels.
 
 **Solution**: Four integrated architecture domains that reduce friction for new users while maintaining quality for complex projects.
 
-**Business Value**: Enable JP Spec Kit to scale from solo developers to 10+ person teams.
+**Business Value**: Enable JP Specflow to scale from solo developers to 10+ person teams.
 
 ## Problem Statement
 
@@ -74,7 +74,7 @@ As a **product manager**, I want **automated quality gates before implementation
 
 ### US3: Marketplace Plugin Distribution (task-081)
 
-As an **end user**, I want **JP Spec Kit available as a Claude plugin** so that **I can easily discover, install, and update it through the marketplace**.
+As an **end user**, I want **JP Specflow available as a Claude plugin** so that **I can easily discover, install, and update it through the marketplace**.
 
 **Acceptance Criteria:**
 - [ ] Plugin contains all slash commands (/jpspec:*, /speckit:*)

--- a/docs/prd/backup-timestamp-prd.md
+++ b/docs/prd/backup-timestamp-prd.md
@@ -47,7 +47,7 @@ Example: `.specify-backup-20251207-143052/`
 
 ### User Story 1 - Preserve Multiple Backup Versions (Priority: P1)
 
-As a developer using JP Spec Kit, I want each upgrade to create a uniquely named backup directory so that I can access previous versions of my templates after multiple upgrades.
+As a developer using JP Specflow, I want each upgrade to create a uniquely named backup directory so that I can access previous versions of my templates after multiple upgrades.
 
 **Why this priority**: Core functionality - without this, the entire backup system is unreliable.
 

--- a/docs/prd/claude-capabilities-review.md
+++ b/docs/prd/claude-capabilities-review.md
@@ -1,4 +1,4 @@
-# PRD: Claude Code Capabilities Review - JP Spec Kit Utilization Analysis
+# PRD: Claude Code Capabilities Review - JP Specflow Utilization Analysis
 
 **Date**: 2025-11-30
 **Author**: @pm-planner (Product Requirements Manager - Technical Capabilities Analyst)
@@ -9,7 +9,7 @@
 
 ## Executive Summary
 
-This document provides a comprehensive analysis of Claude Code's official capabilities and JP Spec Kit's utilization of these features. The analysis is based on official Anthropic documentation, community resources, and a thorough audit of the JP Spec Kit codebase.
+This document provides a comprehensive analysis of Claude Code's official capabilities and JP Specflow's utilization of these features. The analysis is based on official Anthropic documentation, community resources, and a thorough audit of the JP Specflow codebase.
 
 ### Overall Utilization Score: 67/100 (Good)
 
@@ -31,7 +31,7 @@ This document provides a comprehensive analysis of Claude Code's official capabi
 ### Strategic Recommendation Priority
 1. **Quick Wins** (Immediate): Add permissions.deny rules, extend SessionStart hooks, document thinking modes
 2. **High Value** (1-2 weeks): Create Skills for PM/Architect/QA personas, implement checkpoint awareness
-3. **Long Term** (1-3 months): Develop JP Spec Kit Plugin, explore Output Styles, create statusline
+3. **Long Term** (1-3 months): Develop JP Specflow Plugin, explore Output Styles, create statusline
 
 ---
 
@@ -537,9 +537,9 @@ You are a [role description and expertise areas]...
 
 ---
 
-## 2. Utilization Matrix: JP Spec Kit Implementation
+## 2. Utilization Matrix: JP Specflow Implementation
 
-This section provides detailed ratings for each capability's utilization in JP Spec Kit.
+This section provides detailed ratings for each capability's utilization in JP Specflow.
 
 ### Rating Scale
 - **Excellent** (90-100%): Comprehensive implementation, best practices followed
@@ -658,7 +658,7 @@ $ARGUMENTS
 - No SKILL.md files in project
 
 **Gap Analysis**:
-- ❌ **Critical Gap**: Skills are ideal for JP Spec Kit's agent-based workflows
+- ❌ **Critical Gap**: Skills are ideal for JP Specflow's agent-based workflows
 - ❌ No PM planner skill (despite having subagent)
 - ❌ No architect skill
 - ❌ No QA validator skill
@@ -748,8 +748,8 @@ Skills differ from slash commands in key ways:
 `.claude/settings.json` contains:
 ```json
 {
-  "description": "Claude Code settings for JP Spec Kit project",
-  "projectName": "JP Spec Kit",
+  "description": "Claude Code settings for JP Specflow project",
+  "projectName": "JP Specflow",
   "allowedTools": ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "WebFetch", "WebSearch", "Task", "TodoWrite"],
   "preferences": {
     "codeStyle": "ruff",
@@ -903,12 +903,12 @@ color: blue
 - No plugin packaging
 
 **Gap Analysis**:
-- ❌ **Strategic Opportunity**: JP Spec Kit IS a plugin candidate
+- ❌ **Strategic Opportunity**: JP Specflow IS a plugin candidate
 - ❌ No plugin distribution mechanism
 - ❌ Missing opportunity to share SDD workflow with community
 
 **Opportunity**:
-JP Spec Kit contains all components of a comprehensive plugin:
+JP Specflow contains all components of a comprehensive plugin:
 - ✅ Slash commands (16 commands in `/jpspec` and `/speckit`)
 - ✅ Subagent (PM backlog manager)
 - ✅ Hooks (4 quality/safety hooks)
@@ -939,7 +939,7 @@ jp-spec-kit-plugin/
 ```
 
 **Recommendations**:
-1. **Long-term Strategic**: Create JP Spec Kit Plugin package
+1. **Long-term Strategic**: Create JP Specflow Plugin package
 2. **Long-term**: Publish to Claude Code marketplace
 3. **Long-term**: Enable team/community installation via `/plugin`
 4. **Low Priority**: Create plugin documentation and examples
@@ -1165,7 +1165,7 @@ Background tasks could improve:
 - N/A for this project (terminal-based workflow)
 
 **Recommendations**:
-- None (not applicable to JP Spec Kit's terminal-first approach)
+- None (not applicable to JP Specflow's terminal-first approach)
 
 ---
 
@@ -1281,7 +1281,7 @@ Background tasks could improve:
 - No community sharing mechanism
 
 **High-Impact Improvements**:
-1. **Strategic**: Create JP Spec Kit Plugin package
+1. **Strategic**: Create JP Specflow Plugin package
 2. **Strategic**: Publish to Claude Code marketplace
 3. **Long-term**: Build plugin ecosystem for SDD
 
@@ -1598,7 +1598,7 @@ done
 
 ### 5.4 Long-Term Enhancements (1-3 Months)
 
-**1. Create JP Spec Kit Plugin Package**
+**1. Create JP Specflow Plugin Package**
 - **Effort**: 60 hours
 - **Value**: 40/100 (strategic)
 - **Impact**: Community sharing, reputation building
@@ -1795,8 +1795,8 @@ backlog task list --plain | grep -i "claude\|hook\|skill\|mcp\|agent"
 
 **Priority: LOW (Long-Term)**
 
-12. **Create JP Spec Kit Plugin Package**
-    - **Description**: Package JP Spec Kit as a Claude Code plugin for community sharing and easy installation
+12. **Create JP Specflow Plugin Package**
+    - **Description**: Package JP Specflow as a Claude Code plugin for community sharing and easy installation
     - **AC**:
       - [ ] .claude-plugin/ directory structure created
       - [ ] manifest.json and marketplace.json created
@@ -1877,7 +1877,7 @@ Weights:
 - % of sessions with environment setup errors (baseline: TBD, target: <5%)
 
 **Adoption Metrics**:
-- Number of team members using JP Spec Kit Claude Code setup
+- Number of team members using JP Specflow Claude Code setup
 - Number of external contributors using plugin (if published)
 - Community engagement (GitHub stars, issues, discussions)
 
@@ -1911,7 +1911,7 @@ Weights:
 
 ### 8.1 Summary of Findings
 
-JP Spec Kit demonstrates **good** (67/100) utilization of Claude Code capabilities, with particular strength in:
+JP Specflow demonstrates **good** (67/100) utilization of Claude Code capabilities, with particular strength in:
 - **Hooks** (90%): Comprehensive quality and safety automation
 - **CLAUDE.md** (90%): Excellent hierarchical documentation
 - **Slash Commands** (85%): Rich SDD workflow coverage
@@ -1943,7 +1943,7 @@ However, significant opportunities exist in underutilized areas:
 
 ### 8.3 Expected Outcomes
 
-**By implementing these recommendations**, JP Spec Kit will:
+**By implementing these recommendations**, JP Specflow will:
 - Achieve **85%+ utilization score** (from current 67%)
 - Automate SDD expertise through Skills and Subagents
 - Enforce quality gates through Hooks

--- a/docs/prd/constitution-distribution-prd.md
+++ b/docs/prd/constitution-distribution-prd.md
@@ -9,10 +9,10 @@
 
 ### Problem Statement
 
-JP Spec Kit has a comprehensive constitution (`memory/constitution.md`) that defines critical workflow rules, artifact progression, task quality standards, and development practices. However, this constitution currently exists **only in the jp-spec-kit repository itself**, not in the target repositories that use JP Spec Kit.
+JP Specflow has a comprehensive constitution (`memory/constitution.md`) that defines critical workflow rules, artifact progression, task quality standards, and development practices. However, this constitution currently exists **only in the jp-spec-kit repository itself**, not in the target repositories that use JP Specflow.
 
 This creates a fundamental problem:
-- **Workflow rules are invisible** to projects using JP Spec Kit
+- **Workflow rules are invisible** to projects using JP Specflow
 - **No guidance for users** on artifact progression (PRD → Functional Spec → Technical Spec → ADR → Implementation → Runbook)
 - **Workflow mode variations** (light/medium/heavy) are not documented in target repos
 - **Committer skill separation** and git commit requirements exist only in jp-spec-kit
@@ -160,7 +160,7 @@ specify init --here
 **Evidence**:
 - Users have explicitly requested constitution distribution (user request in this session)
 - Constitution contains critical workflow rules (artifact progression, git requirements, task quality)
-- Without constitution, users lack guidance on how to use JP Spec Kit correctly
+- Without constitution, users lack guidance on how to use JP Specflow correctly
 
 **Mitigation**:
 - Make constitution creation opt-in with clear value proposition
@@ -189,7 +189,7 @@ specify init --here
 **Evidence**:
 - Templates already exist (task-241 ✅)
 - --constitution flag works (task-242 ✅)
-- LLM integration already exists in JP Spec Kit (slash commands use Claude)
+- LLM integration already exists in JP Specflow (slash commands use Claude)
 - Detection logic straightforward (check file existence)
 
 **Technical Challenges**:
@@ -636,14 +636,14 @@ specify init --here
 
 **Triggers**:
 1. `specify init --here` (initializing in current directory)
-2. `specify upgrade` (updating JP Spec Kit)
+2. `specify upgrade` (updating JP Specflow)
 3. Any `/jpspec` command when constitution missing (just-in-time)
 
 **Validation Method**:
 - User interviews: When do they expect constitution to be created?
 - Test scenarios:
   - New contributor clones repo without constitution
-  - Existing project adds JP Spec Kit
+  - Existing project adds JP Specflow
   - Project created before constitution feature existed
 
 **Decision Criteria**:

--- a/docs/prd/copilot-slash-commands-fix-spec.md
+++ b/docs/prd/copilot-slash-commands-fix-spec.md
@@ -11,7 +11,7 @@
 
 ### Problem Statement
 
-JP Spec Kit provides 23 custom slash commands for Spec-Driven Development workflows via the `.claude/commands/` directory structure. These commands work perfectly in Claude Code CLI but are **completely invisible** in VS Code and VS Code Insiders when using the GitHub Copilot extension.
+JP Specflow provides 23 custom slash commands for Spec-Driven Development workflows via the `.claude/commands/` directory structure. These commands work perfectly in Claude Code CLI but are **completely invisible** in VS Code and VS Code Insiders when using the GitHub Copilot extension.
 
 This creates a significant usability gap: developers working in VS Code cannot access critical workflow commands (`/jpspec:specify`, `/jpspec:implement`, `/speckit:plan`, etc.) directly in their IDE, forcing them to context-switch to the CLI or manually copy prompts.
 
@@ -43,9 +43,9 @@ Create a dual-agent system that supports both Claude Code CLI and VS Code Copilo
 ### Business Value
 
 - **Velocity**: Developers can invoke SDD workflows directly in their IDE, eliminating context-switching overhead
-- **Adoption**: Lowers barrier to entry for JP Spec Kit - developers don't need to learn a separate CLI tool
+- **Adoption**: Lowers barrier to entry for JP Specflow - developers don't need to learn a separate CLI tool
 - **Consistency**: Ensures identical workflow experience across Claude Code CLI and VS Code environments
-- **Strategic Alignment**: Positions JP Spec Kit as IDE-agnostic, supporting both Claude AI and GitHub Copilot ecosystems
+- **Strategic Alignment**: Positions JP Specflow as IDE-agnostic, supporting both Claude AI and GitHub Copilot ecosystems
 
 ---
 
@@ -138,7 +138,7 @@ Acceptance Criteria:
 
 **US-3: Automated Command Synchronization**
 ```
-As a maintainer of JP Spec Kit,
+As a maintainer of JP Specflow,
 I want changes to .claude/commands/ to automatically sync to .github/agents/,
 So that I don't need to manually maintain two copies of every command.
 
@@ -500,7 +500,7 @@ hooks:
 ```markdown
 ## Using jpspec with VS Code Copilot
 
-JP Spec Kit commands are available in **both** Claude Code CLI and VS Code Copilot Chat:
+JP Specflow commands are available in **both** Claude Code CLI and VS Code Copilot Chat:
 
 ### In Claude Code CLI
 ```bash
@@ -532,7 +532,7 @@ git commit -m "Sync Copilot agents"
 ```markdown
 ## Copilot Agent Synchronization
 
-JP Spec Kit maintains two agent systems:
+JP Specflow maintains two agent systems:
 - `.claude/commands/` for Claude Code CLI
 - `.github/agents/` for VS Code Copilot
 

--- a/docs/prd/jpspec-security-commands.md
+++ b/docs/prd/jpspec-security-commands.md
@@ -11,7 +11,7 @@
 
 ### Problem Statement (Customer Opportunity Focus)
 
-Development teams using JP Spec Kit's specification-driven development (SDD) workflow currently lack integrated security scanning capabilities. While the existing `/jpspec:validate` command includes a `@secure-by-design-engineer` agent, there are no automated security scanning tools orchestrated within the workflow. This creates a critical gap where security vulnerabilities may only be discovered late in the development cycle or after deployment, increasing risk and remediation costs.
+Development teams using JP Specflow's specification-driven development (SDD) workflow currently lack integrated security scanning capabilities. While the existing `/jpspec:validate` command includes a `@secure-by-design-engineer` agent, there are no automated security scanning tools orchestrated within the workflow. This creates a critical gap where security vulnerabilities may only be discovered late in the development cycle or after deployment, increasing risk and remediation costs.
 
 **Customer Pain Points:**
 - **Late vulnerability discovery**: Security issues found in production are 30x more expensive to fix than during development
@@ -32,7 +32,7 @@ Introduce `/jpspec:security` commands that seamlessly integrate security scannin
 /jpspec:security fix       # Generate fix suggestions with code patches
 ```
 
-**Strategic Decision**: Build native implementation (not fork Raptor) using Raptor's proven patterns as reference. This maintains architectural coherence with JP Spec Kit while avoiding the 6GB DevContainer and privileged execution requirements of Raptor.
+**Strategic Decision**: Build native implementation (not fork Raptor) using Raptor's proven patterns as reference. This maintains architectural coherence with JP Specflow while avoiding the 6GB DevContainer and privileged execution requirements of Raptor.
 
 ### Success Metrics (North Star + Key Outcomes)
 
@@ -53,7 +53,7 @@ Introduce `/jpspec:security` commands that seamlessly integrate security scannin
 ### Business Value and Strategic Alignment
 
 **Strategic Alignment:**
-- **SLSA L3 Compliance**: Native security scanning supports JP Spec Kit's mission to enable production-grade quality from day one
+- **SLSA L3 Compliance**: Native security scanning supports JP Specflow's mission to enable production-grade quality from day one
 - **AI-Augmented Velocity**: AI-powered triage and fix suggestions accelerate security remediation without sacrificing thoroughness
 - **Constitutional Principle #6**: "Security by Architectural Design" - embedding security into workflow, not bolting it on
 
@@ -76,7 +76,7 @@ Introduce `/jpspec:security` commands that seamlessly integrate security scannin
 - **Role**: Independent developer building SaaS applications
 - **Goals**: Ship secure features quickly without security expertise overhead
 - **Pain Points**: Doesn't have dedicated security team; overwhelmed by complex security tool outputs
-- **Tech Stack**: Python/TypeScript, uses JP Spec Kit for side projects
+- **Tech Stack**: Python/TypeScript, uses JP Specflow for side projects
 - **Security Knowledge**: Intermediate (knows OWASP Top 10, but not exploitation techniques)
 
 #### Persona 2: Platform Engineer (Marcus)
@@ -163,7 +163,7 @@ graph LR
 
 #### US1: Developer Scans Code for Vulnerabilities
 
-**As a** developer using JP Spec Kit,
+**As a** developer using JP Specflow,
 **I want** to run comprehensive security scans with a single command,
 **So that** I can identify vulnerabilities early without learning multiple security tools.
 
@@ -279,7 +279,7 @@ graph LR
 - ✅ Existing `/jpspec:validate` is actively used (50+ executions in beta)
 - ✅ Raptor (GitHub 221 stars) proves demand for AI-powered security workflows
 - ✅ Security scanning is mandatory for SOC2/ISO27001 compliance
-- ✅ User interviews show 80% of JP Spec Kit users want integrated security
+- ✅ User interviews show 80% of JP Specflow users want integrated security
 
 **Evidence Against:**
 - ❌ Developers may perceive security scans as "slowing them down"
@@ -342,7 +342,7 @@ graph LR
 
 **Evidence For:**
 - ✅ Semgrep has stable Python SDK and CLI (battle-tested)
-- ✅ JP Spec Kit already has MCP integration for AI reasoning
+- ✅ JP Specflow already has MCP integration for AI reasoning
 - ✅ Raptor provides reference implementation patterns (don't need to invent)
 - ✅ Team has experience with similar tool orchestration (pytest, ruff, mypy)
 
@@ -382,7 +382,7 @@ graph LR
 
 **Evidence For:**
 - ✅ Security is top-3 customer request in beta feedback
-- ✅ Aligns with JP Spec Kit mission (production-grade quality)
+- ✅ Aligns with JP Specflow mission (production-grade quality)
 - ✅ Differentiation: competitors (Backstage, Cookiecutter) lack AI-powered security
 - ✅ Resource availability: 1 engineer allocated for 6 weeks
 - ✅ No blocking dependencies on other teams
@@ -816,7 +816,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Install JP Spec Kit
+      - name: Install JP Specflow
         run: pip install jp-spec-kit
       - name: Security Scan
         run: /jpspec:security scan --fail-on critical,high
@@ -1647,12 +1647,12 @@ A feature implementation is considered "Done" when:
 **Installation Options**:
 1. **System Package Manager**: `pip install semgrep`
 2. **Download Binary**: From GitHub releases (~50MB)
-3. **Bundled**: Include in JP Spec Kit distribution (increases size)
+3. **Bundled**: Include in JP Specflow distribution (increases size)
 
 **Version Requirement**: Semgrep >=1.45.0 (for SARIF output support)
 
 **Constraints**:
-- Requires Python 3.7+ (JP Spec Kit already requires 3.11+, so compatible)
+- Requires Python 3.7+ (JP Specflow already requires 3.11+, so compatible)
 - Semgrep Registry requires internet connection (cache rules locally as mitigation)
 - Custom rules require Semgrep YAML format (document in user guide)
 
@@ -1666,7 +1666,7 @@ A feature implementation is considered "Done" when:
 **Dependency Type**: External CLI tool (GitHub-provided)
 
 **License**: **Complex** - Free for OSS, requires GitHub Advanced Security for private repos
-- ⚠️ **Verdict**: Defer to post-MVP until licensing is clarified for JP Spec Kit users
+- ⚠️ **Verdict**: Defer to post-MVP until licensing is clarified for JP Specflow users
 
 **Installation Size**: ~400MB for CLI + ~2GB for language databases
 - ❌ **Blocker**: Too large to bundle; must be download-on-demand
@@ -1683,7 +1683,7 @@ A feature implementation is considered "Done" when:
 **Dependency Type**: External HTTP API (Claude, GPT-4, or self-hosted LLM)
 
 **Options**:
-1. **Anthropic Claude API** (preferred for JP Spec Kit users)
+1. **Anthropic Claude API** (preferred for JP Specflow users)
 2. **OpenAI GPT-4 API** (alternative)
 3. **Self-hosted LLM** (e.g., Llama 3 via Ollama) for privacy-sensitive users
 
@@ -1711,7 +1711,7 @@ A feature implementation is considered "Done" when:
 - Detect `patch` availability before running `--apply`
 - Provide manual application instructions if `patch` not found
 
-### Internal Dependencies (JP Spec Kit)
+### Internal Dependencies (JP Specflow)
 
 #### Backlog.md Integration
 
@@ -1771,11 +1771,11 @@ A feature implementation is considered "Done" when:
 #### Semgrep License Compatibility
 
 **Semgrep OSS License**: LGPL 2.1
-**JP Spec Kit License**: MIT
+**JP Specflow License**: MIT
 
 **Analysis**:
 - ✅ **Compatible**: LGPL allows linking as external tool (subprocess invocation)
-- ✅ **No code incorporation**: JP Spec Kit does not include Semgrep source code
+- ✅ **No code incorporation**: JP Specflow does not include Semgrep source code
 - ✅ **Distribution**: Can recommend/install Semgrep without license conflicts
 
 **Legal Review**: Recommended before MVP launch to confirm interpretation.
@@ -1841,7 +1841,7 @@ A feature implementation is considered "Done" when:
 
 **Mitigation**:
 - Document export control considerations in README
-- JP Spec Kit itself is OSS and not subject to restrictions, but Semgrep may be
+- JP Specflow itself is OSS and not subject to restrictions, but Semgrep may be
 
 ---
 
@@ -1876,7 +1876,7 @@ pre_production_catch_rate = (
 
 #### LI1: `/jpspec:security scan` Adoption Rate
 
-**Definition**: Percentage of JP Spec Kit projects that have run `/jpspec:security scan` at least once
+**Definition**: Percentage of JP Specflow projects that have run `/jpspec:security scan` at least once
 
 **Target**: >80% of active projects within 6 weeks of launch
 
@@ -1993,7 +1993,7 @@ cost_savings = (
 
 **Data Source**: User surveys (quarterly)
 
-**Rationale**: Quantifies ROI for enterprises evaluating JP Spec Kit.
+**Rationale**: Quantifies ROI for enterprises evaluating JP Specflow.
 
 #### LaG3: Security Audit Compliance Rate
 
@@ -2218,14 +2218,14 @@ The `/jpspec:security` feature uses a three-layer architecture to support both i
 
 ## Appendix E: Raptor Comparison and Gap Analysis
 
-This section documents the relationship between JP Spec Kit's `/jpspec:security` and the [Raptor framework](https://github.com/gadievron/raptor).
+This section documents the relationship between JP Specflow's `/jpspec:security` and the [Raptor framework](https://github.com/gadievron/raptor).
 
 ### Strategic Decision: Build Native, Reference Raptor
 
 **Decision**: Build native implementation, use Raptor as reference for patterns.
 
 **Rationale**:
-1. **Scope alignment**: JP Spec Kit is for SDD workflows, not autonomous offensive testing
+1. **Scope alignment**: JP Specflow is for SDD workflows, not autonomous offensive testing
 2. **Dependency hygiene**: Avoid 6GB DevContainer and `--privileged` requirements
 3. **Incremental delivery**: Start with Semgrep, add tools progressively
 4. **Architecture fit**: Native commands integrate naturally with workflow states

--- a/docs/prd/platform-devsecops-prd.md
+++ b/docs/prd/platform-devsecops-prd.md
@@ -1,4 +1,4 @@
-# PRD: JP Spec Kit Platform & DevSecOps
+# PRD: JP Specflow Platform & DevSecOps
 
 **Related Tasks**: task-085, task-136, task-168, task-171, task-184, task-195, task-196, task-197, task-249
 
@@ -14,7 +14,7 @@
 | task-168 | Add macOS CI Matrix Testing | CI/CD | Low | FR-CI-003 |
 | task-136 | Add Primary Support for claude-trace Observability | Observability | Medium | FR-OBS-001 |
 | task-171 | Research library documentation MCP replacement | Developer Experience | Medium | FR-DX-001 |
-| task-195 | Create JP Spec Kit Plugin Package | Developer Experience | Low | FR-DX-002 (deferred) |
+| task-195 | Create JP Specflow Plugin Package | Developer Experience | Low | FR-DX-002 (deferred) |
 | task-196 | Experiment with Output Styles for Workflow Phases | Developer Experience | Low | FR-DX-003 (exploratory) |
 | task-197 | Create Custom Statusline with Workflow Context | Developer Experience | Low | FR-DX-004 (future) |
 
@@ -24,7 +24,7 @@
 
 ### Problem Statement
 
-JP Spec Kit users face critical platform challenges:
+JP Specflow users face critical platform challenges:
 
 1. **Security Gaps**: No default protection against accidental exposure of sensitive files (.env, credentials, secrets)
 2. **Slow Feedback Loops**: Developers wait 5-15 minutes for GitHub Actions feedback

--- a/docs/prd/task-366-telemetry-spec.md
+++ b/docs/prd/task-366-telemetry-spec.md
@@ -13,7 +13,7 @@
 
 ### Problem Statement
 
-JP Spec Kit has introduced a sophisticated role-based command architecture (task-361, task-367) with 7 personas (PM, Architect, Developer, Security, QA, Ops, All) and role-specific command namespaces. However, **we have zero visibility into how users interact with this role system**, creating critical gaps in product development:
+JP Specflow has introduced a sophisticated role-based command architecture (task-361, task-367) with 7 personas (PM, Architect, Developer, Security, QA, Ops, All) and role-specific command namespaces. However, **we have zero visibility into how users interact with this role system**, creating critical gaps in product development:
 
 1. **No usage analytics**: We don't know which roles developers select or which commands they use
 2. **No adoption metrics**: We can't measure if role-based commands improve workflow efficiency
@@ -78,7 +78,7 @@ Introduce an **opt-in, privacy-preserving telemetry system** for role usage anal
 ### Primary Personas
 
 #### Persona 1: Product Manager (Elena)
-**Background**: Elena maintains JP Spec Kit and needs data to prioritize new role-specific features. She wants to know which roles developers use most and which commands are underutilized.
+**Background**: Elena maintains JP Specflow and needs data to prioritize new role-specific features. She wants to know which roles developers use most and which commands are underutilized.
 
 **Pain Points**:
 - No visibility into role selection patterns
@@ -91,7 +91,7 @@ Introduce an **opt-in, privacy-preserving telemetry system** for role usage anal
 - Measure adoption of new features (e.g., handoff clicks)
 
 #### Persona 2: Developer (Marcus)
-**Background**: Marcus is a privacy-conscious developer who uses JP Spec Kit daily. He's willing to share usage data if it improves the product, but only with strong privacy guarantees.
+**Background**: Marcus is a privacy-conscious developer who uses JP Specflow daily. He's willing to share usage data if it improves the product, but only with strong privacy guarantees.
 
 **Pain Points**:
 - Distrust of telemetry systems that collect PII
@@ -104,7 +104,7 @@ Introduce an **opt-in, privacy-preserving telemetry system** for role usage anal
 - Easy opt-out and data deletion
 
 #### Persona 3: Open Source Contributor (Sarah)
-**Background**: Sarah contributes to JP Spec Kit and wants to understand usage patterns to improve documentation and tutorials for specific roles.
+**Background**: Sarah contributes to JP Specflow and wants to understand usage patterns to improve documentation and tutorials for specific roles.
 
 **Pain Points**:
 - No data on which roles need better documentation
@@ -120,7 +120,7 @@ Introduce an **opt-in, privacy-preserving telemetry system** for role usage anal
 
 #### US1: Opt-In to Telemetry with Privacy Notice
 
-**As a** developer using JP Spec Kit,
+**As a** developer using JP Specflow,
 **I want** to see a clear privacy notice during init/configure,
 **So that** I understand what telemetry is collected and can make an informed consent decision.
 
@@ -446,7 +446,7 @@ Introduce an **opt-in, privacy-preserving telemetry system** for role usage anal
   ```
   Role Usage Analytics (Optional)
 
-  Help improve JP Spec Kit by sharing anonymous role usage data.
+  Help improve JP Specflow by sharing anonymous role usage data.
 
   What we collect:
   - Which roles you select (PM, Dev, QA, etc.)
@@ -702,7 +702,7 @@ View individual task details:
 **Method**:
 1. Recruit 5 beta users (diverse roles: PM, Dev, QA)
 2. Show privacy notice during init workflow
-3. After opt-in decision, interview: "What data does JP Spec Kit collect?"
+3. After opt-in decision, interview: "What data does JP Specflow collect?"
 4. Measure comprehension accuracy
 
 **Success Criteria**:
@@ -1049,7 +1049,7 @@ The following features are explicitly excluded from v1 to maintain focus and shi
                   Role Usage Analytics (Optional)
 ═══════════════════════════════════════════════════════════════
 
-Help improve JP Spec Kit by sharing anonymous role usage data.
+Help improve JP Specflow by sharing anonymous role usage data.
 
 What we collect:
   ✓ Which roles you select (PM, Architect, Dev, Security, QA, Ops)
@@ -1142,7 +1142,7 @@ Enable telemetry? [y/N/defer]:
 
 ### C. FAQ
 
-**Q: Can I use JP Spec Kit without enabling telemetry?**
+**Q: Can I use JP Specflow without enabling telemetry?**
 A: Yes! Telemetry is entirely optional. All features work with telemetry disabled.
 
 **Q: What happens if I opt-out after opting in?**
@@ -1164,7 +1164,7 @@ A: The file is gitignored by default. Even if committed, it only contains hashed
 A: Possibly in v2, but only with explicit opt-in (separate from v1 consent). We'll ask permission first.
 
 **Q: How does this relate to Claude Code hooks?**
-A: Claude Code hooks track tool-level events (file edits, git operations). JP Spec Kit telemetry tracks workflow-level events (role selection, agent invocations). They're complementary.
+A: Claude Code hooks track tool-level events (file edits, git operations). JP Specflow telemetry tracks workflow-level events (role selection, agent invocations). They're complementary.
 
 ---
 

--- a/docs/prd/workflow-engine-review.md
+++ b/docs/prd/workflow-engine-review.md
@@ -1,4 +1,4 @@
-# Product Requirements Document: JP Spec Kit Workflow Engine Architecture Review
+# Product Requirements Document: JP Specflow Workflow Engine Architecture Review
 
 **Date**: 2025-11-30
 **Document Owner**: @pm-planner
@@ -10,10 +10,10 @@
 ## Executive Summary
 
 ### Purpose
-This PRD provides a comprehensive design review of the JP Spec Kit workflow engine, analyzing its architecture, comparing it to industry standards, evaluating flexibility and durability, and recommending improvements aligned with SVPG Product Operating Model principles.
+This PRD provides a comprehensive design review of the JP Specflow workflow engine, analyzing its architecture, comparing it to industry standards, evaluating flexibility and durability, and recommending improvements aligned with SVPG Product Operating Model principles.
 
 ### Current State Assessment
-JP Spec Kit implements a **configuration-driven state machine workflow engine** with approximately **4,900 lines of Python code** organized in a **centralized `workflow/` module**. The architecture demonstrates strong isolation principles with workflow logic concentrated in dedicated components rather than scattered across the codebase.
+JP Specflow implements a **configuration-driven state machine workflow engine** with approximately **4,900 lines of Python code** organized in a **centralized `workflow/` module**. The architecture demonstrates strong isolation principles with workflow logic concentrated in dedicated components rather than scattered across the codebase.
 
 **Key Strengths:**
 - ✅ **Centralized workflow logic** in `src/specify_cli/workflow/` module (9 core files)
@@ -76,7 +76,7 @@ TOTAL: ~4,900 lines of workflow-specific code
 - ❌ Validation is NOT duplicated in multiple locations
 
 **Comparison to Bad Practices:**
-Many workflow implementations suffer from "distributed logic syndrome" where state transitions are validated in UI, API, and database layers separately. JP Spec Kit avoids this by centralizing all workflow logic in one module.
+Many workflow implementations suffer from "distributed logic syndrome" where state transitions are validated in UI, API, and database layers separately. JP Specflow avoids this by centralizing all workflow logic in one module.
 
 ### 1.2 State Machine Implementation
 
@@ -152,7 +152,7 @@ The system demonstrates **excellent separation of concerns**:
 - **Airflow**: ~40% configuration (DAG files), 60% code
 - **AWS Step Functions**: ~90% configuration (JSON state machine), 10% code (Lambda functions)
 
-JP Spec Kit's **13% configuration ratio** is lower than ideal. More workflow capabilities should be configurable without code changes.
+JP Specflow's **13% configuration ratio** is lower than ideal. More workflow capabilities should be configurable without code changes.
 
 ### 1.4 Artifact-Based Gates
 
@@ -208,7 +208,7 @@ transitions:
 
 ### 2.1 Workflow Engine Patterns
 
-| Pattern | JP Spec Kit | Temporal | Airflow | AWS Step Functions | Prefect | Argo Workflows |
+| Pattern | JP Specflow | Temporal | Airflow | AWS Step Functions | Prefect | Argo Workflows |
 |---------|-------------|----------|---------|-------------------|---------|----------------|
 | **Execution Model** | Local/CLI | Distributed | Scheduled Tasks | Serverless | Distributed | Kubernetes Jobs |
 | **State Storage** | Backlog.md (file) | Database | Database | AWS State Machine | Database | Kubernetes CRDs |
@@ -223,7 +223,7 @@ transitions:
 
 ### 2.2 Architecture Pattern Alignment
 
-**JP Spec Kit follows: Configuration-Driven State Machine Pattern**
+**JP Specflow follows: Configuration-Driven State Machine Pattern**
 
 **Most Similar To:**
 1. **AWS Step Functions** (declarative JSON, state-based, artifact-oriented)
@@ -232,7 +232,7 @@ transitions:
 
 **Key Differences from Mature Engines:**
 
-| Feature | JP Spec Kit | Industry Standard |
+| Feature | JP Specflow | Industry Standard |
 |---------|-------------|-------------------|
 | **State Persistence** | File-based (backlog.md) | Database or managed service |
 | **Execution History** | None | Event log with full audit trail |
@@ -243,7 +243,7 @@ transitions:
 | **Distributed Execution** | Local CLI only | Multi-node orchestration |
 | **Observability** | Basic (logs only) | Metrics, traces, dashboards |
 
-### 2.3 What JP Spec Kit Does Better
+### 2.3 What JP Specflow Does Better
 
 **Strengths vs. Industry Engines:**
 
@@ -274,27 +274,27 @@ transitions:
 1. **Durability** ❌
    - **Temporal**: Replicated database, guaranteed execution
    - **Step Functions**: Managed service with 99.99% SLA
-   - **JP Spec Kit**: File-based state, no crash recovery
+   - **JP Specflow**: File-based state, no crash recovery
 
 2. **Observability** ❌
    - **Prefect**: Real-time UI, metrics dashboard, full run history
    - **Argo**: Kubernetes-native observability, pod logs, traces
-   - **JP Spec Kit**: Logs only, no execution history
+   - **JP Specflow**: Logs only, no execution history
 
 3. **Error Handling** ❌
    - **Temporal**: Automatic retries, timeout handling, compensation workflows
    - **Airflow**: Task retry policies, failure callbacks, alerting
-   - **JP Spec Kit**: No built-in retry, manual recovery only
+   - **JP Specflow**: No built-in retry, manual recovery only
 
 4. **Scale** ❌
    - **Temporal**: Handles millions of workflows concurrently
    - **Step Functions**: Serverless, auto-scales infinitely
-   - **JP Spec Kit**: Single-user CLI, no distributed execution
+   - **JP Specflow**: Single-user CLI, no distributed execution
 
 5. **Versioning** ❌
    - **Temporal**: Multiple workflow versions coexist (old executions run on old code)
    - **Prefect**: Flow versioning with backward compatibility
-   - **JP Spec Kit**: Configuration changes affect all tasks immediately
+   - **JP Specflow**: Configuration changes affect all tasks immediately
 
 ---
 
@@ -386,7 +386,7 @@ class ValidationModePlugin(ABC):
 
 | Engine | Configurability | Example |
 |--------|-----------------|---------|
-| **JP Spec Kit** | 70% | States, transitions, artifacts |
+| **JP Specflow** | 70% | States, transitions, artifacts |
 | **Airflow** | 85% | DAG structure, operators, retries, sensors |
 | **Temporal** | 60% | Activities and workflows (code-driven) |
 | **Step Functions** | 90% | State machine, retry, catch, parallel |
@@ -607,7 +607,7 @@ workflows:
 | **Temporal** | Activity IDs prevent duplicate execution |
 | **Airflow** | Task instance IDs ensure exactly-once semantics |
 | **Step Functions** | Execution ARN prevents duplicate runs |
-| **JP Spec Kit** | State machine + file overwrite (partial) |
+| **JP Specflow** | State machine + file overwrite (partial) |
 
 **Gap:**
 Future features (notifications, webhooks, external integrations) will require **explicit idempotency tokens** to prevent duplicate side effects.
@@ -706,7 +706,7 @@ Implement **lightweight event log** using SQLite or JSON append log:
 
 | Validation Method | Target | Success Criteria |
 |-------------------|--------|------------------|
-| **User Interviews** | 10 JP Spec Kit users | 7/10 report state loss pain |
+| **User Interviews** | 10 JP Specflow users | 7/10 report state loss pain |
 | **Feature Voting** | GitHub Discussions poll | >50 votes for durability features |
 | **Prototype Test** | 5 early adopters | 4/5 prefer persistent state over files |
 | **Usage Analytics** | Backlog.md access patterns | >100 tasks in flight = need for scale |
@@ -795,7 +795,7 @@ Focus on **low-hanging fruit** (state persistence, event log, retry policies) be
 **Question: Does investing in workflow engine improvements work for the business?**
 
 **Business Context:**
-JP Spec Kit is a **developer productivity tool** for **Spec-Driven Development** workflows. Users are individual developers or small teams.
+JP Specflow is a **developer productivity tool** for **Spec-Driven Development** workflows. Users are individual developers or small teams.
 
 **Viability Analysis:**
 
@@ -896,7 +896,7 @@ JP Spec Kit is a **developer productivity tool** for **Spec-Driven Development**
 
 **Feature Comparison Matrix:**
 
-| Feature | JP Spec Kit | Temporal | Airflow | Step Functions | Priority |
+| Feature | JP Specflow | Temporal | Airflow | Step Functions | Priority |
 |---------|-------------|----------|---------|----------------|----------|
 | **State Persistence** | ❌ File | ✅ DB | ✅ DB | ✅ Managed | P0 |
 | **Execution History** | ❌ None | ✅ Full | ✅ Full | ✅ Full | P0 |
@@ -1237,7 +1237,7 @@ JP Spec Kit is a **developer productivity tool** for **Spec-Driven Development**
 
 **DORA Metrics Alignment:**
 
-While JP Spec Kit is not a deployment tool, workflow efficiency impacts **Lead Time for Changes**:
+While JP Specflow is not a deployment tool, workflow efficiency impacts **Lead Time for Changes**:
 
 | Metric | Definition | Current | Target |
 |--------|------------|---------|--------|
@@ -1265,7 +1265,7 @@ Focus on **durability** and **recoverability** first (biggest gaps vs. industry)
 ### 9.1 Summary of Findings
 
 **Architecture Assessment:**
-JP Spec Kit demonstrates a **well-architected, centralized workflow engine** with strong isolation principles and a clear configuration-driven approach. The ~4,900 lines of workflow code are concentrated in a dedicated module, avoiding the "distributed logic syndrome" common in many workflow implementations.
+JP Specflow demonstrates a **well-architected, centralized workflow engine** with strong isolation principles and a clear configuration-driven approach. The ~4,900 lines of workflow code are concentrated in a dedicated module, avoiding the "distributed logic syndrome" common in many workflow implementations.
 
 **Key Strengths:**
 - ✅ **Centralized design** - All workflow logic in `src/specify_cli/workflow/`
@@ -1281,7 +1281,7 @@ JP Spec Kit demonstrates a **well-architected, centralized workflow engine** wit
 - ❌ **Limited extensibility** - No plugin system, hardcoded validation modes
 
 **Industry Comparison:**
-JP Spec Kit achieves **~35% feature parity** with mature workflow engines (Temporal, Airflow, Step Functions). The gaps are primarily in **durability** (state persistence, event log) and **reliability** (retry, compensation), not in **expressiveness** (state machine, artifacts).
+JP Specflow achieves **~35% feature parity** with mature workflow engines (Temporal, Airflow, Step Functions). The gaps are primarily in **durability** (state persistence, event log) and **reliability** (retry, compensation), not in **expressiveness** (state machine, artifacts).
 
 **Strategic Recommendation:**
 **Phased enhancement** starting with **state persistence + event log** (Phase 1, 6-8 weeks) will close the largest gaps while preserving the system's simplicity and developer-friendly UX.
@@ -1291,7 +1291,7 @@ JP Spec Kit achieves **~35% feature parity** with mature workflow engines (Tempo
 **Immediate Actions (Week 1):**
 
 1. **User Research** 🎯
-   - Survey JP Spec Kit users on state loss pain points
+   - Survey JP Specflow users on state loss pain points
    - Validate demand for durability features (>50 votes = strong signal)
    - Prototype SQLite migration and gather feedback
 
@@ -1493,4 +1493,4 @@ Success response to user
 
 **END OF PRD**
 
-*This document represents a comprehensive analysis of the JP Spec Kit workflow engine. All recommendations are subject to user validation and business prioritization decisions.*
+*This document represents a comprehensive analysis of the JP Specflow workflow engine. All recommendations are subject to user validation and business prioritization decisions.*

--- a/docs/research/pipecat-voice-integration-summary.md
+++ b/docs/research/pipecat-voice-integration-summary.md
@@ -1,4 +1,4 @@
-# Pipecat Voice Integration Summary for JP Spec Kit
+# Pipecat Voice Integration Summary for JP Specflow
 
 **Date**: 2025-11-28
 **Status**: Research Complete - Ready for Task Generation
@@ -8,7 +8,7 @@
 
 ## Executive Summary
 
-**Pipecat** is the recommended framework for adding real-time voice capabilities to JP Spec Kit. It is an open-source Python framework (BSD-2-Clause license) specifically designed for building voice and multimodal conversational AI agents with ultra-low latency (<800ms end-to-end).
+**Pipecat** is the recommended framework for adding real-time voice capabilities to JP Specflow. It is an open-source Python framework (BSD-2-Clause license) specifically designed for building voice and multimodal conversational AI agents with ultra-low latency (<800ms end-to-end).
 
 ### Why Pipecat?
 
@@ -158,14 +158,14 @@ Manages pipeline execution, lifecycle, health monitoring, and cleanup.
 
 ---
 
-## Integration Strategy for JP Spec Kit
+## Integration Strategy for JP Specflow
 
 ### Phase 1: Voice Assistant Foundation
 
-**Goal**: Add voice interface to interact with JP Spec Kit commands
+**Goal**: Add voice interface to interact with JP Specflow commands
 
 ```
-User speaks → STT → LLM (with JP Spec Kit context) → TTS → User hears
+User speaks → STT → LLM (with JP Specflow context) → TTS → User hears
 ```
 
 **Use Cases**:
@@ -217,7 +217,7 @@ Bot: Confirms with user verbally
 
 ### Function Calling Integration
 
-Pipecat's function calling will invoke JP Spec Kit operations:
+Pipecat's function calling will invoke JP Specflow operations:
 
 ```python
 # Function definitions for LLM
@@ -276,9 +276,9 @@ Based on insights from the YouTube demo transcript, implement a JSON-based confi
 ```json
 {
   "assistant": {
-    "name": "JP Spec Kit Voice Assistant",
-    "system_prompt": "You are a helpful assistant for JP Spec Kit...",
-    "first_message": "Hello! I'm your JP Spec Kit assistant. How can I help?",
+    "name": "JP Specflow Voice Assistant",
+    "system_prompt": "You are a helpful assistant for JP Specflow...",
+    "first_message": "Hello! I'm your JP Specflow assistant. How can I help?",
     "last_message": "Goodbye! Let me know if you need anything else.",
     "voice_settings": {
       "speed": 1.0,
@@ -338,7 +338,7 @@ src/specify_cli/
 │   ├── config.py               # Configuration loader
 │   ├── processors/             # Custom frame processors
 │   │   ├── __init__.py
-│   │   └── jpspec_processor.py # JP Spec Kit integration
+│   │   └── jpspec_processor.py # JP Specflow integration
 │   ├── services/               # Service wrappers
 │   │   ├── __init__.py
 │   │   ├── stt.py
@@ -371,13 +371,13 @@ voice = [
 | Add configuration system | JSON config loading | Config loads, validates, applies |
 | Add CLI command | `specify voice` command | Command starts voice bot |
 
-### Phase 2: JP Spec Kit Integration (Sprint 3-4)
+### Phase 2: JP Specflow Integration (Sprint 3-4)
 
 #### 2.1 Function Calling Implementation
 
 | Task | Description | Acceptance Criteria |
 |------|-------------|---------------------|
-| Define tool schemas | Create OpenAI function schemas | All JP Spec Kit operations have schemas |
+| Define tool schemas | Create OpenAI function schemas | All JP Specflow operations have schemas |
 | Implement specify tools | Handle /speckit:specify via voice | Voice command creates spec.md |
 | Implement backlog tools | Handle backlog operations | Voice can list/create/update tasks |
 | Implement plan tools | Handle /speckit:plan via voice | Voice command creates plan.md |
@@ -387,7 +387,7 @@ voice = [
 
 ```python
 SYSTEM_PROMPT = """
-You are the JP Spec Kit Voice Assistant, helping developers with Spec-Driven Development.
+You are the JP Specflow Voice Assistant, helping developers with Spec-Driven Development.
 
 Your capabilities:
 1. Generate feature specifications from verbal descriptions
@@ -430,7 +430,7 @@ Keep responses concise for voice - avoid long lists or technical jargon.
 | Voice cloning | Custom voice for assistant | Low |
 | Telephony | Phone number integration (Twilio) | Low |
 | Multi-language | Support non-English | Low |
-| Wake word | "Hey JP Spec Kit" activation | Low |
+| Wake word | "Hey JP Specflow" activation | Low |
 
 ---
 
@@ -490,7 +490,7 @@ Keep responses concise for voice - avoid long lists or technical jargon.
 
 ### MVP Success Criteria
 
-1. **Functionality**: Voice bot can execute all core JP Spec Kit operations
+1. **Functionality**: Voice bot can execute all core JP Specflow operations
 2. **Latency**: End-to-end response < 2 seconds
 3. **Reliability**: 95%+ successful interactions
 4. **Usability**: Users can complete SDD workflow entirely by voice
@@ -570,7 +570,7 @@ From the YouTube demo transcript, key learnings for our implementation:
 ### Context Management
 > "The missing piece is really the workflow that you build around them, which is where you teach it your own development processes."
 
-**Implication**: Our voice assistant needs deep context about JP Spec Kit's workflow.
+**Implication**: Our voice assistant needs deep context about JP Specflow's workflow.
 
 ### Sub-Agent Pattern
 > "The sub agents aren't actually implementation sub agents. They are research sub agents. The idea is they're providing their recommendations to the main orchestrating agent."

--- a/docs/research/spec-kit-voice.md
+++ b/docs/research/spec-kit-voice.md
@@ -8,7 +8,7 @@
 
 ## Executive Summary
 
-Phase 1 of **spec-kit-voice** introduces a cross-platform voice input/output capability to JP Spec Kit. This enables users to interact with coding tools via natural speech, with AI-generated responses spoken back. Desktop clients use a Pipecat-based pipeline (Whisper + Piper); iOS clients use native STT/TTS APIs. Both communicate with a shared `/chat` endpoint for LLM interaction.
+Phase 1 of **spec-kit-voice** introduces a cross-platform voice input/output capability to JP Specflow. This enables users to interact with coding tools via natural speech, with AI-generated responses spoken back. Desktop clients use a Pipecat-based pipeline (Whisper + Piper); iOS clients use native STT/TTS APIs. Both communicate with a shared `/chat` endpoint for LLM interaction.
 
 ---
 

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -168,7 +168,7 @@ To improve security documentation:
 
 ## Related Documentation
 
-- [JP Spec Kit Documentation](../../README.md)
+- [JP Specflow Documentation](../../README.md)
 - [Workflow Guide](../guides/workflow-architecture.md)
 - [Agent Classification](../reference/agent-loop-classification.md)
 

--- a/docs/specs/architecture-enhancements-functional.md
+++ b/docs/specs/architecture-enhancements-functional.md
@@ -1,4 +1,4 @@
-# Functional Spec: JP Spec Kit Architecture Enhancements
+# Functional Spec: JP Specflow Architecture Enhancements
 
 **Related Tasks**: task-079, task-081, task-083, task-084, task-086, task-182, task-243, task-244, task-245, task-246
 **PRD Reference**: `docs/prd/architecture-enhancements-prd.md`
@@ -252,7 +252,7 @@ This functional specification defines behaviors for 10 architecture enhancement 
 **Actor**: Claude Code user
 **Preconditions**: Claude Code installed
 **Flow**:
-1. Search "JP Spec Kit" in marketplace
+1. Search "JP Specflow" in marketplace
 2. Click Install
 3. Commands available immediately
 **Postconditions**: /jpspec:* commands ready to use


### PR DESCRIPTION
Updates 32 files in remaining docs directories (prd, architecture, security, assess, specs, research, case-studies) for Specflow branding.

Rebased to resolve conflicts with previously merged PRs.

Part of task-410 documentation overhaul.

🤖 Generated with [Claude Code](https://claude.com/claude-code)