### PR TITLE
fix: implement PR-based release workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,15 +1,19 @@
 # Build and deploy DocFX documentation to GitHub Pages
+# Only deploys when a release is published (not on every push)
 name: Deploy Documentation to Pages
 
 on:
-  # Runs on pushes targeting the default branch
-  push:
-    branches: ["main"]
-    paths:
-      - 'docs/**'
+  # Deploy docs when a release is published
+  release:
+    types: [published]
 
-  # Allows you to run this workflow manually from the Actions tab
+  # Allow manual deployment from Actions tab
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to display in docs (e.g., 0.2.344). Leave empty to use latest release.'
+        required: false
+        type: string
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -32,6 +36,40 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all history for git info
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            # Use the release tag (strip leading 'v')
+            VERSION="${{ github.event.release.tag_name }}"
+            VERSION="${VERSION#v}"
+          elif [ -n "${{ inputs.version }}" ]; then
+            # Use manually specified version
+            VERSION="${{ inputs.version }}"
+          else
+            # Fall back to pyproject.toml version
+            VERSION=$(grep -Po '(?<=^version = ")[^"]*' pyproject.toml || echo "dev")
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Documentation version: $VERSION"
+
+      - name: Inject version into docfx.json
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Update docfx.json to include version in global metadata
+          # Using jq to safely modify JSON
+          jq --arg ver "$VERSION" '.build.globalMetadata._appVersion = $ver' docs/docfx.json > docs/docfx.json.tmp
+          mv docs/docfx.json.tmp docs/docfx.json
+
+          # Also update the footer to include version
+          jq --arg footer "Specflow v$VERSION - Specification-driven development for AI-augmented teams" \
+            '.build.globalMetadata._appFooter = $footer' docs/docfx.json > docs/docfx.json.tmp
+          mv docs/docfx.json.tmp docs/docfx.json
+
+          echo "Updated docfx.json with version $VERSION:"
+          jq '.build.globalMetadata' docs/docfx.json
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -69,3 +107,13 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
 
+      - name: Summary
+        run: |
+          echo "## Documentation Deployed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Documentation has been deployed to GitHub Pages." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "**Release**: ${{ github.event.release.tag_name }}" >> $GITHUB_STEP_SUMMARY
+            echo "**URL**: ${{ steps.deployment.outputs.page_url }}" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -1,0 +1,114 @@
+# Automatically create release tag when a release PR is merged
+# This workflow detects merged PRs from release/* branches and creates the git tag,
+# which then triggers the main release.yml workflow.
+
+name: Create Release Tag on Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  create-tag:
+    # Only run if PR was merged (not just closed) AND it's from a release branch
+    if: |
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from branch name
+        id: version
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          # Extract version from branch name (release/v0.2.344 -> v0.2.344)
+          VERSION="${BRANCH#release/}"
+          VERSION_NUM="${VERSION#v}"
+
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version_num=$VERSION_NUM" >> $GITHUB_OUTPUT
+
+          echo "Branch: $BRANCH"
+          echo "Tag to create: $VERSION"
+          echo "Version number: $VERSION_NUM"
+
+      - name: Verify version in source files
+        run: |
+          TAG_VERSION="${{ steps.version.outputs.version_num }}"
+
+          # Get version from pyproject.toml
+          TOML_VERSION=$(grep -Po '(?<=^version = ")[^"]*' pyproject.toml || echo "")
+
+          # Get version from __init__.py
+          INIT_VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' src/specify_cli/__init__.py || echo "")
+
+          echo "Expected version: $TAG_VERSION"
+          echo "pyproject.toml: $TOML_VERSION"
+          echo "__init__.py: $INIT_VERSION"
+
+          if [ "$TAG_VERSION" != "$TOML_VERSION" ]; then
+            echo "::error::Version mismatch! Expected: $TAG_VERSION, pyproject.toml: $TOML_VERSION"
+            exit 1
+          fi
+
+          if [ -n "$INIT_VERSION" ] && [ "$TAG_VERSION" != "$INIT_VERSION" ]; then
+            echo "::error::Version mismatch! Expected: $TAG_VERSION, __init__.py: $INIT_VERSION"
+            exit 1
+          fi
+
+          echo "Version files are in sync with release branch"
+
+      - name: Check if tag already exists
+        id: check_tag
+        run: |
+          TAG="${{ steps.version.outputs.version }}"
+          if git tag -l "$TAG" | grep -q .; then
+            echo "::error::Tag $TAG already exists!"
+            exit 1
+          fi
+          echo "Tag $TAG does not exist, proceeding"
+
+      - name: Create and push tag
+        run: |
+          TAG="${{ steps.version.outputs.version }}"
+
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Create annotated tag
+          git tag -a "$TAG" -m "Release $TAG"
+
+          # Push tag (this will trigger release.yml)
+          git push origin "$TAG"
+
+          echo "Created and pushed tag: $TAG"
+          echo "This will trigger the release workflow to build and publish the release."
+
+      - name: Summary
+        run: |
+          echo "## Release Tag Created" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| PR | #${{ github.event.pull_request.number }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Branch | ${{ steps.version.outputs.branch }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Tag | ${{ steps.version.outputs.version }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The release workflow will now build packages and create the GitHub Release." >> $GITHUB_STEP_SUMMARY
+
+      - name: Delete release branch
+        if: success()
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          echo "Deleting release branch: $BRANCH"
+          git push origin --delete "$BRANCH" || echo "Branch may have been deleted by PR merge settings"


### PR DESCRIPTION
## Summary
This PR replaces the direct-push-to-main release approach with a proper PR-based workflow that supports branch protection rules.

### Problem
The existing `scripts/release.py` assumed it could push directly to main with tags. This doesn't work when branch protection is enabled.

### Solution
Implement a complete PR-based release workflow:

```
┌─────────────────────────────────────────────────────────────────────────┐
│ NEW RELEASE FLOW                                                        │
├─────────────────────────────────────────────────────────────────────────┤
│                                                                         │
│  1. Developer runs:  ./scripts/release.py                               │
│       │                                                                 │
│       ▼                                                                 │
│  2. Creates branch: release/v0.2.344                                    │
│       │                                                                 │
│       ▼                                                                 │
│  3. Updates versions, commits                                           │
│       │                                                                 │
│       ▼                                                                 │
│  4. Pushes release branch + creates PR                                  │
│       │                                                                 │
│       ▼                                                                 │
│  5. CI runs (lint, test, version-check)                                 │
│       │                                                                 │
│       ▼                                                                 │
│  6. Human merges PR to main                                             │
│       │                                                                 │
│       ▼                                                                 │
│  7. release-on-merge.yml detects release PR merge                       │
│       │                                                                 │
│       ▼                                                                 │
│  8. Creates tag v0.2.344, pushes tag                                    │
│       │                                                                 │
│       ▼                                                                 │
│  9. release.yml triggers → Builds & publishes GitHub Release            │
│       │                                                                 │
│       ▼                                                                 │
│ 10. docs.yml triggers on release:published → Deploys docs               │
│                                                                         │
└─────────────────────────────────────────────────────────────────────────┘
```

### Changes

| File | Change |
|------|--------|
| `scripts/release.py` | Create release branch, push, create PR via `gh` CLI |
| `.github/workflows/release-on-merge.yml` | **NEW** - Detect merged release PRs, create tag |
| `.github/workflows/docs.yml` | Change trigger from `push` to `release:published`, inject version |

### Key Benefits
- ✅ Works with branch protection enabled
- ✅ PR provides review checkpoint before release
- ✅ CI validates release PR before merge
- ✅ Docs only deploy on actual releases (not every push)
- ✅ Version is prominently displayed in docs footer
- ✅ Release branch auto-cleaned after successful release

## Test plan
- [ ] Run `./scripts/release.py --dry-run` to verify workflow logic
- [ ] Create a test release to verify end-to-end flow
- [ ] Verify docs.yml doesn't trigger on regular main pushes
- [ ] Verify version appears in deployed documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)