### PR TITLE
Release v0.2.344

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "specify-cli"
 
-version = "0.2.343"
+version = "0.2.344"
 
 
 

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -599,7 +599,7 @@ BANNER = """
 """
 
 # Version - keep in sync with pyproject.toml
-__version__ = "0.2.343"
+__version__ = "0.2.344"
 
 # Constitution template version
 CONSTITUTION_VERSION = "1.0.0"


### PR DESCRIPTION
## Release v0.2.344

This PR releases version **0.2.344** of JP Spec Kit.

### Changes
- Version bump: `0.2.343` → `0.2.344`

### What happens when this PR is merged
1. GitHub Actions detects the merge of the `release/*` branch
2. Creates git tag `v0.2.344`
3. Triggers the release workflow:
   - Builds template packages for all supported AI assistants
   - Creates GitHub Release with all artifacts
   - Deploys documentation to GitHub Pages

### Checklist
- [ ] Version bump is correct
- [ ] CI checks pass
- [ ] Ready to release

---
*Generated by `./scripts/release.py`*
