### PR TITLE
fix(critical): task-428 /specflow commands installation failure

### DIFF
--- a/backlog/tasks/task-428 - CRITICAL-specflow-commands-installation-failure-forensic-analysis-and-fix.md
+++ b/backlog/tasks/task-428 - CRITICAL-specflow-commands-installation-failure-forensic-analysis-and-fix.md
@@ -1,0 +1,255 @@
+---
+id: task-428
+title: 'CRITICAL: /specflow commands installation failure - forensic analysis and fix'
+status: To Do
+assignee: []
+created_date: '2025-12-10 20:17'
+updated_date: '2025-12-10 20:52'
+labels:
+  - critical
+  - release
+  - specflow
+  - cli
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+# Critical Failure Analysis: /specflow Commands Not Working
+
+## Executive Summary
+
+Multiple cascading failures have resulted in users being unable to use `/specflow` commands when installing jp-spec-kit. This affects ALL new installations and reinstallations.
+
+## Root Cause Analysis
+
+### Failure #1: Release Tag Race Condition
+
+**What happened:** The v0.2.344 release was tagged on a commit (`8b0c8d6`) that **forked BEFORE** the specflow rename PR was merged.
+
+**Evidence:**
+```
+Git graph shows parallel paths:
+* d04de27 chore: release v0.2.344 (#722)   <-- CURRENT main
+* 9908e7d fix: PR-based release workflow (#721)
+* 8da08a6 feat!: rename /jpspec to /specflow (#719)  <-- SPECFLOW RENAME
+| * 8b0c8d6 chore: release v0.2.344        <-- v0.2.344 TAG HERE (WRONG!)
+|/  
+* ac228c2 docs(task-410.06): Specflow branding  <-- COMMON ANCESTOR
+```
+
+**Impact:** v0.2.344 release packages contain `/jpspec` commands, NOT `/specflow` commands.
+
+**Verification:**
+- `git merge-base --is-ancestor 8da08a6 v0.2.344` returns FALSE
+- v0.2.344 packages show `templates/commands/jpspec/` (no specflow)
+
+### Failure #2: Symlinks in Git Don't Work in GitHub Zipballs
+
+**What happened:** The `.claude/commands/` directory uses symlinks pointing to `../../../templates/commands/...`. GitHub zipballs convert these to text files containing the path string.
+
+**Evidence:**
+```bash
+# At v0.2.343, .claude/commands/jpspec/init.md is:
+$ git show v0.2.343:.claude/commands/jpspec/init.md
+../../../templates/commands/jpspec/init.md  # Just 46 bytes of text!
+
+# Should be 11,580 bytes of actual content
+```
+
+**Impact:** Anyone cloning the repo directly (not using release packages) gets broken commands that are just text files with paths.
+
+**Note:** This doesn't affect `specify init` users because that downloads RELEASE PACKAGES (which are generated from templates), not the repo zipball. But it affects:
+- Direct cloners
+- Developers working on the repo
+- CI/CD pipelines that clone
+
+### Failure #3: Incorrect Command Namespace in All Recent Releases
+
+**What happened:** Even v0.2.344 (today's release) generates packages with `/jpspec:*` commands instead of `/specflow:*`.
+
+**Evidence:**
+```bash
+$ unzip -l spec-kit-template-claude-sh-v0.2.344.zip | grep commands
+.claude/commands/jpspec/init.md      # WRONG - should be specflow
+.claude/commands/jpspec/specify.md   # WRONG
+.claude/commands/jpspec/plan.md      # WRONG
+```
+
+**Impact:** Users installing with `specify init` get commands like `/jpspec:init` which:
+1. Don't match the documentation (which says `/specflow:*`)
+2. Don't match the CLAUDE.md instructions
+3. Create massive user confusion
+
+### Failure #4: Version Display Issue (Needs Clarification)
+
+**User reported:** "it said jp-spec-kit was version 1.0.0"
+
+**Investigation:** The code has `CONSTITUTION_VERSION = "1.0.0"` which is for constitution templates, not the package version. Package version at v0.2.344 is correctly "0.2.344".
+
+**Possible causes:**
+- User may have seen constitution version instead of package version
+- May be a display bug in `specify init` output
+- May be from a different error path
+
+**ACTION NEEDED:** User clarification on where "1.0.0" was displayed.
+
+## Affected Users
+
+1. **ALL new `specify init` installations** - Get jpspec commands instead of specflow
+2. **ALL reinstallations** - Same issue
+3. **Direct repo cloners** - Get broken symlink text files
+4. **Developers** - Local development environment has broken symlinks
+
+## Timeline of Events
+
+| Date | Event | Commit | Issue |
+|------|-------|--------|-------|
+| Dec 7 | jpspec symlinks introduced | 520e124 | Symlinks don't work in zipballs |
+| Dec 10 9:37 | Specflow rename merged | 8da08a6 | -- |
+| Dec 10 ~10:00 | v0.2.344 release created | 8b0c8d6 | Tagged BEFORE rename merge |
+| Dec 10 ~11:00 | v0.2.344 packages built | -- | Built from wrong commit |
+
+## What Works vs What's Broken
+
+| Scenario | Status | Details |
+|----------|--------|---------|
+| `specify init --ai claude` | PARTIAL | Gets jpspec commands, not specflow |
+| `/specflow:init` command | BROKEN | Command doesn't exist in packages |
+| `/jpspec:init` command | WORKS | But deprecated/undocumented |
+| Direct repo clone | BROKEN | Symlinks become text files |
+| Documentation | INCORRECT | Says /specflow but users get /jpspec |
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Running `specify init --ai claude` creates project with `/specflow:*` commands
+- [ ] #2 All /specflow commands work as documented
+- [ ] #3 Release packages contain specflow directory (not jpspec)
+- [ ] #4 Direct repo clones have real files (not symlinks) in .claude/commands/
+- [ ] #5 Version numbers are correct and consistent
+- [ ] #6 Documentation matches actual behavior
+
+- [ ] #7 Release system MUST accept explicit commit hash parameter to prevent race conditions between branch creation and tag creation
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+## Implementation Plan
+
+### Phase 1: Replace Symlinks with Real Files (~30 min)
+**Problem solved:** Failure #2 - GitHub zipballs break symlinks
+
+**Directories to fix:**
+- `.claude/commands/specflow/` - Replace symlinks → real files
+- `.claude/commands/pm/` - Replace symlinks → real files
+- `.claude/commands/dev/` - Replace symlinks → real files
+- `.claude/commands/arch/` - Replace symlinks → real files
+- `.claude/commands/ops/` - Replace symlinks → real files
+- `.claude/commands/qa/` - Replace symlinks → real files
+- `.claude/commands/sec/` - Replace symlinks → real files
+- `.claude/commands/speckit/` - Replace symlinks → real files
+- `.claude/skills/` - Check and fix if symlinks
+
+**New files:**
+- `.github/workflows/check-command-sync.yml` - CI check that .claude/commands/ matches templates/commands/
+- `scripts/bash/sync-commands.sh` - Script to copy from templates/ to .claude/
+
+### Phase 2: Clean Up jpspec (~15 min)
+**Problem solved:** Failure #4 - DEPRECATED stubs confusing users
+
+**Files to delete:**
+- All `templates/commands/jpspec/_DEPRECATED_*.md` files
+- Archive or remove `templates/commands/jpspec/` directory
+
+**Files to modify:**
+- `.github/workflows/scripts/create-release-packages.sh` - Ensure jpspec excluded
+
+### Phase 3: Fix Release System (~45 min)
+**Problem solved:** Failures #1 and #5 - Race condition, unreliable releases
+
+**scripts/release.py changes:**
+- Add `--commit-hash` parameter (optional, defaults to HEAD)
+- Write commit hash to `.release-commit` file in release branch
+- Validate hash format
+
+**release-on-merge.yml changes:**
+- Read `.release-commit` file from merged PR
+- Tag THAT specific commit, not HEAD
+- Validate commit is ancestor of current HEAD
+- Fail with clear error if validation fails
+
+### Phase 4: Cut New Release (~15 min)
+- Run `./scripts/release.py --commit-hash $(git rev-parse HEAD)`
+- Verify PR contains correct commit reference
+- After merge, verify tag points to correct commit
+- Verify packages contain `/specflow` commands
+
+### Phase 5: Verification (~20 min)
+- Fresh install: `uv tool install specify-cli --from git+https://github.com/jpoley/jp-spec-kit.git`
+- Run: `specify init test-project --ai claude`
+- Verify `/specflow:*` commands present and functional
+- Verify `/pm:*` commands present and functional
+- Verify no `_DEPRECATED_` stubs in commands
+
+## Risk Mitigations
+
+1. **Breaking existing cloners:** Fix improves things - symlinks were already broken
+2. **Release system changes:** Test with dry-run before real release
+3. **Removing jpspec:** DEPRECATED stubs were broken anyway; document migration
+4. **CI sync friction:** Provide sync-commands.sh script with clear errors
+
+## Future Work (Separate Task)
+
+- task-430: `specflow-cli init` to replace `specify init` for AI tool management
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+## Additional Failure Mode: Fresh Install via `specify init`
+
+When user runs:
+```bash
+uv tool install specify-cli --from git+https://github.com/jpoley/jp-spec-kit.git
+specify init my-project --ai claude
+```
+
+They get:
+1. CLI installs correctly (from git main branch)
+2. `specify init` downloads RELEASE PACKAGES (v0.2.343 or v0.2.344)
+3. Release packages contain `/jpspec:*` commands, NOT `/specflow:*`
+4. User sees `/jpspec:_DEPRECATED_*` commands (confusing)
+5. Role-based commands (/pm, /dev, /arch) are MISSING
+
+## Why DEPRECATED Commands Appear
+
+The rename commit created `_DEPRECATED_*.md` stub files that say "use /pm:assess instead". These:
+1. Were meant as backward compatibility redirects
+2. Are showing up as primary commands because specflow commands don't exist in packages
+3. Are confusing users
+
+## Role-Based Commands Missing
+
+The /pm, /dev, /arch, /ops, /qa, /sec namespaces were supposed to be:
+- ADDITIONS (new way to invoke same functionality)
+- NOT deprecations of anything
+- Should coexist with /specflow commands
+
+But they're:
+1. Symlinks on origin/main (broken in git clones)
+2. NOT in release packages at all (built from old code)
+
+## Failure #5: Release System is Unreliable (CRITICAL)
+
+**User reported:** `./scripts/release.py` was run AFTER the specflow merge was on main, but the release was still built from old code.
+
+**Impact:** The release system cannot be trusted to release current main. The next release will have the same problem.
+
+**This MUST be fixed as part of this task** - without it, any fix we make won't actually get released correctly.
+
+**Root cause investigation needed** - but NOT until user approves the plan.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-429 - Create-specflow-CLI-ASCII-logo.md
+++ b/backlog/tasks/task-429 - Create-specflow-CLI-ASCII-logo.md
@@ -1,0 +1,19 @@
+---
+id: task-429
+title: Create specflow CLI ASCII logo
+status: To Do
+assignee: []
+created_date: '2025-12-10 20:51'
+labels:
+  - cli
+  - branding
+  - specflow
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create an ASCII art logo for the specflow CLI similar to what specify has. This will be displayed when running specflow-cli commands.
+<!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/task-430 - Create-specflow-cli-to-replace-specify-init-for-AI-tool-management.md
+++ b/backlog/tasks/task-430 - Create-specflow-cli-to-replace-specify-init-for-AI-tool-management.md
@@ -1,0 +1,39 @@
+---
+id: task-430
+title: Create specflow-cli to replace specify init for AI tool management
+status: To Do
+assignee: []
+created_date: '2025-12-10 20:52'
+labels:
+  - cli
+  - specflow
+  - enhancement
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a new `specflow-cli` command that:
+1. Replaces `specify init` for bootstrapping projects
+2. Handles adding AI tools to existing projects (re-ask which tools)
+3. Manages both AI tool setup AND constitution initialization
+4. Removes the need for users to know about `specify init`
+
+The goal is a single entry point:
+- `specflow init .` - Initialize current directory with AI tools + constitution
+- `specflow init my-project` - Create new project
+- `specflow init --add-ai copilot` - Add AI tool to existing project
+
+This task comes AFTER task-428 (critical fix) and task-429 (ASCII logo).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 specflow-cli init creates project with AI tool support
+- [ ] #2 specflow-cli init --add-ai adds AI tool to existing project
+- [ ] #3 specflow-cli init handles constitution setup
+- [ ] #4 specify init still works but specflow-cli is primary
+- [ ] #5 Documentation updated to recommend specflow-cli
+<!-- AC:END -->


### PR DESCRIPTION
## Summary

- Documents CRITICAL failure affecting ALL new installations of jp-spec-kit
- Complete root cause analysis of 5 cascading failures
- Implementation plan for fix
- Creates follow-up tasks (ASCII logo, specflow-cli)

## Critical Failures Identified

| # | Failure | Impact |
|---|---------|--------|
| 1 | **Tag race condition** | v0.2.344 tagged on wrong commit (before specflow merge) |
| 2 | **Symlinks → text files** | GitHub zipballs break symlinks in `.claude/commands/` |
| 3 | **Wrong namespace** | All packages have `/jpspec:*` not `/specflow:*` |
| 4 | **DEPRECATED stubs** | Backward compat stubs showing as primary commands |
| 5 | **Release system unreliable** | Can't trust release.py to release current main |

## Implementation Plan (5 Phases)

### Phase 1: Replace Symlinks with Real Files
- Replace all symlinks in `.claude/commands/` with real files
- Add CI check to keep files in sync with `templates/commands/`
- Add `scripts/bash/sync-commands.sh` helper script

### Phase 2: Clean Up jpspec
- Delete all `_DEPRECATED_*.md` files
- Archive or remove `templates/commands/jpspec/`
- Update release packaging scripts

### Phase 3: Fix Release System
- `scripts/release.py`: Add `--commit-hash` parameter
- Write commit hash to `.release-commit` file in release branch
- `release-on-merge.yml`: Tag specific commit, not HEAD
- Prevent race conditions between branch creation and tag creation

### Phase 4: Cut New Release
- Run fixed release.py with explicit commit hash
- Verify packages contain `/specflow` commands
- Test before publishing

### Phase 5: Verification
- Fresh install on clean machine
- Verify `/specflow:*` and `/pm:*` commands work

## Tasks Created

- **task-428**: This fix (CRITICAL)
- **task-429**: Specflow ASCII logo (medium)
- **task-430**: specflow-cli init to replace specify init (medium)

## Acceptance Criteria

- [ ] `specify init --ai claude` creates project with `/specflow:*` commands
- [ ] All /specflow commands work as documented
- [ ] Release packages contain specflow directory (not jpspec)
- [ ] Direct repo clones have real files (not symlinks)
- [ ] Version numbers correct and consistent
- [ ] Documentation matches actual behavior
- [ ] Release system accepts explicit commit hash parameter

## Test Plan

1. Review this plan
2. Execute phases 1-4 with commits
3. Cut new release v0.2.345
4. Test: `uv tool install specify-cli --from git+https://github.com/jpoley/jp-spec-kit.git`
5. Test: `specify init test-project --ai claude`
6. Verify: `/specflow:init`, `/pm:assess`, etc. all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)