### PR TITLE
fix(task-428): fix release tag race condition with --commit-hash

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -95,21 +95,58 @@ jobs:
           fi
           echo "Tag $TAG does not exist, proceeding"
 
+      - name: Read pinned release commit
+        id: release-commit
+        run: |
+          # Read the .release-commit file that was created by release.py
+          # This file contains the commit SHA that should be tagged
+          if [ ! -f ".release-commit" ]; then
+            echo "::warning::No .release-commit file found. Using HEAD for backward compatibility."
+            RELEASE_COMMIT=$(git rev-parse HEAD)
+          else
+            RELEASE_COMMIT=$(cat .release-commit | tr -d '[:space:]')
+          fi
+
+          # Validate the commit hash format (40 hex characters)
+          if ! [[ "$RELEASE_COMMIT" =~ ^[a-f0-9]{40}$ ]]; then
+            echo "::error::Invalid commit hash format in .release-commit: $RELEASE_COMMIT"
+            exit 1
+          fi
+
+          # Verify the commit exists
+          if ! git cat-file -e "$RELEASE_COMMIT^{commit}" 2>/dev/null; then
+            echo "::error::Commit $RELEASE_COMMIT does not exist in repository"
+            exit 1
+          fi
+
+          # Verify the commit is an ancestor of HEAD (i.e., it's part of history)
+          if ! git merge-base --is-ancestor "$RELEASE_COMMIT" HEAD; then
+            echo "::error::Commit $RELEASE_COMMIT is not an ancestor of HEAD"
+            echo "::error::This could indicate a race condition or incorrect commit hash"
+            exit 1
+          fi
+
+          echo "release_commit=$RELEASE_COMMIT" >> "$GITHUB_OUTPUT"
+          echo "Release commit: $RELEASE_COMMIT"
+          echo "Commit is verified as ancestor of HEAD"
+
       - name: Create and push tag
         env:
           TAG: ${{ steps.version.outputs.version }}
+          RELEASE_COMMIT: ${{ steps.release-commit.outputs.release_commit }}
         run: |
           # Configure git
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Create annotated tag
-          git tag -a "$TAG" -m "Release $TAG"
+          # Create annotated tag on the PINNED commit (not HEAD)
+          git tag -a "$TAG" "$RELEASE_COMMIT" -m "Release $TAG"
 
           # Push tag (this will trigger release.yml)
           git push origin "$TAG"
 
           echo "Created and pushed tag: $TAG"
+          echo "Tag points to commit: $RELEASE_COMMIT"
           echo "This will trigger the release workflow to build and publish the release."
 
       - name: Summary
@@ -117,6 +154,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BRANCH: ${{ steps.version.outputs.branch }}
           TAG: ${{ steps.version.outputs.version }}
+          RELEASE_COMMIT: ${{ steps.release-commit.outputs.release_commit }}
         run: |
           {
             echo "## Release Tag Created"
@@ -126,8 +164,11 @@ jobs:
             echo "| PR | #$PR_NUMBER |"
             echo "| Branch | $BRANCH |"
             echo "| Tag | $TAG |"
+            echo "| Tagged Commit | \`${RELEASE_COMMIT:0:8}\` |"
             echo ""
             echo "The release workflow will now build packages and create the GitHub Release."
+            echo ""
+            echo "**Note**: Tag was created on the pinned commit from \`.release-commit\`, not HEAD."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Delete release branch

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -9,6 +9,7 @@ Usage:
     ./scripts/release.py --major            # Bump major (0.2.343 → 1.0.0)
     ./scripts/release.py --dry-run          # Show what would happen
     ./scripts/release.py --create-pr        # Auto-create PR without confirmation
+    ./scripts/release.py --commit-hash abc123  # Pin release to specific commit
 
 This script:
 1. Determines the new version (auto-increment or specified)
@@ -224,6 +225,12 @@ Workflow:
         "--create-pr", action="store_true", help="Create PR without confirmation"
     )
     parser.add_argument("--force", action="store_true", help="Skip safety checks")
+    parser.add_argument(
+        "--commit-hash",
+        type=str,
+        help="Pin release to specific commit (defaults to HEAD). "
+        "Use this to prevent race conditions between PR creation and merge.",
+    )
 
     args = parser.parse_args()
 
@@ -257,6 +264,25 @@ Workflow:
     if not args.dry_run and not check_gh_cli():
         sys.exit(1)
     print("  GitHub CLI authenticated")
+
+    # Determine release commit
+    if args.commit_hash:
+        release_commit = args.commit_hash
+        # Validate it's a valid commit
+        result = run(
+            ["git", "rev-parse", "--verify", release_commit],
+            capture=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            print(f"\n Error: Invalid commit hash: {release_commit}")
+            sys.exit(1)
+        release_commit = result.stdout.strip()[:40]  # Full SHA
+        print(f"  Release pinned to commit: {release_commit[:8]}")
+    else:
+        result = run(["git", "rev-parse", "HEAD"], capture=True)
+        release_commit = result.stdout.strip()[:40]
+        print(f"  Release will use HEAD: {release_commit[:8]}")
 
     # Get current version
     print("\n Current state:")
@@ -302,9 +328,10 @@ Workflow:
         print(f"  1. Create branch: {release_branch}")
         print(f'  2. Update pyproject.toml: version = "{new_version}"')
         print(f'  3. Update __init__.py: __version__ = "{new_version}"')
-        print(f'  4. Commit: "chore: release v{new_version}"')
-        print(f"  5. Push branch: {release_branch}")
-        print(f'  6. Create PR: "Release v{new_version}" to main')
+        print(f"  4. Write .release-commit: {release_commit}")
+        print(f'  5. Commit: "chore: release v{new_version}"')
+        print(f"  6. Push branch: {release_branch}")
+        print(f'  7. Create PR: "Release v{new_version}" to main')
         print("\nNo changes made.")
         sys.exit(0)
 
@@ -327,9 +354,22 @@ Workflow:
     print("\n Updating version files:")
     update_version_files(new_version)
 
+    # Write .release-commit file (used by release-on-merge.yml to tag correct commit)
+    release_commit_file = Path(".release-commit")
+    release_commit_file.write_text(f"{release_commit}\n")
+    print(f"  .release-commit: {release_commit}")
+
     # Git operations
     print("\n Creating commit:")
-    run(["git", "add", "pyproject.toml", "src/specify_cli/__init__.py"])
+    run(
+        [
+            "git",
+            "add",
+            "pyproject.toml",
+            "src/specify_cli/__init__.py",
+            ".release-commit",
+        ]
+    )
     run(["git", "commit", "-m", f"chore: release v{new_version}"])
 
     # Push branch
@@ -346,16 +386,24 @@ This PR releases version **{new_version}** of JP Spec Kit.
 ### Changes
 - Version bump: `{current_version}` → `{new_version}`
 
+### Release Commit
+**Pinned commit**: `{release_commit}`
+
+This release will tag commit `{release_commit[:8]}` to prevent race conditions.
+The `.release-commit` file in this branch contains the full SHA.
+
 ### What happens when this PR is merged
 1. GitHub Actions detects the merge of the `release/*` branch
-2. Creates git tag `{tag_name}`
-3. Triggers the release workflow:
+2. Reads `.release-commit` to get the pinned commit SHA
+3. Creates git tag `{tag_name}` **on the pinned commit** (not HEAD)
+4. Triggers the release workflow:
    - Builds template packages for all supported AI assistants
    - Creates GitHub Release with all artifacts
    - Deploys documentation to GitHub Pages
 
 ### Checklist
 - [ ] Version bump is correct
+- [ ] Pinned commit is correct (should contain latest changes)
 - [ ] CI checks pass
 - [ ] Ready to release
 


### PR DESCRIPTION
## Summary

Fixes the release tag race condition that caused v0.2.344 to be tagged on the wrong commit.

### Root Cause

When a release PR is created, the intended commit to tag is captured. However, if `main` advances between PR creation and merge (e.g., other PRs merge), the release-on-merge workflow tags HEAD instead of the original intended commit.

### Solution

1. **`scripts/release.py`**: Added `--commit-hash` parameter to pin releases to a specific commit
   - Creates `.release-commit` file containing the SHA to tag
   - Validates the commit exists and is reachable

2. **`.github/workflows/release-on-merge.yml`**: Updated to read pinned commit
   - Reads `.release-commit` file to get target SHA
   - Tags the pinned commit instead of HEAD
   - Validates commit format and existence
   - Falls back to HEAD for backward compatibility

## Test Plan

1. Merge this PR
2. Create release with: `./scripts/release.py --commit-hash $(git rev-parse HEAD)`
3. Merge the release PR
4. Verify tag points to the pinned commit (not HEAD)

## Acceptance Criteria

- [x] `--commit-hash` parameter added to release.py
- [x] `.release-commit` file created during release
- [x] `release-on-merge.yml` reads and uses pinned commit
- [x] Validation ensures commit exists and is ancestor of HEAD
- [x] All CI checks pass

Fixes: task-428 (Failure #1: Release tag race condition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)