### PR TITLE
Release v0.2.345

### DIFF
--- a/.release-commit
+++ b/.release-commit
@@ -1,0 +1,1 @@
+88b6abc5e71cca9af83dc8a6d6c1efcd7ee04cd3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "specify-cli"
 
-version = "0.2.344"
+version = "0.2.345"
 
 
 

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -599,7 +599,7 @@ BANNER = """
 """
 
 # Version - keep in sync with pyproject.toml
-__version__ = "0.2.344"
+__version__ = "0.2.345"
 
 # Constitution template version
 CONSTITUTION_VERSION = "1.0.0"


### PR DESCRIPTION
## Release v0.2.345

This PR releases version **0.2.345** of JP Spec Kit.

### Changes
- Version bump: `0.2.344` → `0.2.345`

### Release Commit
**Pinned commit**: `88b6abc5e71cca9af83dc8a6d6c1efcd7ee04cd3`

This release will tag commit `88b6abc5` to prevent race conditions.
The `.release-commit` file in this branch contains the full SHA.

### What happens when this PR is merged
1. GitHub Actions detects the merge of the `release/*` branch
2. Reads `.release-commit` to get the pinned commit SHA
3. Creates git tag `v0.2.345` **on the pinned commit** (not HEAD)
4. Triggers the release workflow:
   - Builds template packages for all supported AI assistants
   - Creates GitHub Release with all artifacts
   - Deploys documentation to GitHub Pages

### Checklist
- [ ] Version bump is correct
- [ ] Pinned commit is correct (should contain latest changes)
- [ ] CI checks pass
- [ ] Ready to release

---
*Generated by `./scripts/release.py`*
