### PR TITLE
docs: command cleanup plan - 2 workflows + utilities

### DIFF
--- a/backlog/tasks/task-433 - Fix-incorrect-deprecation-mappings-specflow-is-primary,-role-commands-are-aliases.md
+++ b/backlog/tasks/task-433 - Fix-incorrect-deprecation-mappings-specflow-is-primary,-role-commands-are-aliases.md
@@ -6,6 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2025-12-10 22:20'
+updated_date: '2025-12-10 22:48'
 labels:
   - bug
   - commands
@@ -17,32 +18,46 @@ priority: high
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-The DEPRECATED commands have WRONG mappings. They tell users to use role-based commands (`/pm:define`, `/arch:design`, etc.) instead of `/specflow:*` commands.
+## Target Architecture
 
-**This is backwards.**
+**2 Workflows + Many Utilities**
 
-The rule is:
-- `/specflow` is the PRIMARY namespace - all SDD workflow functionality MUST be available here
-- Role-based commands (`/pm`, `/arch`, `/dev`, `/qa`, `/sec`, `/ops`) are OPTIONAL convenience aliases
-- `/specflow:specify` should NOT be deprecated - it's the canonical command
-- `/pm:define` is an ALIAS to `/specflow:specify`, not a replacement
+- `/speckit:*` - Lightweight SDD workflow (10 commands)
+- `/specflow:*` - Full agent-based SDD workflow (14 commands)
+- `/dev:*`, `/sec:*`, `/arch:*`, `/ops:*`, `/qa:*` - Stateless utilities (run anytime)
 
-Current WRONG deprecation messages:
-- `/specflow:_DEPRECATED_specify` → "Use /pm:define" ❌
-- `/specflow:_DEPRECATED_assess` → "Use /pm:assess" ❌  
-- `/specflow:_DEPRECATED_research` → "Use /pm:discover" ❌
-- `/specflow:_DEPRECATED_plan` → "Use /arch:design" ❌
-- `/specflow:_DEPRECATED_validate` → "Use /qa:verify" ❌
-- etc.
+## Problem
 
-**Fix**: Remove all `_DEPRECATED_*` files from `/specflow` namespace. The `/specflow:*` commands are NOT deprecated.
+The "role-based" reorganization made things worse:
+- 8 namespaces instead of 2 clear workflows
+- Deprecation warnings pointing users AWAY from specflow (wrong direction)
+- Duplicate commands scattered everywhere
+- PM work duplicated as both workflow AND role namespace
+
+## Solution
+
+1. **DELETE** all `_DEPRECATED_*.md` files (13 files) - wrong direction
+2. **DELETE** entire `/pm` namespace - PM work IS the workflow
+3. **DELETE** workflow duplicates from role namespaces:
+   - `/arch:design` → use `/specflow:plan`
+   - `/dev:build` → use `/specflow:implement`
+   - `/qa:verify` → use `/specflow:validate`
+   - `/ops:deploy` → use `/specflow:operate`
+   - `/sec:audit` → use `/specflow:security_workflow`
+4. **KEEP** utility commands in role namespaces (debug, refactor, scan, etc.)
+
+See: `docs/audit/command-cleanup-plan.md` for full implementation plan.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 All _DEPRECATED_*.md files removed from templates/commands/specflow/
-- [ ] #2 All _DEPRECATED_*.md symlinks removed from .claude/commands/specflow/
-- [ ] #3 /specflow:specify, /specflow:assess, /specflow:plan, /specflow:validate etc. work as primary commands
-- [ ] #4 Role-based commands (/pm:*, /arch:*, etc.) remain as optional aliases
-- [ ] #5 Documentation updated to clarify /specflow is primary namespace
+- [ ] #1 All 13 _DEPRECATED_*.md files deleted from templates/commands/specflow/
+- [ ] #2 Entire /pm namespace deleted (3 commands + symlink)
+- [ ] #3 Workflow duplicate commands deleted: /arch:design, /dev:build, /qa:verify, /ops:deploy, /sec:audit
+- [ ] #4 All symlinks in .claude/commands/ updated (no broken links)
+- [ ] #5 /specflow:* commands work as primary workflow (no deprecation warnings)
+
+- [ ] #6 Utility commands preserved: /dev:debug, /dev:refactor, /sec:scan, etc.
+- [ ] #7 Documentation updated (CLAUDE.md, guides)
+- [ ] #8 Command count reduced from 61 to 38
 <!-- AC:END -->

--- a/docs/audit/command-cleanup-plan.md
+++ b/docs/audit/command-cleanup-plan.md
@@ -1,0 +1,263 @@
+# Command Cleanup Plan
+
+**Date**: 2025-12-10
+**Status**: PROPOSED
+**Related**: task-433, `docs/audit/command-taxonomy-current-state.md`
+
+---
+
+## Target Architecture
+
+**2 Workflows + Many Utilities**
+
+```
+WORKFLOWS (stateful, sequential stages)
+├── /speckit:*    → Lightweight SDD workflow
+└── /specflow:*   → Full agent-based SDD workflow
+
+UTILITIES (stateless, run anytime)
+├── /dev:*        → Developer utilities
+├── /sec:*        → Security utilities
+├── /arch:*       → Architecture utilities
+├── /ops:*        → Operations utilities
+└── /qa:*         → QA utilities
+```
+
+---
+
+## Workflows
+
+### `/speckit:*` - Lightweight SDD
+
+Simple, script-based workflow for smaller features.
+
+| Command | Purpose | Keep/Change |
+|---------|---------|-------------|
+| `/speckit:init` | Initialize project | KEEP |
+| `/speckit:specify` | Create spec from natural language | KEEP |
+| `/speckit:clarify` | Refine spec with questions | KEEP |
+| `/speckit:plan` | Generate design artifacts | KEEP |
+| `/speckit:tasks` | Generate task backlog | KEEP |
+| `/speckit:implement` | Execute tasks | KEEP |
+| `/speckit:analyze` | Cross-artifact validation | KEEP |
+| `/speckit:checklist` | Generate feature checklist | KEEP |
+| `/speckit:constitution` | Generate constitution from tech stack | KEEP |
+| `/speckit:configure` | Configure workflow settings | KEEP |
+
+**Total: 10 commands - NO CHANGES**
+
+### `/specflow:*` - Full Agent-Based SDD
+
+Comprehensive workflow with specialized agents, workflow state, constitution checks.
+
+| Command | Purpose | Keep/Change |
+|---------|---------|-------------|
+| `/specflow:init` | Initialize constitution (greenfield/brownfield) | KEEP |
+| `/specflow:assess` | Evaluate SDD appropriateness | KEEP |
+| `/specflow:specify` | Full PRD with PM Planner agent | KEEP |
+| `/specflow:research` | Research and validation | KEEP |
+| `/specflow:plan` | Architecture planning with agents | KEEP |
+| `/specflow:implement` | Implementation with frontend/backend agents | KEEP |
+| `/specflow:validate` | QA and security validation | KEEP |
+| `/specflow:operate` | SRE operations workflow | KEEP |
+| `/specflow:reset` | Reset workflow configuration | KEEP |
+| `/specflow:security_workflow` | Security scanning integration | KEEP |
+| `/specflow:security_fix` | Apply security patches | KEEP |
+| `/specflow:security_report` | Generate security report | KEEP |
+| `/specflow:security_triage` | Triage security findings | KEEP |
+| `/specflow:security_web` | Web security scanning | KEEP |
+| `/specflow:prune-branch` | Git branch cleanup | MOVE to `/dev:cleanup` |
+
+**Total: 15 commands → 14 commands (move 1)**
+
+---
+
+## Utilities
+
+Stateless commands that can run anytime, outside of workflow context.
+
+### `/dev:*` - Developer Utilities
+
+| Command | Purpose | Action |
+|---------|---------|--------|
+| `/dev:debug` | Debugging assistance | KEEP |
+| `/dev:refactor` | Refactoring guidance | KEEP |
+| `/dev:cleanup` | Prune merged branches | KEEP (absorb `/specflow:prune-branch`) |
+| `/dev:build` | - | **DELETE** (duplicate of `/specflow:implement`) |
+
+### `/sec:*` - Security Utilities
+
+| Command | Purpose | Action |
+|---------|---------|--------|
+| `/sec:scan` | Security scanning | KEEP |
+| `/sec:triage` | Triage findings | KEEP |
+| `/sec:fix` | Apply patches | KEEP |
+| `/sec:report` | Generate report | KEEP |
+| `/sec:audit` | - | **DELETE** (duplicate of `/specflow:security_workflow`) |
+
+### `/arch:*` - Architecture Utilities
+
+| Command | Purpose | Action |
+|---------|---------|--------|
+| `/arch:decide` | Create ADRs | KEEP |
+| `/arch:model` | Create data models, API contracts | KEEP |
+| `/arch:design` | - | **DELETE** (duplicate of `/specflow:plan`) |
+
+### `/ops:*` - Operations Utilities
+
+| Command | Purpose | Action |
+|---------|---------|--------|
+| `/ops:monitor` | Setup monitoring | KEEP |
+| `/ops:respond` | Incident response | KEEP |
+| `/ops:scale` | Scaling guidance | KEEP |
+| `/ops:deploy` | - | **DELETE** (duplicate of `/specflow:operate`) |
+
+### `/qa:*` - QA Utilities
+
+| Command | Purpose | Action |
+|---------|---------|--------|
+| `/qa:test` | Execute tests | KEEP |
+| `/qa:review` | Generate checklist | KEEP |
+| `/qa:verify` | - | **DELETE** (duplicate of `/specflow:validate`) |
+
+### `/pm:*` - Product Manager
+
+| Command | Purpose | Action |
+|---------|---------|--------|
+| `/pm:assess` | - | **DELETE** (duplicate of `/specflow:assess`) |
+| `/pm:define` | - | **DELETE** (duplicate of `/specflow:specify`) |
+| `/pm:discover` | - | **DELETE** (duplicate of `/specflow:research`) |
+
+**DELETE ENTIRE NAMESPACE** - PM work IS the workflow.
+
+---
+
+## Files to Delete
+
+### Deprecated Command Files
+
+All `_DEPRECATED_*.md` files in `templates/commands/specflow/`:
+
+```
+templates/commands/specflow/_DEPRECATED_assess.md
+templates/commands/specflow/_DEPRECATED_implement.md
+templates/commands/specflow/_DEPRECATED_operate.md
+templates/commands/specflow/_DEPRECATED_plan.md
+templates/commands/specflow/_DEPRECATED_prune-branch.md
+templates/commands/specflow/_DEPRECATED_research.md
+templates/commands/specflow/_DEPRECATED_security_fix.md
+templates/commands/specflow/_DEPRECATED_security_report.md
+templates/commands/specflow/_DEPRECATED_security_triage.md
+templates/commands/specflow/_DEPRECATED_security_web.md
+templates/commands/specflow/_DEPRECATED_security_workflow.md
+templates/commands/specflow/_DEPRECATED_specify.md
+templates/commands/specflow/_DEPRECATED_validate.md
+```
+
+**Total: 13 files**
+
+### Workflow Duplicate Commands
+
+```
+templates/commands/pm/assess.md
+templates/commands/pm/define.md
+templates/commands/pm/discover.md
+templates/commands/arch/design.md
+templates/commands/dev/build.md
+templates/commands/qa/verify.md
+templates/commands/ops/deploy.md
+templates/commands/sec/audit.md
+```
+
+**Total: 8 files**
+
+### Entire Namespace
+
+```
+templates/commands/pm/           (entire directory)
+.claude/commands/pm              (symlink)
+```
+
+---
+
+## Symlinks to Update
+
+After deleting files, update `.claude/commands/`:
+
+```bash
+# Remove broken symlinks in specflow/
+rm .claude/commands/specflow/_DEPRECATED_*.md
+
+# Remove pm namespace entirely
+rm .claude/commands/pm
+
+# Keep other role namespaces (they still have utility commands)
+```
+
+---
+
+## Summary of Changes
+
+| Action | Count |
+|--------|-------|
+| Commands KEPT | 35 |
+| Commands DELETED | 21 |
+| Namespaces DELETED | 1 (`/pm`) |
+| Deprecated files DELETED | 13 |
+
+### Final Command Count by Namespace
+
+| Namespace | Before | After |
+|-----------|--------|-------|
+| `/speckit:*` | 10 | 10 |
+| `/specflow:*` | 29 | 14 |
+| `/pm:*` | 3 | **0 (deleted)** |
+| `/arch:*` | 3 | 2 |
+| `/dev:*` | 4 | 3 |
+| `/qa:*` | 3 | 2 |
+| `/sec:*` | 5 | 4 |
+| `/ops:*` | 4 | 3 |
+| **TOTAL** | **61** | **38** |
+
+---
+
+## Implementation Order
+
+1. **Delete deprecated files** (13 files)
+   - All `_DEPRECATED_*.md` in specflow
+   - Update symlinks
+
+2. **Delete `/pm` namespace** (3 files + symlink)
+   - `templates/commands/pm/` directory
+   - `.claude/commands/pm` symlink
+
+3. **Delete workflow duplicates** (5 files)
+   - `/arch:design`
+   - `/dev:build`
+   - `/qa:verify`
+   - `/ops:deploy`
+   - `/sec:audit`
+
+4. **Move `/specflow:prune-branch`** to `/dev:cleanup`
+   - Verify `/dev:cleanup` has same functionality
+   - Delete `/specflow:prune-branch`
+
+5. **Update documentation**
+   - CLAUDE.md command references
+   - Any guides referencing deleted commands
+
+6. **Test**
+   - Verify all kept commands work
+   - Verify no broken symlinks
+
+---
+
+## Rollback Plan
+
+If issues found:
+1. Git revert the cleanup commit
+2. All files restored from git history
+
+---
+
+*This plan requires approval before implementation.*


### PR DESCRIPTION
## Summary

Defines the target architecture for command cleanup:

**2 Workflows:**
- `/speckit:*` - Lightweight SDD (10 commands)
- `/specflow:*` - Full agent-based SDD (14 commands)

**Utilities (stateless, run anytime):**
- `/dev:debug`, `/dev:refactor`, `/dev:cleanup`
- `/sec:scan`, `/sec:triage`, `/sec:fix`, `/sec:report`
- `/arch:decide`, `/arch:model`
- `/ops:monitor`, `/ops:respond`, `/ops:scale`
- `/qa:test`, `/qa:review`

## What Gets Deleted

| Category | Count |
|----------|-------|
| `_DEPRECATED_*.md` files | 13 |
| `/pm` namespace (entire) | 3 |
| Workflow duplicates | 5 |
| **Total removed** | **21** |

## Result

- **Before**: 61 commands across 8 namespaces
- **After**: 38 commands across 7 namespaces (no `/pm`)

## Files

- `docs/audit/command-cleanup-plan.md` - Full implementation plan
- `backlog/tasks/task-433` - Updated with new acceptance criteria

## Next Steps

Review plan, then implement in separate PR.

---

Signed-off-by: Jason Poley <jason.poley@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)