### PR TITLE
fix(upgrade-tools): Update EXTENSION_REPO_NAME from jp-spec-kit to flowspec

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -614,7 +614,7 @@ BASE_REPO_NAME = "spec-kit"
 BASE_REPO_DEFAULT_VERSION = "latest"  # or specific version like "0.0.20"
 
 EXTENSION_REPO_OWNER = "jpoley"
-EXTENSION_REPO_NAME = "jp-spec-kit"
+EXTENSION_REPO_NAME = "flowspec"
 EXTENSION_REPO_DEFAULT_VERSION = "latest"
 
 # Marker file that identifies the jp-spec-kit source repository


### PR DESCRIPTION
## Summary
- Fix `specify upgrade-tools` version lookup failure after repository rename
- Update `EXTENSION_REPO_NAME` constant from `jp-spec-kit` to `flowspec`

## Problem
The GitHub repository was renamed from `jp-spec-kit` to `flowspec`, but the code still referenced the old name. The GitHub API returns a redirect for the old repo name which wasn't being followed, causing version lookup to fail with "Could not determine latest version".

## Test plan
- [ ] Run `specify upgrade-tools --dry-run` and verify jp-spec-kit shows correct available version
- [ ] Run `specify upgrade-tools` and verify upgrade works

🤖 Generated with [Claude Code](https://claude.com/claude-code)