### PR TITLE
fix: GitHub Pages deployment after flowspec rename

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -67,7 +67,7 @@
       "_enableSearch": true,
       "_disableContribution": false,
       "_gitContribute": {
-        "repo": "https://github.com/jpoley/jp-spec-kit",
+        "repo": "https://github.com/jpoley/flowspec",
         "branch": "main"
       }
     }


### PR DESCRIPTION
## Summary

- Update `docs/docfx.json` repo URL from `jp-spec-kit` to `flowspec` to fix broken "Edit this page" links
- Added `v*` tag pattern to `github-pages` environment deployment policies (via GitHub API) to allow release tag deployments

## Problem

After renaming the repository from `jp-spec-kit` to `flowspec`:
1. Release v0.2.348 deployment failed with: "Tag 'v0.2.348' is not allowed to deploy to github-pages due to environment protection rules"
2. The docfx.json still referenced the old repository URL

## Test plan

- [ ] Verify docs workflow runs successfully after merge
- [ ] Verify "Edit this page" links work correctly on deployed docs
- [ ] Manually trigger docs workflow or create a new release to test

🤖 Generated with [Claude Code](https://claude.com/claude-code)