### PR TITLE
feat(docker): add version tag publishing on release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,6 +2,8 @@ name: Docker Publish
 
 on:
   push:
+    tags:
+      - 'v*'  # Trigger on version tags (e.g., v0.2.349)
     branches: [main]
     paths:
       - '.devcontainer/Dockerfile'
@@ -49,6 +51,8 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=sha-
             type=ref,event=branch
 
@@ -83,10 +87,26 @@ jobs:
     needs: build-and-push
     runs-on: ubuntu-latest
     steps:
-      - name: Pull and verify image
+      - name: Determine image tag to verify
+        id: verify-tag
         run: |
-          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest zsh -c "
+          # For tag pushes, verify the version tag; otherwise verify latest
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            TAG="${{ github.ref_name }}"
+            # Remove 'v' prefix for semver tag (v0.2.349 -> 0.2.349)
+            TAG="${TAG#v}"
+          else
+            TAG="latest"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Will verify tag: $TAG"
+
+      - name: Pull and verify image
+        env:
+          VERIFY_TAG: ${{ steps.verify-tag.outputs.tag }}
+        run: |
+          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERIFY_TAG}
+          docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERIFY_TAG} zsh -c "
             echo '=== Verification ===' &&
             node --version &&
             pnpm --version &&


### PR DESCRIPTION
## Summary
- Add Docker image version tagging when releases are created
- Docker images now pushed with semver tags (e.g., `0.2.349`, `0.2`) in addition to `latest`
- Update verify step to test the correct tag based on trigger type

## Problem
Docker Scout reported no version-tagged images. Previously, the `docker-publish.yml` workflow only triggered on:
1. Pushes to `main` that modified Dockerfile-related files
2. Manual workflow_dispatch

This meant releases like `v0.2.349` never produced Docker images tagged `jpoley/flowspec-agents:0.2.349`.

## Solution
1. **Add tag trigger**: Workflow now also triggers on `v*` tag pushes (which happen during releases)
2. **Add semver patterns**: Using `docker/metadata-action` semver patterns to generate:
   - `{{version}}` → `0.2.349` (full version)
   - `{{major}}.{{minor}}` → `0.2` (minor version)
3. **Update verification**: Verify step now pulls the appropriate tag based on trigger type

## Test plan
- [ ] Merge this PR
- [ ] Create a new release (v0.2.350 or similar)
- [ ] Verify Docker Hub shows new version tags: `docker pull jpoley/flowspec-agents:0.2.350`
- [ ] Verify `0.2` tag is updated
- [ ] Verify `latest` tag still works on main branch pushes

## Expected Docker Hub tags after release v0.2.350
| Tag | When Created |
|-----|--------------|
| `0.2.350` | On release v0.2.350 |
| `0.2` | On release v0.2.x (updates with each minor release) |
| `latest` | On main branch push |
| `sha-xxxxxxx` | Every build |

Closes task-437

🤖 Generated with [Claude Code](https://claude.com/claude-code)