### PR TITLE
fix(cli): update branding from Specify to Flowspec

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -590,12 +590,12 @@ def has_constitution(path: Path) -> bool:
 CLAUDE_LOCAL_PATH = Path.home() / ".claude" / "local" / "claude"
 
 BANNER = """
-███████╗██████╗ ███████╗ ██████╗██╗███████╗██╗   ██╗
-██╔════╝██╔══██╗██╔════╝██╔════╝██║██╔════╝╚██╗ ██╔╝
-███████╗██████╔╝█████╗  ██║     ██║█████╗   ╚████╔╝ 
-╚════██║██╔═══╝ ██╔══╝  ██║     ██║██╔══╝    ╚██╔╝  
-███████║██║     ███████╗╚██████╗██║██║        ██║   
-╚══════╝╚═╝     ╚══════╝ ╚═════╝╚═╝╚═╝        ╚═╝   
+███████╗██╗      ██████╗ ██╗    ██╗███████╗██████╗ ███████╗ ██████╗
+██╔════╝██║     ██╔═══██╗██║    ██║██╔════╝██╔══██╗██╔════╝██╔════╝
+█████╗  ██║     ██║   ██║██║ █╗ ██║███████╗██████╔╝█████╗  ██║
+██╔══╝  ██║     ██║   ██║██║███╗██║╚════██║██╔═══╝ ██╔══╝  ██║
+██║     ███████╗╚██████╔╝╚███╔███╔╝███████║██║     ███████╗╚██████╗
+╚═╝     ╚══════╝ ╚═════╝  ╚══╝╚══╝ ╚══════╝╚═╝     ╚══════╝ ╚═════╝
 """
 
 # Version - keep in sync with pyproject.toml
@@ -605,7 +605,7 @@ __version__ = "0.2.351"
 CONSTITUTION_VERSION = "1.0.0"
 
 TAGLINE = (
-    f"(jp extension v{__version__}) GitHub Spec Kit - Spec-Driven Development Toolkit"
+    f"(flowspec v{__version__}) built on spec-kit & backlog.md - Spec-Driven Development with a Backlog"
 )
 
 # Repository configuration for two-stage download


### PR DESCRIPTION
## Summary
- Update ASCII banner from SPECIFY to FLOWSPEC
- Update tagline to reflect flowspec branding: `(flowspec v{version}) built on spec-kit & backlog.md - Spec-Driven Development with a Backlog`

## Test plan
- [x] Verified `specify --help` displays new FLOWSPEC banner
- [x] Verified tagline shows correct branding

🤖 Generated with [Claude Code](https://claude.com/claude-code)