### PR TITLE
chore: release v0.2.353

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "specify-cli"
 
-version = "0.2.352"
+version = "0.2.353"
 
 
 

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -599,14 +599,12 @@ BANNER = """
 """
 
 # Version - keep in sync with pyproject.toml
-__version__ = "0.2.352"
+__version__ = "0.2.353"
 
 # Constitution template version
 CONSTITUTION_VERSION = "1.0.0"
 
-TAGLINE = (
-    f"(flowspec v{__version__}) built on spec-kit & backlog.md - Spec-Driven Development with a Backlog"
-)
+TAGLINE = f"(flowspec v{__version__}) built on spec-kit & backlog.md - Spec-Driven Development with a Backlog"
 
 # Repository configuration for two-stage download
 BASE_REPO_OWNER = "github"


### PR DESCRIPTION
## Release v0.2.353

This PR releases version **0.2.353** of Flowspec.

### Changes
- Version bump: `0.2.352` → `0.2.353`

### What happens when this PR is merged
1. GitHub Actions detects the merge of the `release/*` branch
2. Tags the **merge commit** as `v0.2.353`
3. Builds template packages for all supported AI assistants
4. Creates GitHub Release with all artifacts

### Checklist
- [x] Version bump is correct
- [x] DCO signed
- [ ] CI checks pass
- [ ] Ready to release

---
*Generated by `./scripts/release.py`*