### PR TITLE
fix(hooks): use python3 instead of python for hook commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -36,7 +36,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python .claude/hooks/permission-auto-approve.py",
+            "command": "python3 .claude/hooks/permission-auto-approve.py",
             "timeout": 3
           }
         ]
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python .claude/hooks/pre-tool-use-sensitive-files.py",
+            "command": "python3 .claude/hooks/pre-tool-use-sensitive-files.py",
             "timeout": 5
           }
         ]
@@ -56,7 +56,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python .claude/hooks/pre-tool-use-git-safety.py",
+            "command": "python3 .claude/hooks/pre-tool-use-git-safety.py",
             "timeout": 5
           }
         ]
@@ -83,7 +83,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python .claude/hooks/post-slash-command-emit.py",
+            "command": "python3 .claude/hooks/post-slash-command-emit.py",
             "timeout": 35
           }
         ]
@@ -92,7 +92,7 @@
     "Stop": [
       {
         "type": "command",
-        "command": "python .claude/hooks/stop-quality-gate.py",
+        "command": "python3 .claude/hooks/stop-quality-gate.py",
         "timeout": 5
       }
     ]


### PR DESCRIPTION
## Summary
- Changed all Python hook commands from `python` to `python3` in `.claude/settings.json`
- Fixes hook execution on systems where only `python3` is available (no `python` symlink)

## Affected Hooks
- `permission-auto-approve.py`
- `pre-tool-use-sensitive-files.py`
- `pre-tool-use-git-safety.py`
- `post-slash-command-emit.py`
- `stop-quality-gate.py`

## Test plan
- [x] Verified `python3` is available on target system
- [x] Tested `stop-quality-gate.py` hook execution with `python3`
- [ ] Verify hooks work in new Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)