### PR TITLE
feat(memory): Task Memory steel thread with lifecycle hooks

### DIFF
--- a/.claude/hooks/post-tool-use-task-memory-lifecycle.py
+++ b/.claude/hooks/post-tool-use-task-memory-lifecycle.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Post-tool-use hook for task memory lifecycle management.
+
+This hook intercepts 'backlog task edit' Bash commands and triggers
+task memory lifecycle operations when task status changes are detected.
+
+Hook Integration:
+    - Type: PostToolUse
+    - Triggers on: Bash tool with 'backlog task edit' command
+    - Actions: Create/archive task memory based on status transitions
+
+State Transitions:
+    - To Do → In Progress: Create memory file
+    - In Progress → Done: Archive memory file
+    - Done → In Progress: Restore memory file from archive
+"""
+
+import json
+import logging
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+# Add src to path for imports
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root / "src"))
+
+from specify_cli.memory.lifecycle import LifecycleManager  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+
+def parse_backlog_command(command: str) -> Optional[Dict[str, Any]]:
+    """Parse backlog task edit command to extract status change information.
+
+    Args:
+        command: Full bash command string
+
+    Returns:
+        Dict with task_id, old_status, new_status if status change detected,
+        None otherwise
+
+    Example:
+        >>> parse_backlog_command("backlog task edit 370 -s 'In Progress'")
+        {'task_id': 'task-370', 'new_status': 'In Progress'}
+    """
+    # Pattern: backlog task edit <task-id> ... -s "status" or --status "status"
+    task_edit_pattern = r"backlog\s+task\s+edit\s+(\d+|task-\d+)"
+    status_pattern = r"(?:-s|--status)\s+['\"]?([^'\"]+)['\"]?"
+
+    # Check if this is a task edit command
+    task_match = re.search(task_edit_pattern, command)
+    if not task_match:
+        return None
+
+    task_id = task_match.group(1)
+    # Normalize to task-XXX format
+    if not task_id.startswith("task-"):
+        task_id = f"task-{task_id}"
+
+    # Check for status change
+    status_match = re.search(status_pattern, command)
+    if not status_match:
+        return None
+
+    new_status = status_match.group(1)
+
+    return {
+        "task_id": task_id,
+        "new_status": new_status,
+    }
+
+
+def infer_old_status(new_status: str, memory_exists: bool) -> Optional[str]:
+    """Infer the previous status based on new status and memory state.
+
+    Since PostToolUse runs AFTER the command, we can't get the true old status.
+    Instead, we infer it based on:
+    - The new target status
+    - Whether a task memory file exists
+
+    Args:
+        new_status: The new status being set
+        memory_exists: Whether task memory file exists
+
+    Returns:
+        Inferred old status for lifecycle management
+    """
+    new_lower = new_status.lower().strip()
+
+    # Case 1: Moving to "In Progress"
+    # - If memory exists, was probably already In Progress (no action needed)
+    # - If no memory, was probably To Do (create memory)
+    if new_lower == "in progress":
+        return "To Do" if not memory_exists else "In Progress"
+
+    # Case 2: Moving to "Done"
+    # - If memory exists, was probably In Progress (archive memory)
+    # - If no memory, was probably already Done or never started
+    if new_lower == "done":
+        return "In Progress" if memory_exists else "Done"
+
+    # Case 3: Moving to "To Do"
+    # - If memory exists, was probably In Progress (delete memory)
+    # - If no memory, was probably already To Do
+    if new_lower == "to do":
+        return "In Progress" if memory_exists else "To Do"
+
+    return None
+
+
+def get_task_current_status(task_id: str) -> Optional[str]:
+    """Get current status of a task (after the edit).
+
+    Note: Since this runs in PostToolUse, this returns the NEW status.
+    We use infer_old_status() instead to determine lifecycle actions.
+
+    Args:
+        task_id: Task identifier (e.g., "task-370")
+
+    Returns:
+        Current task status or None if task not found
+    """
+    try:
+        result = subprocess.run(
+            ["backlog", "task", task_id.replace("task-", ""), "--plain"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+
+        if result.returncode != 0:
+            logger.warning(f"Failed to get task status: {result.stderr}")
+            return None
+
+        # Parse status from output - looks for "Status: ..." line
+        status_match = re.search(r"Status:\s*([^\n]+)", result.stdout)
+        if status_match:
+            status = status_match.group(1).strip()
+            # Remove status icons (◯, ◒, ●)
+            status = re.sub(r"^[◯◒●✔✓]", "", status).strip()
+            return status
+
+        return None
+
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        logger.error(f"Error getting task status: {e}")
+        return None
+
+
+def get_task_title(task_id: str) -> str:
+    """Get task title for memory file creation.
+
+    Args:
+        task_id: Task identifier
+
+    Returns:
+        Task title or empty string if not found
+    """
+    try:
+        result = subprocess.run(
+            ["backlog", "task", task_id.replace("task-", ""), "--plain"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+
+        if result.returncode != 0:
+            return ""
+
+        # Parse title from output - looks for "Task task-XXX - <title>" line
+        title_match = re.search(r"Task\s+task-\d+\s+-\s+(.+)", result.stdout)
+        if title_match:
+            return title_match.group(1).strip()
+
+        return ""
+
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        logger.error(f"Error getting task title: {e}")
+        return ""
+
+
+def main() -> None:
+    """Main hook entry point.
+
+    Reads tool use event from stdin, checks for backlog task edit with
+    status change, and triggers lifecycle management if detected.
+
+    Exit codes:
+        0: Success (always - fail open)
+    """
+    try:
+        # Read tool use event from stdin
+        event_data = json.load(sys.stdin)
+
+        tool_name = event_data.get("tool_name", "")
+        tool_input = event_data.get("tool_input", {})
+
+        # Only process Bash tool commands
+        if tool_name != "Bash":
+            logger.debug("Not a Bash command, skipping")
+            return
+
+        command = tool_input.get("command", "")
+        if not command:
+            logger.debug("Empty command, skipping")
+            return
+
+        # Parse the command
+        parsed = parse_backlog_command(command)
+        if not parsed:
+            logger.debug("Not a backlog task edit with status change, skipping")
+            return
+
+        task_id = parsed["task_id"]
+        new_status = parsed["new_status"]
+
+        logger.info(f"Detected status change for {task_id} → {new_status}")
+
+        # Check if memory exists to infer old status
+        # Import here to avoid issues if specify_cli not installed
+        from specify_cli.memory.store import TaskMemoryStore
+
+        store = TaskMemoryStore()
+        memory_exists = store.exists(task_id)
+
+        # Infer old status based on new status and memory state
+        old_status = infer_old_status(new_status, memory_exists)
+        if old_status is None:
+            logger.warning(
+                f"Could not infer status transition for {task_id} → {new_status}"
+            )
+            return
+
+        logger.info(
+            f"Inferred transition: {old_status} → {new_status} (memory_exists={memory_exists})"
+        )
+
+        # Only trigger lifecycle if status actually changed
+        if old_status.lower() == new_status.lower():
+            logger.debug(
+                "No lifecycle action needed (status unchanged or no memory impact)"
+            )
+            return
+
+        # Get task title for memory creation
+        task_title = get_task_title(task_id)
+
+        # Trigger lifecycle manager
+        manager = LifecycleManager()
+        manager.on_state_change(task_id, old_status, new_status, task_title)
+
+        logger.info(
+            f"Task memory lifecycle hook completed for {task_id} ({old_status} → {new_status})"
+        )
+
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to parse tool use event: {e}")
+    except Exception as e:
+        logger.error(f"Unexpected error in lifecycle hook: {e}", exc_info=True)
+    finally:
+        # Always succeed - fail open to avoid breaking Claude workflow
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -87,6 +87,16 @@
             "timeout": 35
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/post-tool-use-task-memory-lifecycle.py",
+            "timeout": 10
+          }
+        ]
       }
     ],
     "Stop": [

--- a/.github/workflows/task-memory-validation.yml
+++ b/.github/workflows/task-memory-validation.yml
@@ -218,6 +218,52 @@ jobs:
               });
             }
 
+      - name: Validate AC coverage in memory files
+        id: ac_coverage
+        run: |
+          echo "Validating acceptance criteria coverage in task memories..."
+
+          # Check if memory files reference corresponding backlog tasks
+          # and if AC tracking is consistent
+          WARNINGS=0
+
+          if [ -d "backlog/memory" ] && [ -d "backlog/tasks" ]; then
+            for memory_file in backlog/memory/*.md; do
+              if [ -f "$memory_file" ]; then
+                # Extract task ID from filename (e.g., task-42.md -> task-42)
+                task_id=$(basename "$memory_file" .md)
+
+                # Find corresponding task file (supports various naming patterns)
+                task_file=$(find backlog/tasks -name "${task_id}*" -type f 2>/dev/null | head -1)
+
+                if [ -z "$task_file" ]; then
+                  echo "::warning file=$memory_file::No corresponding backlog task found for $task_id"
+                  WARNINGS=$((WARNINGS + 1))
+                  continue
+                fi
+
+                # Check if memory documents AC progress
+                # Look for patterns like "AC#1", "AC1:", "[x] #1", etc.
+                if grep -qiE "(AC#?[0-9]+|acceptance.criter)" "$memory_file"; then
+                  echo "✓ $task_id: Memory documents AC progress"
+                else
+                  echo "::notice file=$memory_file::Consider documenting AC progress in memory"
+                fi
+
+                # Check memory references task context
+                if grep -qi "context\|decision\|approach" "$memory_file"; then
+                  echo "✓ $task_id: Memory contains structured context"
+                fi
+              fi
+            done
+          fi
+
+          if [ $WARNINGS -gt 0 ]; then
+            echo "::notice::$WARNINGS memory file(s) have no corresponding backlog task"
+          fi
+
+          echo "✓ AC coverage validation complete"
+
       - name: Summary
         run: |
           echo "## Task Memory Validation Complete" >> $GITHUB_STEP_SUMMARY
@@ -225,3 +271,4 @@ jobs:
           echo "✓ Size validation passed" >> $GITHUB_STEP_SUMMARY
           echo "✓ Secret detection passed" >> $GITHUB_STEP_SUMMARY
           echo "✓ Format validation passed" >> $GITHUB_STEP_SUMMARY
+          echo "✓ AC coverage validation passed" >> $GITHUB_STEP_SUMMARY

--- a/backlog/CLAUDE.md
+++ b/backlog/CLAUDE.md
@@ -98,3 +98,7 @@ Tasks with labels `design`, `research`, `spike`, `architecture`:
 - User Guide: `docs/guides/backlog-user-guide.md`
 - Commands: `docs/reference/backlog-commands.md`
 - Flush/Archive: `docs/guides/backlog-flush.md`
+
+## Active Task Context
+
+@import ../memory/task-383.md

--- a/docs/guides/task-memory-cicd-integration.md
+++ b/docs/guides/task-memory-cicd-integration.md
@@ -1,0 +1,348 @@
+# Task Memory CI/CD Integration Guide
+
+**Version**: 1.0
+**Last Updated**: 2025-12-11
+
+## Overview
+
+This guide explains how Task Memory integrates with CI/CD pipelines to ensure memory files are valid, secure, and properly linked to backlog tasks. The integration provides automated validation on every PR and push.
+
+## Workflows
+
+Task Memory uses two GitHub Actions workflows:
+
+| Workflow | File | Purpose |
+|----------|------|---------|
+| Task Memory Validation | `.github/workflows/task-memory-validation.yml` | Comprehensive validation |
+| Memory Size Check | `.github/workflows/memory-size-check.yml` | Lightweight size monitoring |
+
+## Validation Checks
+
+### 1. Size Validation
+
+**Limits**:
+- Warning threshold: 25KB
+- Error threshold: 100KB (blocks merge)
+
+**Rationale**: Large memory files indicate accumulated context that should be refactored. They increase Claude Code context consumption and slow down agents.
+
+**CI Behavior**:
+```
+# Warning (non-blocking)
+::warning file=backlog/memory/task-42.md::Memory file exceeds 25KB: 28672 bytes
+
+# Error (blocking)
+::error file=backlog/memory/task-42.md::Memory file exceeds 100KB: 115200 bytes
+```
+
+**Resolution**:
+```bash
+# Compact the memory file
+specify memory compact task-42
+
+# Or manually archive and recreate
+mv backlog/memory/task-42.md backlog/memory/archive/task-42-v1.md
+backlog task edit task-42 -s "To Do"
+backlog task edit task-42 -s "In Progress"
+```
+
+### 2. Secret Detection (gitleaks)
+
+Scans memory files for accidentally committed secrets:
+
+**Detected Patterns**:
+- API keys and tokens
+- Passwords and credentials
+- AWS/GCP/Azure secrets
+- Private keys
+- Database connection strings
+
+**CI Behavior**:
+```
+::error::Secrets detected in task memory files!
+```
+
+**Resolution**:
+```bash
+# Edit memory to remove secrets
+nvim backlog/memory/task-42.md
+
+# Replace with reference
+# ❌ API_KEY=sk_live_abc123
+# ✓ API Key: See 1Password "Engineering Team" vault
+```
+
+### 3. Format Validation
+
+Ensures memory files follow the standard structure:
+
+**Checks**:
+- Filename format: `task-NNN.md`
+- Required header: `# Task Memory:`
+- Required section: `## Context`
+
+**CI Behavior**:
+```
+::warning file=backlog/memory/task-42.md::Missing '## Context' section
+::error file=backlog/memory/invalid.md::Invalid filename format
+```
+
+### 4. AC Coverage Validation
+
+Validates that memory files track acceptance criteria progress:
+
+**Checks**:
+- Memory file has corresponding backlog task
+- Memory documents AC progress (e.g., "AC#1", "acceptance criteria")
+- Memory contains structured context
+
+**CI Behavior**:
+```
+✓ task-42: Memory documents AC progress
+✓ task-42: Memory contains structured context
+::notice file=backlog/memory/task-99.md::Consider documenting AC progress
+```
+
+### 5. PR Comments
+
+Automatically posts memory change summary on PRs:
+
+```markdown
+## Task Memory Changes
+
+### Changed Files
+- `backlog/memory/task-42.md` (12KB)
+- `backlog/memory/task-43.md` (deleted)
+
+### Statistics
+- Files changed: 2
+- Total active memories: 15
+- Total size: 187KB
+```
+
+## Configuration
+
+### Workflow Triggers
+
+Both workflows trigger on:
+- Pull requests modifying `backlog/memory/**`
+- Push to `main` branch modifying `backlog/memory/**`
+
+```yaml
+on:
+  pull_request:
+    paths:
+      - 'backlog/memory/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'backlog/memory/**'
+```
+
+### Customizing Thresholds
+
+Edit `.github/workflows/task-memory-validation.yml`:
+
+```yaml
+- name: Check memory file sizes
+  run: |
+    MAX_SIZE=102400   # 100KB - change this
+    WARN_SIZE=25600   # 25KB - change this
+```
+
+### Disabling Checks
+
+To disable a specific check, comment out the step:
+
+```yaml
+# - name: Scan memory files for secrets
+#   run: |
+#     ...
+```
+
+## Local Validation
+
+Run the same checks locally before pushing:
+
+### Size Check
+```bash
+# Check all memory files
+for file in backlog/memory/*.md; do
+  size=$(stat -c%s "$file" 2>/dev/null || stat -f%z "$file")
+  size_kb=$((size / 1024))
+  echo "$file: ${size_kb}KB"
+done
+```
+
+### Secret Scan
+```bash
+# Install gitleaks
+brew install gitleaks  # macOS
+# or download from https://github.com/gitleaks/gitleaks/releases
+
+# Scan memory directory
+gitleaks detect --source=backlog/memory --no-git
+```
+
+### Format Check
+```bash
+# Check filename format
+for file in backlog/memory/*.md; do
+  filename=$(basename "$file")
+  if ! echo "$filename" | grep -qE '^task-[0-9]+\.md$'; then
+    echo "Invalid: $filename"
+  fi
+done
+
+# Check required sections
+for file in backlog/memory/*.md; do
+  grep -L "^# Task Memory:" "$file" 2>/dev/null
+  grep -L "^## Context" "$file" 2>/dev/null
+done
+```
+
+## Pre-commit Hook
+
+Add a pre-commit hook to validate locally:
+
+```bash
+# .git/hooks/pre-commit
+#!/bin/bash
+
+# Check for secrets in staged memory files
+STAGED_MEMORY=$(git diff --cached --name-only | grep '^backlog/memory/')
+
+if [ -n "$STAGED_MEMORY" ]; then
+  echo "Checking memory files for secrets..."
+
+  for file in $STAGED_MEMORY; do
+    if [ -f "$file" ]; then
+      # Check file size
+      size=$(stat -c%s "$file" 2>/dev/null || stat -f%z "$file")
+      if [ $size -gt 102400 ]; then
+        echo "ERROR: $file exceeds 100KB"
+        exit 1
+      fi
+
+      # Basic secret patterns
+      if grep -qiE '(api[_-]?key|secret|password)\s*[:=]\s*[^\s]{8,}' "$file"; then
+        echo "WARNING: Potential secret in $file"
+        echo "Review before committing."
+      fi
+    fi
+  done
+fi
+```
+
+Make it executable:
+```bash
+chmod +x .git/hooks/pre-commit
+```
+
+## GitHub Actions Summary
+
+After each run, a summary is posted to the Actions tab:
+
+```
+## Task Memory Validation Complete
+
+✓ Size validation passed
+✓ Secret detection passed
+✓ Format validation passed
+✓ AC coverage validation passed
+```
+
+## Troubleshooting
+
+### CI Fails: Memory File Too Large
+
+**Symptom**: `Memory file exceeds 100KB`
+
+**Solution**:
+1. Review the memory file for unnecessary content
+2. Move detailed research to `docs/research/`
+3. Archive old decisions
+4. Use `specify memory compact task-NNN`
+
+### CI Fails: Secrets Detected
+
+**Symptom**: `Secrets detected in task memory files!`
+
+**Solution**:
+1. Remove the secret from the memory file
+2. If already committed, follow secret rotation procedures
+3. Reference secrets by vault location instead
+
+### CI Warning: No Corresponding Task
+
+**Symptom**: `No corresponding backlog task found`
+
+**Solution**:
+1. Ensure the task exists in `backlog/tasks/`
+2. Check filename matches task ID
+3. If task was archived, archive the memory too
+
+### CI Warning: Missing Sections
+
+**Symptom**: `Missing '## Context' section`
+
+**Solution**:
+```bash
+# Add missing section to memory file
+nvim backlog/memory/task-42.md
+
+# Add at the beginning:
+# ## Context
+# [Brief task description]
+```
+
+## Integration with Other Tools
+
+### Dependabot
+
+Memory validation doesn't conflict with Dependabot. Memory files aren't dependencies.
+
+### Branch Protection
+
+Recommended branch protection rules:
+```
+- Require status checks: Task Memory Validation
+- Require branches to be up to date
+```
+
+### CODEOWNERS
+
+Add memory review requirements:
+```
+# .github/CODEOWNERS
+backlog/memory/ @team-leads
+```
+
+## Metrics and Monitoring
+
+### Workflow Run History
+
+View historical runs:
+```
+https://github.com/YOUR_ORG/YOUR_REPO/actions/workflows/task-memory-validation.yml
+```
+
+### Failure Rate
+
+Track validation failure rate in GitHub Insights or export to metrics systems.
+
+### Memory Growth
+
+Monitor total memory size over time using the workflow's statistics output.
+
+## Related Documentation
+
+- [Task Memory User Guide](task-memory-user-guide.md)
+- [Task Memory Architecture](../architecture/task-memory-detailed.md)
+- [Backlog Quick Start](backlog-quickstart.md)
+- [GitHub Actions Documentation](https://docs.github.com/en/actions)
+
+---
+
+**Version**: 1.0 | **Last Updated**: 2025-12-11

--- a/src/specify_cli/memory/injector.py
+++ b/src/specify_cli/memory/injector.py
@@ -7,6 +7,9 @@ and other AI agents via the @import directive.
 The injector maintains an "Active Task Context" section in backlog/CLAUDE.md
 that includes @import directives for active task memory files.
 
+Token-aware injection ensures memory doesn't exceed 2000 tokens per task,
+truncating from oldest content when necessary to preserve recent context.
+
 Example:
     ```python
     from specify_cli.memory.injector import ContextInjector
@@ -28,6 +31,7 @@ class ContextInjector:
     Attributes:
         base_path: Root directory of the project
         claude_md_path: Path to backlog/CLAUDE.md file
+        max_tokens: Maximum tokens allowed per task (default: 2000)
     """
 
     # Template for the Active Task Context section
@@ -43,14 +47,20 @@ class ContextInjector:
         re.MULTILINE | re.DOTALL,
     )
 
-    def __init__(self, base_path: Optional[Path] = None):
+    # Token estimation: approximately 4 characters per token
+    # This is a conservative estimate based on GPT tokenization
+    CHARS_PER_TOKEN = 4
+
+    def __init__(self, base_path: Optional[Path] = None, max_tokens: int = 2000):
         """Initialize injector with optional custom base path.
 
         Args:
             base_path: Root directory of the project. Defaults to current working directory.
+            max_tokens: Maximum tokens allowed per task memory (default: 2000)
         """
         self.base_path = base_path or Path.cwd()
         self.claude_md_path = self.base_path / "backlog" / "CLAUDE.md"
+        self.max_tokens = max_tokens
 
     def update_active_task(self, task_id: Optional[str] = None) -> None:
         """Update CLAUDE.md with @import for active task memory.
@@ -145,3 +155,203 @@ class ContextInjector:
             return import_match.group(1)
 
         return None
+
+    def estimate_tokens(self, text: str) -> int:
+        """Estimate token count for text using character-based approximation.
+
+        Uses a conservative estimate of ~4 characters per token, which is
+        typical for English text with GPT-style tokenization.
+
+        Args:
+            text: Text to estimate token count for
+
+        Returns:
+            Estimated token count
+        """
+        return len(text) // self.CHARS_PER_TOKEN
+
+    def truncate_memory_content(self, content: str) -> str:
+        """Truncate memory content to stay within token limit.
+
+        Preserves recent content by truncating from the oldest sections.
+        The strategy:
+        1. Always keep the header (Task Memory: {task_id}, metadata)
+        2. Truncate from the Notes section first (oldest content)
+        3. If still too large, truncate from Key Decisions
+        4. Always preserve Context section (recent context)
+
+        Args:
+            content: Full memory content to truncate
+
+        Returns:
+            Truncated content within token limit
+        """
+        # Check if content is within limit
+        estimated_tokens = self.estimate_tokens(content)
+        if estimated_tokens <= self.max_tokens:
+            return content
+
+        max_chars = self.max_tokens * self.CHARS_PER_TOKEN
+
+        # Try to preserve structure by keeping header and recent sections
+        lines = content.split("\n")
+
+        # Find section boundaries
+        header_end = 0
+        context_start = None
+        key_decisions_start = None
+        notes_start = None
+
+        for i, line in enumerate(lines):
+            if line.startswith("## Context"):
+                context_start = i
+            elif line.startswith("## Key Decisions"):
+                key_decisions_start = i
+            elif line.startswith("## Notes"):
+                notes_start = i
+            elif i < 10 and (
+                line.startswith("**") or line.startswith("# Task Memory:")
+            ):
+                header_end = max(header_end, i)
+
+        # Strategy: Keep header + Context, truncate Notes and Key Decisions if needed
+        preserved_lines = []
+
+        # Always keep header (first few lines with metadata)
+        preserved_lines.extend(lines[: header_end + 1])
+
+        # Always keep Context section if it exists
+        if context_start is not None:
+            context_end = (
+                key_decisions_start
+                if key_decisions_start
+                else notes_start
+                if notes_start
+                else len(lines)
+            )
+            preserved_lines.extend(lines[context_start:context_end])
+
+        # Add Key Decisions if we have space
+        if key_decisions_start is not None:
+            decisions_end = notes_start if notes_start else len(lines)
+            decisions_section = lines[key_decisions_start:decisions_end]
+
+            # Check if adding decisions keeps us within limit
+            test_content = "\n".join(preserved_lines + decisions_section)
+            if len(test_content) <= max_chars:
+                preserved_lines.extend(decisions_section)
+
+        # Add Notes section if we still have space
+        # Reserve space for truncation notice (approximately 60 chars)
+        truncation_notice = (
+            f"*[Content truncated - exceeded {self.max_tokens} token limit]*"
+        )
+        reserved_space = len(truncation_notice) + 10  # +10 for newlines
+
+        if notes_start is not None:
+            notes_section = lines[notes_start:]
+
+            # Try to add as much of notes as we can
+            test_content = "\n".join(preserved_lines + notes_section)
+            if len(test_content) <= max_chars - reserved_space:
+                # All notes fit
+                preserved_lines.extend(notes_section)
+            else:
+                # Add notes line by line until we hit the limit
+                notes_added = False
+                for line in notes_section:
+                    test_content = "\n".join(preserved_lines + [line])
+                    if len(test_content) > max_chars - reserved_space:
+                        # Hit limit - add truncation notice
+                        if notes_added:
+                            preserved_lines.append("")
+                            preserved_lines.append(truncation_notice)
+                        break
+                    preserved_lines.append(line)
+                    notes_added = True
+
+        truncated = "\n".join(preserved_lines)
+
+        # Final safety check - hard truncate if still too large
+        if len(truncated) > max_chars:
+            truncated = truncated[: max_chars - len(truncation_notice) - 5]
+            truncated += f"\n\n{truncation_notice}"
+
+        return truncated
+
+    def get_memory_path(self, task_id: str) -> Path:
+        """Get the path to a task's memory file.
+
+        Args:
+            task_id: Task identifier (e.g., "task-375")
+
+        Returns:
+            Path to the memory file
+        """
+        return self.base_path / "backlog" / "memory" / f"{task_id}.md"
+
+    def update_active_task_with_truncation(self, task_id: Optional[str] = None) -> None:
+        """Update CLAUDE.md with @import for active task, applying token truncation.
+
+        This method reads the task memory, applies token-aware truncation if needed,
+        and writes a truncated copy for injection. The original memory file remains
+        unchanged.
+
+        Args:
+            task_id: Task identifier (e.g., "task-375"). If None, clears the section.
+
+        Raises:
+            FileNotFoundError: If CLAUDE.md or memory file doesn't exist
+        """
+        if task_id is None:
+            self.update_active_task(None)
+            return
+
+        # Read the memory file
+        memory_path = self.get_memory_path(task_id)
+        if not memory_path.exists():
+            # Memory file doesn't exist - just add the @import anyway
+            # (file might be created later, or this is intentional)
+            self.update_active_task(task_id)
+            return
+
+        content = memory_path.read_text()
+
+        # Check if truncation needed
+        estimated_tokens = self.estimate_tokens(content)
+        if estimated_tokens <= self.max_tokens:
+            # No truncation needed - use standard injection
+            self.update_active_task(task_id)
+            return
+
+        # Truncate content and write to a temporary injection file
+        truncated = self.truncate_memory_content(content)
+
+        # Write truncated version to a temp file for injection
+        truncated_path = self.get_memory_path(f"{task_id}.truncated")
+        truncated_path.write_text(truncated)
+
+        # Update CLAUDE.md to import the truncated version
+        if not self.claude_md_path.exists():
+            raise FileNotFoundError(f"CLAUDE.md not found: {self.claude_md_path}")
+
+        claude_content = self.claude_md_path.read_text()
+
+        # Create import directive for the truncated file
+        memory_path_rel = f"../memory/{task_id}.truncated.md"
+        new_section = self.ACTIVE_TASK_SECTION_TEMPLATE.format(
+            content=f"@import {memory_path_rel}\n"
+        )
+
+        # Replace or add the section
+        if self.ACTIVE_TASK_SECTION_REGEX.search(claude_content):
+            new_content = self.ACTIVE_TASK_SECTION_REGEX.sub(
+                new_section.rstrip() + "\n", claude_content
+            )
+        else:
+            new_content = claude_content.rstrip() + "\n\n" + new_section.rstrip() + "\n"
+
+        # Clean up multiple consecutive blank lines
+        new_content = re.sub(r"\n{3,}", "\n\n", new_content)
+
+        self.claude_md_path.write_text(new_content)

--- a/templates/memory/default.md
+++ b/templates/memory/default.md
@@ -1,29 +1,23 @@
+---
+task_id: {task_id}
+created: {created_date}
+updated: {updated_date}
+---
 # Task Memory: {task_id}
 
-**Created**: {created_date}
-**Last Updated**: {updated_date}
-**Task**: {task_title}
+{task_title}
 
 ## Context
 
-<!-- Brief description of what this task is about -->
+
 
 ## Key Decisions
 
-<!-- Record important decisions made during implementation -->
 
-## Approaches Tried
 
-<!-- Document approaches attempted and their outcomes -->
+## Progress
+
+
 
 ## Open Questions
 
-<!-- Track unresolved questions -->
-
-## Resources
-
-<!-- Links to relevant documentation, PRs, discussions -->
-
-## Notes
-
-<!-- Freeform notes section -->

--- a/tests/e2e/test_memory_lifecycle_e2e.py
+++ b/tests/e2e/test_memory_lifecycle_e2e.py
@@ -390,9 +390,9 @@ class TestCLAUDEMDIntegrationE2E:
         )
 
         # Verify CLAUDE.md was updated with @import
-        # LifecycleManager uses format: @import memory/{task_id}.md
+        # LifecycleManager uses ContextInjector format: @import ../memory/{task_id}.md
         content = backlog_claude_md.read_text()
-        assert f"@import memory/{task_id}.md" in content
+        assert f"@import ../memory/{task_id}.md" in content
 
     def test_claude_md_preserves_existing_content(
         self, lifecycle_manager, context_injector, e2e_project
@@ -417,8 +417,8 @@ class TestCLAUDEMDIntegrationE2E:
         updated_content = backlog_claude_md.read_text()
         assert "Backlog Task Management" in updated_content
         assert "test project for context injection" in updated_content
-        # Also verify @import was added
-        assert f"@import memory/{task_id}.md" in updated_content
+        # Also verify @import was added (ContextInjector uses ../memory/ format)
+        assert f"@import ../memory/{task_id}.md" in updated_content
 
 
 class TestErrorRecoveryE2E:

--- a/tests/test_memory_lifecycle.py
+++ b/tests/test_memory_lifecycle.py
@@ -153,7 +153,7 @@ class TestTaskStartTransition:
         # Verify CLAUDE.md updated
         assert claude_md.exists()
         content = claude_md.read_text()
-        assert f"@import memory/{task_id}.md" in content
+        assert f"@import ../memory/{task_id}.md" in content
 
     def test_task_start_without_title(self, manager):
         """Test starting task without title."""
@@ -201,7 +201,7 @@ class TestTaskCompleteTransition:
 
         # Verify import cleared
         content = claude_md.read_text()
-        assert f"@import memory/{task_id}.md" not in content
+        assert f"@import ../memory/{task_id}.md" not in content
 
     def test_task_complete_preserves_content(self, manager):
         """Test that archiving preserves memory content."""
@@ -306,7 +306,7 @@ class TestTaskReopenTransition:
 
         # Verify CLAUDE.md updated
         content = claude_md.read_text()
-        assert f"@import memory/{task_id}.md" in content
+        assert f"@import ../memory/{task_id}.md" in content
 
 
 class TestTaskResetTransition:
@@ -378,7 +378,7 @@ class TestClaudeMdManagement:
 
         assert claude_md.exists()
         content = claude_md.read_text()
-        assert f"@import memory/{task_id}.md" in content
+        assert f"@import ../memory/{task_id}.md" in content
 
     def test_clear_active_task_import(self, manager, temp_project):
         """Test clearing CLAUDE.md import."""
@@ -392,7 +392,7 @@ class TestClaudeMdManagement:
         manager.update_active_task_import(None)
 
         content = claude_md.read_text()
-        assert f"@import memory/{task_id}.md" not in content
+        assert f"@import ../memory/{task_id}.md" not in content
 
     def test_replace_active_task_import(self, manager, temp_project):
         """Test replacing one task import with another."""
@@ -405,8 +405,8 @@ class TestClaudeMdManagement:
         manager.update_active_task_import("task-376")
 
         content = claude_md.read_text()
-        assert "@import memory/task-375.md" not in content
-        assert "@import memory/task-376.md" in content
+        assert "@import ../memory/task-375.md" not in content
+        assert "@import ../memory/task-376.md" in content
 
     def test_create_claude_md_if_missing(self, manager, temp_project):
         """Test that CLAUDE.md is created if it doesn't exist."""
@@ -442,7 +442,7 @@ Follow these rules.
         manager.update_active_task_import("task-375")
 
         content = claude_md.read_text()
-        assert "@import memory/task-375.md" in content
+        assert "@import ../memory/task-375.md" in content
         assert "Some important documentation here" in content
         assert "## Guidelines" in content
 


### PR DESCRIPTION
## Summary

Implements the core Task Memory steel thread - automatic context persistence that follows tasks through their lifecycle.

### What it does

- **Auto-create memory** when task status changes to "In Progress"
- **Auto-archive memory** when task status changes to "Done"
- **@import directive** in `backlog/CLAUDE.md` injects task context automatically
- **PostToolUse hook** detects `backlog task edit` commands and triggers lifecycle

### Key Fix

The hook runs AFTER the backlog command executes, so `get_task_current_status()` returns the NEW status (not old). Fixed by adding `infer_old_status()` which determines the previous state based on:
1. The new target status
2. Whether a memory file already exists

### Files Changed

| File | Description |
|------|-------------|
| `.claude/hooks/post-tool-use-task-memory-lifecycle.py` | New PostToolUse hook |
| `.claude/settings.json` | Hook registration |
| `src/specify_cli/memory/lifecycle.py` | LifecycleManager integration |
| `src/specify_cli/memory/store.py` | YAML frontmatter support |
| `src/specify_cli/memory/injector.py` | @import directive handling |
| `templates/memory/default.md` | Simplified template |
| `.github/workflows/task-memory-validation.yml` | AC coverage validation |
| `docs/guides/task-memory-cicd-integration.md` | CI/CD guide |

### Test Plan

- [x] All 208 memory tests pass
- [x] Hook creates memory on `backlog task edit <id> -s "In Progress"`
- [x] Hook archives memory on `backlog task edit <id> -s Done`
- [x] @import directive added/removed from CLAUDE.md
- [x] YAML validation passes on workflow files

### Related

- task-368: Task Memory feature
- task-383: Advanced features (Phase 6)
- task-388: CI/CD integration (Phase 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)