### PR TITLE
feat(docs): move logo to content area, improve dark mode support

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -63,7 +63,7 @@
     "globalMetadata": {
       "_appTitle": "Flowspec Documentation",
       "_appName": "Flowspec",
-      "_appLogoPath": "media/flowspec.png",
+      "_appFaviconPath": "media/flowspec.png",
       "_appFooter": "Flowspec - Specification-driven development for AI-augmented teams",
       "_enableSearch": true,
       "_disableContribution": false,

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,7 @@
 # Flowspec
 
+![Flowspec Logo](media/flowspec.png)
+
 *Specification-driven development for AI-augmented teams.*
 
 **An effort to allow organizations to focus on product scenarios rather than writing undifferentiated code with the help of Spec-Driven Development.**


### PR DESCRIPTION
## Summary
- Move Flowspec logo from header to content area on index page
- Keep logo as favicon for browser tab
- DocFX modern template supports dark mode via system preferences

## Changes

1. **Logo position**: Moved from `_appLogoPath` (header) to inline image in `index.md`
2. **Favicon**: Changed to `_appFaviconPath` so logo shows in browser tab
3. **Dark mode**: Already supported by DocFX modern template based on `prefers-color-scheme`

## Dark Mode Behavior

The DocFX modern template automatically:
- Detects system dark/light preference
- Shows theme toggle in top-right corner
- Stores user preference in localStorage

## Test Plan

- [ ] Verify CI passes
- [ ] After merge + deploy, check logo appears in content area
- [ ] Verify dark mode toggle works in top-right corner

🤖 Generated with [Claude Code](https://claude.com/claude-code)