### PR TITLE
docs: add backlog and spec research notes

### DIFF
--- a/docs/research/backlog-research.md
+++ b/docs/research/backlog-research.md
@@ -1,0 +1,14 @@
+| Rank | Project | Stars (approx) | Description | URL |
+|---:|---|---:|---|---|
+| 1 | Backlog.md | ~4,200 | Markdown-native backlog + task manager. Tasks live as `.md` files in your repo, with CLI and optional web UI. Very “git is the source of truth.” | https://github.com/MrLesk/Backlog.md |
+| 2 | Taskell | ~1,800 | Terminal Kanban board backed by Markdown files. Clean diffs, git-friendly, archived but still widely used. | https://github.com/smallhadroncollider/taskell |
+| 3 | dstask | ~1,100 | Git-backed CLI task manager where each task has its own Markdown note. Strong focus on versioned task history. | https://github.com/naggie/dstask |
+| 4 | MarkdownTaskManager | ~270 | Local-first Kanban UI that renders boards directly from Markdown files without a server or database. | https://github.com/ioniks/MarkdownTaskManager |
+| 5 | imdone-core | ~150 | Text-based Kanban that extracts tasks from TODO/FIXME comments and Markdown inside a repo. | https://github.com/imdone/imdone-core |
+| 6 | Fira | ~75 | Markdown-file-based Kanban/project management tool aimed at repo-centric and AI-assisted workflows. | https://github.com/Onix-Systems/Fira |
+| 7 | Kanbana | ~65 | Generates Kanban boards from flat Markdown files. Older project, but conceptually very aligned. | https://github.com/SrGMC/kanbana |
+| 8 | Kanbn | ~40 | CLI Kanban app storing boards and tasks as Markdown files directly inside your repository. | https://github.com/basementuniverse/kanbn |
+| 9 | boards | ~30 | Filesystem-centric CLI Kanban; items are files (often Markdown) and can be committed to git. | https://github.com/benrutter/boards |
+|10 | Signboard | ~25 | Local Kanban desktop app where lists are folders and cards are Markdown files (git-friendly by design). | https://github.com/cdevroe/signboard |
+|11 | veggiemonk/backlog | ~7 | Small, explicit “backlog in Markdown in git” project inspired by Backlog.md-style workflows. | https://github.com/veggiemonk/backlog |
+|12 | Cardsboard | ~2 | Ultra-lightweight terminal Kanban using plain files on disk (Markdown-compatible). | https://github.com/markus-kreft/cardsboard |

--- a/docs/research/spec-research.md
+++ b/docs/research/spec-research.md
@@ -1,0 +1,14 @@
+| Rank | Repo | Stars | What it is (plain English) |
+|---:|---|---:|---|
+| 1 | github/spec-kit | 55.1k | The “original” Spec-Driven Development toolkit from GitHub—structured workflow + commands/templates for specs → plans → tasks → execution. |
+| 2 | MrLesk/Backlog.md | 4.2k | Markdown-native backlog + kanban-in-a-repo approach, designed for humans + AI agents collaborating inside Git. |
+| 3 | wordflowlab/novel-writer | 436 | **Not a generic toolkit**—a spec-kit-inspired novel writing tool. Including it because it’s one of the biggest “spec-kit based” repos by stars. |
+| 4 | specpulse/specpulse | 322 | A full SDD framework + CLI with multi-agent / multi-assistant integrations (positions itself as “complete AI-enhanced dev framework”). |
+| 5 | Priivacy-ai/spec-kitty | 228 | Spec-driven workflow automation + live kanban dashboard + multi-agent orchestration (more “workflow platform” than just templates). |
+| 6 | madebyaris/spec-kit-command-cursor | 90 | Cursor-focused SDD command set (/specify, /plan, /tasks, etc.) to drive a spec→plan→tasks loop inside the IDE. |
+| 7 | ibuildwith-ai/cody-pbt | 46 | Opinionated “product builder toolkit” that forces structured docs + planning before implementation (spec-driven guardrails). |
+| 8 | MartyBonacci/specswarm | 29 | Claude Code plugin layering SDD + lifecycle commands into a “one plugin” workflow (fork lineage traces back to spec-kit). |
+| 9 | sengac/fspec | 21 | Spec-driven system emphasizing Gherkin-style scenarios + test linkage (leans into spec→tests→code traceability). |
+| 10 | IBM/iac-spec-kit | 19 | A spec-kit adaptation aimed at Infrastructure-as-Code workflows (requirements → IaC). |
+| 11 | davidlee/spec-driver | 10 | Spec-driven framework that treats specs as the “evergreen truth” emitting deltas code must conform to. |
+| 12 | chernistry/SDDRush | 0 | Minimal prompt templates + scripts to kickstart SDD (tiny starter kit). |


### PR DESCRIPTION
## Summary
- Add research notes for backlog and spec workflows

## Files
- `docs/research/backlog-research.md`
- `docs/research/spec-research.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)