### PR TITLE
feat(backlog): add shim wrapper for backlog CLI with auto event emission

### DIFF
--- a/src/specify_cli/backlog/__init__.py
+++ b/src/specify_cli/backlog/__init__.py
@@ -3,6 +3,19 @@ Backlog.md integration module for flowspec.
 
 This module provides task generation and management integration between
 flowspec specs and Backlog.md task management system.
+
+Components:
+    - TaskParser: Parse task files into Task objects
+    - BacklogWriter: Write tasks to backlog.md format files
+    - TaskMapper: Map spec tasks to backlog format
+    - DependencyGraphBuilder: Build task dependency graphs
+    - shim: CLI wrapper with automatic event emission (recommended for agents)
+
+Example using shim (recommended for agents):
+    >>> from specify_cli.backlog.shim import task_edit, complete_task
+    >>> result = task_edit("task-123", status="In Progress")
+    >>> # Later...
+    >>> result = complete_task("task-123")  # Emits task.completed event
 """
 
 from .parser import TaskParser
@@ -10,9 +23,41 @@ from .writer import BacklogWriter
 from .mapper import TaskMapper
 from .dependency_graph import DependencyGraphBuilder
 
+# Import shim functions for convenience
+from .shim import (
+    ShimResult,
+    task_create,
+    task_edit,
+    task_view,
+    task_list,
+    task_search,
+    task_archive,
+    # Convenience aliases
+    create_task,
+    edit_task,
+    complete_task,
+    start_task,
+    check_acceptance_criteria,
+)
+
 __all__ = [
+    # Legacy components
     "TaskParser",
     "BacklogWriter",
     "TaskMapper",
     "DependencyGraphBuilder",
+    # Shim (recommended for agents)
+    "ShimResult",
+    "task_create",
+    "task_edit",
+    "task_view",
+    "task_list",
+    "task_search",
+    "task_archive",
+    # Convenience aliases
+    "create_task",
+    "edit_task",
+    "complete_task",
+    "start_task",
+    "check_acceptance_criteria",
 ]

--- a/src/specify_cli/backlog/shim.py
+++ b/src/specify_cli/backlog/shim.py
@@ -1,0 +1,696 @@
+"""Backlog CLI shim with automatic event emission.
+
+This module provides wrapper functions around the backlog CLI that automatically
+emit flowspec events for task lifecycle operations. This is the preferred way
+for flowspec agents and workflows to interact with backlog.md.
+
+The shim ensures consistent event emission regardless of whether operations
+are triggered via CLI, MCP tools, or programmatic calls.
+
+Design:
+    - Each function wraps a backlog CLI operation
+    - Events are emitted AFTER successful operations (fail-safe)
+    - Functions return structured results including operation success and event emission status
+    - All functions are designed to be called from Python code (agents, workflows)
+
+Example:
+    >>> from specify_cli.backlog.shim import task_edit, task_create
+    >>>
+    >>> # Create a task with auto event emission
+    >>> result = task_create(title="Implement feature", priority="high")
+    >>> if result.success:
+    ...     print(f"Created {result.task_id}")
+    >>>
+    >>> # Edit task status with auto event emission
+    >>> result = task_edit("task-123", status="Done")
+    >>> # Automatically emits task.completed event
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ShimResult:
+    """Result of a backlog shim operation.
+
+    Attributes:
+        success: Whether the backlog operation succeeded.
+        exit_code: Exit code from the backlog CLI.
+        output: Stdout from the backlog CLI.
+        stderr: Stderr from the backlog CLI.
+        task_id: Task ID (extracted from output for create operations, or passed in).
+        event_emitted: Whether an event was successfully emitted.
+        event_type: Type of event that was emitted (if any).
+        error: Error message if operation failed.
+    """
+
+    success: bool
+    exit_code: int
+    output: str
+    stderr: str
+    task_id: str | None = None
+    event_emitted: bool = False
+    event_type: str | None = None
+    error: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def _run_backlog_command(args: list[str], timeout: int = 30) -> tuple[int, str, str]:
+    """Run a backlog CLI command and capture output.
+
+    Args:
+        args: Command arguments (excluding 'backlog').
+        timeout: Command timeout in seconds.
+
+    Returns:
+        Tuple of (exit_code, stdout, stderr).
+    """
+    cmd = ["backlog"] + args
+    logger.debug(f"Running backlog command: {' '.join(cmd)}")
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return result.returncode, result.stdout, result.stderr
+    except subprocess.TimeoutExpired:
+        logger.error(f"Backlog command timed out after {timeout}s: {' '.join(cmd)}")
+        return -1, "", f"Command timed out after {timeout}s"
+    except FileNotFoundError:
+        logger.error("Backlog CLI not found. Is it installed?")
+        return -1, "", "Backlog CLI not found"
+    except Exception as e:
+        logger.error(f"Backlog command failed: {e}")
+        return -1, "", str(e)
+
+
+def _emit_event(
+    event_type: str,
+    task_id: str,
+    workspace_root: Path | None = None,
+    **kwargs: Any,
+) -> bool:
+    """Emit a flowspec event for a task operation.
+
+    Args:
+        event_type: Event type (e.g., 'task.created', 'task.completed').
+        task_id: Task identifier.
+        workspace_root: Project root directory. Defaults to current directory.
+        **kwargs: Additional event context.
+
+    Returns:
+        True if event was emitted successfully, False otherwise.
+    """
+    if workspace_root is None:
+        workspace_root = Path.cwd()
+
+    try:
+        # Import here to avoid circular imports and make this module standalone
+        from specify_cli.hooks.events import Event
+        from specify_cli.hooks.emitter import emit_event as _emit
+
+        # Build context
+        context: dict[str, Any] = {"task_id": task_id}
+        context.update(kwargs)
+
+        # Create event
+        event = Event(
+            event_type=event_type,
+            project_root=str(workspace_root),
+            context=context,
+        )
+
+        # Emit event
+        results = _emit(event, workspace_root=workspace_root)
+
+        # Log results
+        for result in results:
+            if result.success:
+                logger.info(f"Hook '{result.hook_name}' executed for {event_type}")
+            else:
+                logger.warning(f"Hook '{result.hook_name}' failed: {result.error}")
+
+        return True
+
+    except ImportError as e:
+        logger.warning(f"Could not import hooks module: {e}")
+        return False
+    except Exception as e:
+        logger.warning(f"Failed to emit event {event_type}: {e}")
+        return False
+
+
+def _extract_task_id_from_create_output(output: str) -> str | None:
+    """Extract task ID from backlog create command output.
+
+    Args:
+        output: Stdout from backlog task create command.
+
+    Returns:
+        Task ID (e.g., 'task-123') or None if not found.
+    """
+    # Pattern matches "Created task task-123" or similar
+    pattern = r"Created\s+task\s+(task-\d+(?:\.\d+)*)"
+    match = re.search(pattern, output, re.IGNORECASE)
+    if match:
+        return match.group(1)
+    return None
+
+
+def task_create(
+    title: str,
+    description: str | None = None,
+    priority: str | None = None,
+    labels: list[str] | None = None,
+    acceptance_criteria: list[str] | None = None,
+    parent_task_id: str | None = None,
+    workspace_root: Path | None = None,
+) -> ShimResult:
+    """Create a new backlog task with automatic event emission.
+
+    This function:
+    1. Calls `backlog task create` with the provided arguments
+    2. Extracts the created task ID from output
+    3. Emits a `task.created` event
+
+    Args:
+        title: Task title (required).
+        description: Task description.
+        priority: Priority level ('high', 'medium', 'low').
+        labels: List of labels to apply.
+        acceptance_criteria: List of acceptance criteria.
+        parent_task_id: Parent task ID for subtasks.
+        workspace_root: Project root directory.
+
+    Returns:
+        ShimResult with operation details.
+
+    Example:
+        >>> result = task_create(
+        ...     title="Implement user authentication",
+        ...     priority="high",
+        ...     labels=["backend", "security"],
+        ...     acceptance_criteria=["Users can login", "Sessions expire after 1h"],
+        ... )
+        >>> if result.success:
+        ...     print(f"Created {result.task_id}")
+    """
+    if workspace_root is None:
+        workspace_root = Path.cwd()
+
+    # Build command arguments
+    args = ["task", "create", title]
+
+    if description:
+        args.extend(["--description", description])
+    if priority:
+        args.extend(["--priority", priority])
+    if labels:
+        for label in labels:
+            args.extend(["--label", label])
+    if acceptance_criteria:
+        for ac in acceptance_criteria:
+            args.extend(["--ac", ac])
+    if parent_task_id:
+        args.extend(["--parent", parent_task_id])
+
+    # Run backlog command
+    exit_code, stdout, stderr = _run_backlog_command(args)
+
+    if exit_code != 0:
+        return ShimResult(
+            success=False,
+            exit_code=exit_code,
+            output=stdout,
+            stderr=stderr,
+            error=stderr or "Task creation failed",
+        )
+
+    # Extract task ID from output
+    task_id = _extract_task_id_from_create_output(stdout)
+
+    if not task_id:
+        logger.warning(f"Could not extract task ID from output: {stdout}")
+
+    # Emit task.created event
+    event_emitted = False
+    if task_id:
+        event_emitted = _emit_event(
+            event_type="task.created",
+            task_id=task_id,
+            workspace_root=workspace_root,
+            title=title,
+            priority=priority,
+            labels=labels,
+        )
+
+    return ShimResult(
+        success=True,
+        exit_code=exit_code,
+        output=stdout,
+        stderr=stderr,
+        task_id=task_id,
+        event_emitted=event_emitted,
+        event_type="task.created" if event_emitted else None,
+        metadata={
+            "title": title,
+            "priority": priority,
+            "labels": labels,
+        },
+    )
+
+
+def task_edit(
+    task_id: str,
+    status: str | None = None,
+    title: str | None = None,
+    priority: str | None = None,
+    labels: list[str] | None = None,
+    assignee: list[str] | None = None,
+    check_ac: list[int] | None = None,
+    uncheck_ac: list[int] | None = None,
+    plan: str | None = None,
+    notes: str | None = None,
+    workspace_root: Path | None = None,
+) -> ShimResult:
+    """Edit a backlog task with automatic event emission.
+
+    This function:
+    1. Calls `backlog task edit` with the provided arguments
+    2. Detects what type of change was made
+    3. Emits appropriate event(s):
+       - `task.completed` if status changed to "Done"
+       - `task.status_changed` if status changed to another value
+       - `task.ac_checked` if acceptance criteria were checked/unchecked
+
+    Args:
+        task_id: Task ID to edit (e.g., 'task-123').
+        status: New status value.
+        title: New title.
+        priority: New priority.
+        labels: New labels (replaces existing).
+        assignee: New assignees (replaces existing).
+        check_ac: Acceptance criteria indices to check (1-based).
+        uncheck_ac: Acceptance criteria indices to uncheck (1-based).
+        plan: Implementation plan content.
+        notes: Implementation notes content.
+        workspace_root: Project root directory.
+
+    Returns:
+        ShimResult with operation details.
+
+    Example:
+        >>> # Mark task as done
+        >>> result = task_edit("task-123", status="Done")
+        >>> # Emits task.completed event
+        >>>
+        >>> # Check acceptance criteria
+        >>> result = task_edit("task-123", check_ac=[1, 2])
+        >>> # Emits task.ac_checked event
+    """
+    if workspace_root is None:
+        workspace_root = Path.cwd()
+
+    # Build command arguments
+    args = ["task", "edit", task_id]
+
+    if status:
+        args.extend(["-s", status])
+    if title:
+        args.extend(["--title", title])
+    if priority:
+        args.extend(["--priority", priority])
+    if labels:
+        for label in labels:
+            args.extend(["-l", label])
+    if assignee:
+        for a in assignee:
+            args.extend(["-a", a])
+    if check_ac:
+        for ac_num in check_ac:
+            args.extend(["--check-ac", str(ac_num)])
+    if uncheck_ac:
+        for ac_num in uncheck_ac:
+            args.extend(["--uncheck-ac", str(ac_num)])
+    if plan:
+        args.extend(["--plan", plan])
+    if notes:
+        args.extend(["--notes", notes])
+
+    # Run backlog command
+    exit_code, stdout, stderr = _run_backlog_command(args)
+
+    if exit_code != 0:
+        return ShimResult(
+            success=False,
+            exit_code=exit_code,
+            output=stdout,
+            stderr=stderr,
+            task_id=task_id,
+            error=stderr or "Task edit failed",
+        )
+
+    # Determine which event(s) to emit
+    event_emitted = False
+    event_type = None
+
+    # Status change events
+    if status:
+        if status.lower() == "done":
+            event_emitted = _emit_event(
+                event_type="task.completed",
+                task_id=task_id,
+                workspace_root=workspace_root,
+                status_to="Done",
+            )
+            event_type = "task.completed"
+        else:
+            event_emitted = _emit_event(
+                event_type="task.status_changed",
+                task_id=task_id,
+                workspace_root=workspace_root,
+                status_to=status,
+            )
+            event_type = "task.status_changed"
+
+    # AC check/uncheck events
+    if check_ac or uncheck_ac:
+        ac_event_emitted = _emit_event(
+            event_type="task.ac_checked",
+            task_id=task_id,
+            workspace_root=workspace_root,
+            checked=check_ac or [],
+            unchecked=uncheck_ac or [],
+        )
+        if ac_event_emitted:
+            event_emitted = True
+            # If we already emitted a status event, note that we emitted multiple
+            event_type = (
+                "task.ac_checked"
+                if event_type is None
+                else f"{event_type},task.ac_checked"
+            )
+
+    return ShimResult(
+        success=True,
+        exit_code=exit_code,
+        output=stdout,
+        stderr=stderr,
+        task_id=task_id,
+        event_emitted=event_emitted,
+        event_type=event_type,
+        metadata={
+            "status": status,
+            "check_ac": check_ac,
+            "uncheck_ac": uncheck_ac,
+        },
+    )
+
+
+def task_view(
+    task_id: str,
+    plain: bool = True,
+) -> ShimResult:
+    """View a backlog task.
+
+    This is a read-only operation that does NOT emit events.
+
+    Args:
+        task_id: Task ID to view.
+        plain: Use plain text output (AI-friendly).
+
+    Returns:
+        ShimResult with task content in output.
+    """
+    args = ["task", task_id]
+    if plain:
+        args.append("--plain")
+
+    exit_code, stdout, stderr = _run_backlog_command(args)
+
+    return ShimResult(
+        success=exit_code == 0,
+        exit_code=exit_code,
+        output=stdout,
+        stderr=stderr,
+        task_id=task_id,
+        error=stderr if exit_code != 0 else None,
+    )
+
+
+def task_list(
+    status: str | None = None,
+    labels: list[str] | None = None,
+    assignee: str | None = None,
+    plain: bool = True,
+) -> ShimResult:
+    """List backlog tasks.
+
+    This is a read-only operation that does NOT emit events.
+
+    Args:
+        status: Filter by status.
+        labels: Filter by labels.
+        assignee: Filter by assignee.
+        plain: Use plain text output (AI-friendly).
+
+    Returns:
+        ShimResult with task list in output.
+    """
+    args = ["task", "list"]
+
+    if status:
+        args.extend(["-s", status])
+    if labels:
+        for label in labels:
+            args.extend(["-l", label])
+    if assignee:
+        args.extend(["-a", assignee])
+    if plain:
+        args.append("--plain")
+
+    exit_code, stdout, stderr = _run_backlog_command(args)
+
+    return ShimResult(
+        success=exit_code == 0,
+        exit_code=exit_code,
+        output=stdout,
+        stderr=stderr,
+        error=stderr if exit_code != 0 else None,
+    )
+
+
+def task_search(
+    query: str,
+    status: str | None = None,
+    priority: str | None = None,
+    limit: int | None = None,
+) -> ShimResult:
+    """Search backlog tasks.
+
+    This is a read-only operation that does NOT emit events.
+
+    Args:
+        query: Search query string.
+        status: Filter by status.
+        priority: Filter by priority.
+        limit: Maximum number of results.
+
+    Returns:
+        ShimResult with search results in output.
+    """
+    args = ["task", "search", query]
+
+    if status:
+        args.extend(["--status", status])
+    if priority:
+        args.extend(["--priority", priority])
+    if limit:
+        args.extend(["--limit", str(limit)])
+
+    exit_code, stdout, stderr = _run_backlog_command(args)
+
+    return ShimResult(
+        success=exit_code == 0,
+        exit_code=exit_code,
+        output=stdout,
+        stderr=stderr,
+        error=stderr if exit_code != 0 else None,
+    )
+
+
+def task_archive(
+    task_id: str,
+    workspace_root: Path | None = None,
+) -> ShimResult:
+    """Archive a backlog task with automatic event emission.
+
+    This function:
+    1. Calls `backlog task archive`
+    2. Emits a `task.archived` event
+
+    Args:
+        task_id: Task ID to archive.
+        workspace_root: Project root directory.
+
+    Returns:
+        ShimResult with operation details.
+    """
+    if workspace_root is None:
+        workspace_root = Path.cwd()
+
+    args = ["task", "archive", task_id]
+
+    exit_code, stdout, stderr = _run_backlog_command(args)
+
+    if exit_code != 0:
+        return ShimResult(
+            success=False,
+            exit_code=exit_code,
+            output=stdout,
+            stderr=stderr,
+            task_id=task_id,
+            error=stderr or "Task archive failed",
+        )
+
+    # Emit task.archived event
+    event_emitted = _emit_event(
+        event_type="task.archived",
+        task_id=task_id,
+        workspace_root=workspace_root,
+    )
+
+    return ShimResult(
+        success=True,
+        exit_code=exit_code,
+        output=stdout,
+        stderr=stderr,
+        task_id=task_id,
+        event_emitted=event_emitted,
+        event_type="task.archived" if event_emitted else None,
+    )
+
+
+# --- Convenience aliases ---
+
+
+def create_task(
+    title: str,
+    description: str | None = None,
+    priority: str | None = None,
+    labels: list[str] | None = None,
+    acceptance_criteria: list[str] | None = None,
+    workspace_root: Path | None = None,
+) -> ShimResult:
+    """Alias for task_create (more Pythonic naming)."""
+    return task_create(
+        title=title,
+        description=description,
+        priority=priority,
+        labels=labels,
+        acceptance_criteria=acceptance_criteria,
+        workspace_root=workspace_root,
+    )
+
+
+def edit_task(
+    task_id: str,
+    status: str | None = None,
+    check_ac: list[int] | None = None,
+    workspace_root: Path | None = None,
+    **kwargs: Any,
+) -> ShimResult:
+    """Alias for task_edit (more Pythonic naming)."""
+    return task_edit(
+        task_id=task_id,
+        status=status,
+        check_ac=check_ac,
+        workspace_root=workspace_root,
+        **kwargs,
+    )
+
+
+def complete_task(
+    task_id: str,
+    workspace_root: Path | None = None,
+) -> ShimResult:
+    """Mark a task as Done (convenience wrapper).
+
+    Args:
+        task_id: Task ID to complete.
+        workspace_root: Project root directory.
+
+    Returns:
+        ShimResult with operation details.
+
+    Example:
+        >>> result = complete_task("task-123")
+        >>> # Equivalent to: task_edit("task-123", status="Done")
+    """
+    return task_edit(task_id=task_id, status="Done", workspace_root=workspace_root)
+
+
+def start_task(
+    task_id: str,
+    assignee: str | None = None,
+    workspace_root: Path | None = None,
+) -> ShimResult:
+    """Start a task by setting status to In Progress (convenience wrapper).
+
+    Args:
+        task_id: Task ID to start.
+        assignee: Assignee to add.
+        workspace_root: Project root directory.
+
+    Returns:
+        ShimResult with operation details.
+
+    Example:
+        >>> result = start_task("task-123", assignee="@backend-engineer")
+        >>> # Equivalent to: task_edit("task-123", status="In Progress", assignee=["@backend-engineer"])
+    """
+    assignees = [assignee] if assignee else None
+    return task_edit(
+        task_id=task_id,
+        status="In Progress",
+        assignee=assignees,
+        workspace_root=workspace_root,
+    )
+
+
+def check_acceptance_criteria(
+    task_id: str,
+    criteria_indices: list[int],
+    workspace_root: Path | None = None,
+) -> ShimResult:
+    """Check acceptance criteria on a task (convenience wrapper).
+
+    Args:
+        task_id: Task ID.
+        criteria_indices: List of AC indices to check (1-based).
+        workspace_root: Project root directory.
+
+    Returns:
+        ShimResult with operation details.
+
+    Example:
+        >>> result = check_acceptance_criteria("task-123", [1, 2, 3])
+        >>> # Equivalent to: task_edit("task-123", check_ac=[1, 2, 3])
+    """
+    return task_edit(
+        task_id=task_id,
+        check_ac=criteria_indices,
+        workspace_root=workspace_root,
+    )

--- a/tests/test_backlog_shim.py
+++ b/tests/test_backlog_shim.py
@@ -1,0 +1,587 @@
+"""Tests for backlog CLI shim with automatic event emission.
+
+This module tests the shim wrapper functions that call backlog CLI
+and automatically emit flowspec events for task lifecycle operations.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from specify_cli.backlog.shim import (
+    ShimResult,
+    _extract_task_id_from_create_output,
+    _run_backlog_command,
+    check_acceptance_criteria,
+    complete_task,
+    start_task,
+    task_archive,
+    task_create,
+    task_edit,
+    task_list,
+    task_search,
+    task_view,
+)
+
+
+@pytest.fixture
+def workspace_root(tmp_path: Path) -> Path:
+    """Create temporary workspace root."""
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    # Create hooks directory structure
+    hooks_dir = workspace / ".specify" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    # Create empty hooks.yaml
+    hooks_file = hooks_dir / "hooks.yaml"
+    hooks_file.write_text("version: '1.0'\nhooks: []\n")
+    return workspace
+
+
+class TestShimResult:
+    """Test ShimResult dataclass."""
+
+    def test_shim_result_defaults(self):
+        """Test ShimResult default values."""
+        result = ShimResult(
+            success=True,
+            exit_code=0,
+            output="output",
+            stderr="",
+        )
+        assert result.success is True
+        assert result.exit_code == 0
+        assert result.output == "output"
+        assert result.stderr == ""
+        assert result.task_id is None
+        assert result.event_emitted is False
+        assert result.event_type is None
+        assert result.error is None
+        assert result.metadata == {}
+
+    def test_shim_result_with_event(self):
+        """Test ShimResult with event emission."""
+        result = ShimResult(
+            success=True,
+            exit_code=0,
+            output="Created task task-123",
+            stderr="",
+            task_id="task-123",
+            event_emitted=True,
+            event_type="task.created",
+        )
+        assert result.task_id == "task-123"
+        assert result.event_emitted is True
+        assert result.event_type == "task.created"
+
+
+class TestExtractTaskId:
+    """Test task ID extraction from output."""
+
+    def test_extract_simple_task_id(self):
+        """Test extracting simple task ID."""
+        output = "Created task task-123"
+        assert _extract_task_id_from_create_output(output) == "task-123"
+
+    def test_extract_subtask_id(self):
+        """Test extracting subtask ID (with dots)."""
+        output = "Created task task-123.01"
+        assert _extract_task_id_from_create_output(output) == "task-123.01"
+
+    def test_extract_deeply_nested_subtask(self):
+        """Test extracting deeply nested subtask ID."""
+        output = "Created task task-123.01.02"
+        assert _extract_task_id_from_create_output(output) == "task-123.01.02"
+
+    def test_extract_case_insensitive(self):
+        """Test case insensitive extraction."""
+        output = "CREATED TASK task-456"
+        assert _extract_task_id_from_create_output(output) == "task-456"
+
+    def test_no_match_returns_none(self):
+        """Test no match returns None."""
+        output = "Task creation failed"
+        assert _extract_task_id_from_create_output(output) is None
+
+    def test_multiline_output(self):
+        """Test extraction from multiline output."""
+        output = """
+        Processing...
+        Created task task-789
+        Done!
+        """
+        assert _extract_task_id_from_create_output(output) == "task-789"
+
+
+class TestRunBacklogCommand:
+    """Test _run_backlog_command helper."""
+
+    @patch("subprocess.run")
+    def test_successful_command(self, mock_run):
+        """Test successful backlog command execution."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="Success",
+            stderr="",
+        )
+
+        exit_code, stdout, stderr = _run_backlog_command(["task", "list"])
+
+        assert exit_code == 0
+        assert stdout == "Success"
+        assert stderr == ""
+        mock_run.assert_called_once()
+
+    @patch("subprocess.run")
+    def test_failed_command(self, mock_run):
+        """Test failed backlog command execution."""
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout="",
+            stderr="Error: task not found",
+        )
+
+        exit_code, stdout, stderr = _run_backlog_command(
+            ["task", "view", "nonexistent"]
+        )
+
+        assert exit_code == 1
+        assert stderr == "Error: task not found"
+
+    @patch("subprocess.run")
+    def test_command_timeout(self, mock_run):
+        """Test command timeout handling."""
+        import subprocess
+
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="backlog", timeout=30)
+
+        exit_code, stdout, stderr = _run_backlog_command(["task", "list"])
+
+        assert exit_code == -1
+        assert "timed out" in stderr.lower()
+
+    @patch("subprocess.run")
+    def test_backlog_not_found(self, mock_run):
+        """Test backlog CLI not found."""
+        mock_run.side_effect = FileNotFoundError()
+
+        exit_code, stdout, stderr = _run_backlog_command(["task", "list"])
+
+        assert exit_code == -1
+        assert "not found" in stderr.lower()
+
+
+class TestTaskCreate:
+    """Test task_create function."""
+
+    @patch("specify_cli.backlog.shim._emit_event")
+    @patch("specify_cli.backlog.shim._run_backlog_command")
+    def test_create_task_success(self, mock_run, mock_emit, workspace_root: Path):
+        """Test successful task creation with event emission."""
+        mock_run.return_value = (0, "Created task task-100", "")
+        mock_emit.return_value = True
+
+        result = task_create(
+            title="Test task",
+            priority="high",
+            workspace_root=workspace_root,
+        )
+
+        assert result.success is True
+        assert result.task_id == "task-100"
+        assert result.event_emitted is True
+        assert result.event_type == "task.created"
+
+        # Verify backlog command called correctly
+        call_args = mock_run.call_args[0][0]
+        assert "task" in call_args
+        assert "create" in call_args
+        assert "Test task" in call_args
+        assert "--priority" in call_args
+        assert "high" in call_args
+
+        # Verify event emitted
+        mock_emit.assert_called_once()
+
+    @patch("specify_cli.backlog.shim._run_backlog_command")
+    def test_create_task_failure(self, mock_run, workspace_root: Path):
+        """Test task creation failure."""
+        mock_run.return_value = (1, "", "Error: invalid priority")
+
+        result = task_create(
+            title="Test task",
+            priority="invalid",
+            workspace_root=workspace_root,
+        )
+
+        assert result.success is False
+        assert result.exit_code == 1
+        assert result.error is not None
+        assert result.event_emitted is False
+
+    @patch("specify_cli.backlog.shim._emit_event")
+    @patch("specify_cli.backlog.shim._run_backlog_command")
+    def test_create_task_with_labels(self, mock_run, mock_emit, workspace_root: Path):
+        """Test task creation with labels."""
+        mock_run.return_value = (0, "Created task task-101", "")
+        mock_emit.return_value = True
+
+        result = task_create(
+            title="Backend feature",
+            labels=["backend", "feature"],
+            workspace_root=workspace_root,
+        )
+
+        assert result.success is True
+        call_args = mock_run.call_args[0][0]
+        assert call_args.count("--label") == 2
+        assert "backend" in call_args
+        assert "feature" in call_args
+
+    @patch("specify_cli.backlog.shim._emit_event")
+    @patch("specify_cli.backlog.shim._run_backlog_command")
+    def test_create_task_with_acceptance_criteria(
+        self, mock_run, mock_emit, workspace_root: Path
+    ):
+        """Test task creation with acceptance criteria."""
+        mock_run.return_value = (0, "Created task task-102", "")
+        mock_emit.return_value = True
+
+        result = task_create(
+            title="Feature with ACs",
+            acceptance_criteria=["AC 1", "AC 2"],
+            workspace_root=workspace_root,
+        )
+
+        assert result.success is True
+        call_args = mock_run.call_args[0][0]
+        assert call_args.count("--ac") == 2
+
+
+class TestTaskEdit:
+    """Test task_edit function."""
+
+    @patch("specify_cli.backlog.shim._emit_event")
+    @patch("specify_cli.backlog.shim._run_backlog_command")
+    def test_edit_status_to_done(self, mock_run, mock_emit, workspace_root: Path):
+        """Test editing task status to Done emits task.completed."""
+        mock_run.return_value = (0, "Task updated", "")
+        mock_emit.return_value = True
+
+        result = task_edit(
+            task_id="task-123",
+            status="Done",
+            workspace_root=workspace_root,
+        )
+
+        assert result.success is True
+        assert result.event_emitted is True
+        assert result.event_type == "task.completed"
+
+        # Verify event type passed to emit
+        call_args = mock_emit.call_args
+        assert call_args[1]["event_type"] == "task.completed"
+
+    @patch("specify_cli.backlog.shim._emit_event")
+    @patch("specify_cli.backlog.shim._run_backlog_command")
+    def test_edit_status_to_in_progress(
+        self, mock_run, mock_emit, workspace_root: Path
+    ):
+        """Test editing task status to In Progress emits task.status_changed."""
+        mock_run.return_value = (0, "Task updated", "")
+        mock_emit.return_value = True
+
+        result = task_edit(
+            task_id="task-123",
+            status="In Progress",
+            workspace_root=workspace_root,
+        )
+
+        assert result.success is True
+        assert result.event_emitted is True
+        assert result.event_type == "task.status_changed"
+
+    @patch("specify_cli.backlog.shim._emit_event")
+    @patch("specify_cli.backlog.shim._run_backlog_command")
+    def test_edit_check_acceptance_criteria(
+        self, mock_run, mock_emit, workspace_root: Path
+    ):
+        """Test checking acceptance criteria emits task.ac_checked."""
+        mock_run.return_value = (0, "Task updated", "")
+        mock_emit.return_value = True
+
+        result = task_edit(
+            task_id="task-123",
+            check_ac=[1, 2],
+            workspace_root=workspace_root,
+        )
+
+        assert result.success is True
+        assert result.event_emitted is True
+        assert result.event_type == "task.ac_checked"
+
+        # Verify command includes check-ac flags
+        call_args = mock_run.call_args[0][0]
+        assert call_args.count("--check-ac") == 2
+
+    @patch("specify_cli.backlog.shim._emit_event")
+    @patch("specify_cli.backlog.shim._run_backlog_command")
+    def test_edit_uncheck_acceptance_criteria(
+        self, mock_run, mock_emit, workspace_root: Path
+    ):
+        """Test unchecking acceptance criteria emits task.ac_checked."""
+        mock_run.return_value = (0, "Task updated", "")
+        mock_emit.return_value = True
+
+        result = task_edit(
+            task_id="task-123",
+            uncheck_ac=[1],
+            workspace_root=workspace_root,
+        )
+
+        assert result.success is True
+        assert result.event_emitted is True
+        assert "task.ac_checked" in result.event_type
+
+    @patch("specify_cli.backlog.shim._emit_event")
+    @patch("specify_cli.backlog.shim._run_backlog_command")
+    def test_edit_status_and_ac_emits_multiple_events(
+        self, mock_run, mock_emit, workspace_root: Path
+    ):
+        """Test editing both status and AC emits multiple events."""
+        mock_run.return_value = (0, "Task updated", "")
+        mock_emit.return_value = True
+
+        result = task_edit(
+            task_id="task-123",
+            status="Done",
+            check_ac=[1],
+            workspace_root=workspace_root,
+        )
+
+        assert result.success is True
+        assert result.event_emitted is True
+        # Should contain both event types
+        assert "task.completed" in result.event_type
+        assert "task.ac_checked" in result.event_type
+
+    @patch("specify_cli.backlog.shim._run_backlog_command")
+    def test_edit_failure(self, mock_run, workspace_root: Path):
+        """Test edit failure."""
+        mock_run.return_value = (1, "", "Error: task not found")
+
+        result = task_edit(
+            task_id="nonexistent",
+            status="Done",
+            workspace_root=workspace_root,
+        )
+
+        assert result.success is False
+        assert result.event_emitted is False
+
+
+class TestTaskView:
+    """Test task_view function."""
+
+    @patch("specify_cli.backlog.shim._run_backlog_command")
+    def test_view_task(self, mock_run):
+        """Test viewing a task (read-only, no event)."""
+        mock_run.return_value = (0, "Task details...", "")
+
+        result = task_view("task-123")
+
+        assert result.success is True
+        assert result.task_id == "task-123"
+        assert result.event_emitted is False  # Read-only, no event
+
+    @patch("specify_cli.backlog.shim._run_backlog_command")
+    def test_view_task_plain(self, mock_run):
+        """Test viewing task with plain flag."""
+        mock_run.return_value = (0, "Task details...", "")
+
+        task_view("task-123", plain=True)
+
+        call_args = mock_run.call_args[0][0]
+        assert "--plain" in call_args
+
+
+class TestTaskList:
+    """Test task_list function."""
+
+    @patch("specify_cli.backlog.shim._run_backlog_command")
+    def test_list_tasks(self, mock_run):
+        """Test listing tasks (read-only, no event)."""
+        mock_run.return_value = (0, "task-1, task-2, task-3", "")
+
+        result = task_list()
+
+        assert result.success is True
+        assert result.event_emitted is False  # Read-only, no event
+
+    @patch("specify_cli.backlog.shim._run_backlog_command")
+    def test_list_tasks_with_filters(self, mock_run):
+        """Test listing tasks with filters."""
+        mock_run.return_value = (0, "task-1", "")
+
+        task_list(status="To Do", labels=["backend"])
+
+        call_args = mock_run.call_args[0][0]
+        assert "-s" in call_args
+        assert "To Do" in call_args
+        assert "-l" in call_args
+        assert "backend" in call_args
+
+
+class TestTaskSearch:
+    """Test task_search function."""
+
+    @patch("specify_cli.backlog.shim._run_backlog_command")
+    def test_search_tasks(self, mock_run):
+        """Test searching tasks (read-only, no event)."""
+        mock_run.return_value = (0, "task-1: matching task", "")
+
+        result = task_search("authentication")
+
+        assert result.success is True
+        assert result.event_emitted is False  # Read-only, no event
+
+
+class TestTaskArchive:
+    """Test task_archive function."""
+
+    @patch("specify_cli.backlog.shim._emit_event")
+    @patch("specify_cli.backlog.shim._run_backlog_command")
+    def test_archive_task(self, mock_run, mock_emit, workspace_root: Path):
+        """Test archiving task emits task.archived."""
+        mock_run.return_value = (0, "Task archived", "")
+        mock_emit.return_value = True
+
+        result = task_archive("task-123", workspace_root=workspace_root)
+
+        assert result.success is True
+        assert result.event_emitted is True
+        assert result.event_type == "task.archived"
+
+
+class TestConvenienceWrappers:
+    """Test convenience wrapper functions."""
+
+    @patch("specify_cli.backlog.shim._emit_event")
+    @patch("specify_cli.backlog.shim._run_backlog_command")
+    def test_complete_task(self, mock_run, mock_emit, workspace_root: Path):
+        """Test complete_task convenience wrapper."""
+        mock_run.return_value = (0, "Task updated", "")
+        mock_emit.return_value = True
+
+        result = complete_task("task-123", workspace_root=workspace_root)
+
+        assert result.success is True
+        assert result.event_type == "task.completed"
+
+        # Verify status was set to Done
+        call_args = mock_run.call_args[0][0]
+        assert "-s" in call_args
+        assert "Done" in call_args
+
+    @patch("specify_cli.backlog.shim._emit_event")
+    @patch("specify_cli.backlog.shim._run_backlog_command")
+    def test_start_task(self, mock_run, mock_emit, workspace_root: Path):
+        """Test start_task convenience wrapper."""
+        mock_run.return_value = (0, "Task updated", "")
+        mock_emit.return_value = True
+
+        result = start_task(
+            "task-123",
+            assignee="@backend-engineer",
+            workspace_root=workspace_root,
+        )
+
+        assert result.success is True
+        assert result.event_type == "task.status_changed"
+
+        # Verify status was set to In Progress
+        call_args = mock_run.call_args[0][0]
+        assert "-s" in call_args
+        assert "In Progress" in call_args
+        assert "-a" in call_args
+        assert "@backend-engineer" in call_args
+
+    @patch("specify_cli.backlog.shim._emit_event")
+    @patch("specify_cli.backlog.shim._run_backlog_command")
+    def test_check_acceptance_criteria(self, mock_run, mock_emit, workspace_root: Path):
+        """Test check_acceptance_criteria convenience wrapper."""
+        mock_run.return_value = (0, "Task updated", "")
+        mock_emit.return_value = True
+
+        result = check_acceptance_criteria(
+            "task-123",
+            criteria_indices=[1, 2, 3],
+            workspace_root=workspace_root,
+        )
+
+        assert result.success is True
+        assert result.event_type == "task.ac_checked"
+
+        # Verify check-ac flags
+        call_args = mock_run.call_args[0][0]
+        assert call_args.count("--check-ac") == 3
+
+
+class TestEventEmissionFailure:
+    """Test graceful handling of event emission failures."""
+
+    @patch("specify_cli.backlog.shim._emit_event")
+    @patch("specify_cli.backlog.shim._run_backlog_command")
+    def test_event_emission_failure_doesnt_fail_operation(
+        self, mock_run, mock_emit, workspace_root: Path
+    ):
+        """Test that event emission failure doesn't fail the operation."""
+        mock_run.return_value = (0, "Created task task-123", "")
+        mock_emit.return_value = False  # Event emission fails
+
+        result = task_create(
+            title="Test task",
+            workspace_root=workspace_root,
+        )
+
+        # Operation should still succeed
+        assert result.success is True
+        assert result.task_id == "task-123"
+        # But event was not emitted
+        assert result.event_emitted is False
+
+
+class TestBacklogModuleImports:
+    """Test that shim functions are properly exported from backlog module."""
+
+    def test_import_from_backlog_module(self):
+        """Test importing shim functions from backlog module."""
+        from specify_cli.backlog import (
+            ShimResult,
+            check_acceptance_criteria,
+            complete_task,
+            create_task,
+            edit_task,
+            start_task,
+            task_archive,
+            task_create,
+            task_edit,
+            task_list,
+            task_search,
+            task_view,
+        )
+
+        # All should be importable
+        assert ShimResult is not None
+        assert task_create is not None
+        assert task_edit is not None
+        assert task_view is not None
+        assert task_list is not None
+        assert task_search is not None
+        assert task_archive is not None
+        assert create_task is not None
+        assert edit_task is not None
+        assert complete_task is not None
+        assert start_task is not None
+        assert check_acceptance_criteria is not None


### PR DESCRIPTION
## Summary

- Add Python shim module that wraps backlog CLI commands and automatically emits flowspec events
- Provides programmatic API for agents/workflows to interact with backlog.md consistently
- Events are emitted AFTER successful operations (fail-safe design)

## Changes

### New Files
- `src/specify_cli/backlog/shim.py` - Shim wrapper module with:
  - `task_create()`: Creates task and emits `task.created` event
  - `task_edit()`: Edits task and emits `task.completed`/`task.status_changed`/`task.ac_checked`
  - `task_view/list/search()`: Read-only operations (no events)
  - `task_archive()`: Archives task and emits `task.archived`
  - Convenience wrappers: `complete_task()`, `start_task()`, `check_acceptance_criteria()`

- `tests/test_backlog_shim.py` - 33 comprehensive tests

### Modified Files
- `src/specify_cli/backlog/__init__.py` - Export shim functions from backlog module

## Usage Example

```python
from specify_cli.backlog import task_edit, complete_task, start_task

# Start a task (emits task.status_changed)
result = start_task("task-123", assignee="@backend-engineer")

# Check acceptance criteria (emits task.ac_checked)
result = task_edit("task-123", check_ac=[1, 2])

# Complete the task (emits task.completed)
result = complete_task("task-123")
```

## Test plan
- [x] All 33 new tests pass
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format .`)
- [x] Related hooks tests still pass (73 tests total)

Closes task-204, task-204.03

🤖 Generated with [Claude Code](https://claude.com/claude-code)