### PR TITLE
chore(backlog): close CI/release tasks - process working

### DIFF
--- a/backlog/tasks/task-278 - Add-CI-validation-for-command-structure.md
+++ b/backlog/tasks/task-278 - Add-CI-validation-for-command-structure.md
@@ -1,11 +1,11 @@
 ---
 id: task-278
 title: Add CI validation for command structure
-status: To Do
+status: Done
 assignee:
   - '@galway'
 created_date: '2025-12-03 14:01'
-updated_date: '2025-12-04 04:01'
+updated_date: '2025-12-15 13:43'
 labels:
   - ci
   - validation

--- a/backlog/tasks/task-282 - Create-backlog-archive.yml-workflow-with-manual-scheduled-and-keyword-triggers.md
+++ b/backlog/tasks/task-282 - Create-backlog-archive.yml-workflow-with-manual-scheduled-and-keyword-triggers.md
@@ -3,11 +3,11 @@ id: task-282
 title: >-
   Create backlog-archive.yml workflow with manual, scheduled, and keyword
   triggers
-status: To Do
+status: Done
 assignee:
   - '@galway'
 created_date: '2025-12-04 03:32'
-updated_date: '2025-12-04 04:01'
+updated_date: '2025-12-15 13:43'
 labels:
   - infrastructure
   - ci-cd

--- a/backlog/tasks/task-311 - Fix-orphaned-chore-version-bump-branches-not-being-cleaned-up.md
+++ b/backlog/tasks/task-311 - Fix-orphaned-chore-version-bump-branches-not-being-cleaned-up.md
@@ -1,11 +1,11 @@
 ---
 id: task-311
 title: Fix orphaned chore/version-bump branches not being cleaned up
-status: To Do
+status: Done
 assignee:
   - '@galway'
 created_date: '2025-12-08 01:43'
-updated_date: '2025-12-08 02:32'
+updated_date: '2025-12-15 13:43'
 labels:
   - bug
   - ci

--- a/backlog/tasks/task-311.01 - Fix-double-dash-in-version-bump-branch-name.md
+++ b/backlog/tasks/task-311.01 - Fix-double-dash-in-version-bump-branch-name.md
@@ -1,11 +1,11 @@
 ---
 id: task-311.01
 title: Fix double-dash in version-bump branch name
-status: To Do
+status: Done
 assignee:
   - '@galway'
 created_date: '2025-12-08 01:43'
-updated_date: '2025-12-08 02:31'
+updated_date: '2025-12-15 13:43'
 labels:
   - bug
   - ci

--- a/backlog/tasks/task-311.02 - Delete-branch-after-PR-creation-failure.md
+++ b/backlog/tasks/task-311.02 - Delete-branch-after-PR-creation-failure.md
@@ -1,11 +1,11 @@
 ---
 id: task-311.02
 title: Delete branch after PR creation failure
-status: To Do
+status: Done
 assignee:
   - '@galway'
 created_date: '2025-12-08 01:43'
-updated_date: '2025-12-15 02:17'
+updated_date: '2025-12-15 13:43'
 labels:
   - bug
   - ci

--- a/backlog/tasks/task-311.03 - Enable-auto-delete-branch-on-PR-merge-in-GitHub-repo-settings.md
+++ b/backlog/tasks/task-311.03 - Enable-auto-delete-branch-on-PR-merge-in-GitHub-repo-settings.md
@@ -1,11 +1,11 @@
 ---
 id: task-311.03
 title: Enable auto-delete branch on PR merge in GitHub repo settings
-status: To Do
+status: Done
 assignee:
   - '@galway'
 created_date: '2025-12-08 01:43'
-updated_date: '2025-12-15 02:17'
+updated_date: '2025-12-15 13:43'
 labels:
   - ci
   - github-actions

--- a/backlog/tasks/task-311.04 - Add-scheduled-workflow-to-cleanup-stale-version-bump-branches.md
+++ b/backlog/tasks/task-311.04 - Add-scheduled-workflow-to-cleanup-stale-version-bump-branches.md
@@ -1,11 +1,11 @@
 ---
 id: task-311.04
 title: Add scheduled workflow to cleanup stale version-bump branches
-status: To Do
+status: Done
 assignee:
   - '@galway'
 created_date: '2025-12-08 01:43'
-updated_date: '2025-12-15 02:17'
+updated_date: '2025-12-15 13:43'
 labels:
   - ci
   - github-actions

--- a/backlog/tasks/task-313 - Fix-release-workflow-Update-version-files-before-creating-tag.md
+++ b/backlog/tasks/task-313 - Fix-release-workflow-Update-version-files-before-creating-tag.md
@@ -1,11 +1,11 @@
 ---
 id: task-313
 title: 'Fix release workflow: Update version files before creating tag'
-status: To Do
+status: Done
 assignee:
   - '@galway'
 created_date: '2025-12-08 02:05'
-updated_date: '2025-12-08 02:31'
+updated_date: '2025-12-15 13:43'
 labels:
   - implement
   - ci

--- a/backlog/tasks/task-335 - Add-CI-check-for-agent-sync-drift.md
+++ b/backlog/tasks/task-335 - Add-CI-check-for-agent-sync-drift.md
@@ -1,11 +1,11 @@
 ---
 id: task-335
 title: Add CI check for agent sync drift
-status: To Do
+status: Done
 assignee:
   - '@galway'
 created_date: '2025-12-08 22:28'
-updated_date: '2025-12-15 02:17'
+updated_date: '2025-12-15 13:43'
 labels:
   - implement
   - ci


### PR DESCRIPTION
## Summary
- Mark 9 galway CI/release tasks as Done since the release process is now working correctly
- Tasks closed: task-278, task-282, task-311, task-311.01, task-311.02, task-311.03, task-311.04, task-313, task-335

## Test plan
- [x] Tasks marked as Done in backlog

🤖 Generated with [Claude Code](https://claude.com/claude-code)