### PR TITLE
fix(git): add worktree directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,10 @@ env/
 *.zip
 sdd-*/
 .coverage
+
+# Git worktrees (local development - never commit)
+*-worktree/
+task-*-worktree
+
+# Backup files from specify
+.specify/backups/


### PR DESCRIPTION
## Summary
- Adds git worktree directories to `.gitignore` (`*-worktree/`, `task-*-worktree`)
- Adds `.specify/backups/` to `.gitignore`

## Problem
PR #853 failed with labeler CI error:
```
fatal: No url found for submodule path 'task-251-worktree' in .gitmodules
```

Git worktrees were accidentally committed as gitlinks (submodule references), causing CI to fail when trying to process them.

## Solution
Prevent this class of issues by ignoring worktree directories in `.gitignore`.

## Test plan
- [x] Verify `.gitignore` patterns match common worktree naming conventions
- [ ] CI passes (labeler workflow specifically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)