### PR TITLE
docs(build-docs): Replace specify-cli with flowspec-cli

### DIFF
--- a/build-docs/adr/ADR-007-unified-security-finding-format.md
+++ b/build-docs/adr/ADR-007-unified-security-finding-format.md
@@ -406,7 +406,7 @@ class SARIFExporter:
             "tool": {
                 "driver": {
                     "name": scanner,
-                    "informationUri": f"https://specify-cli.dev/security/{scanner}",
+                    "informationUri": f"https://flowspec-cli.dev/security/{scanner}",
                     "rules": list(rules.values()),
                 }
             },

--- a/build-docs/adr/LAYERED-EXTENSION-ARCHITECTURE.md
+++ b/build-docs/adr/LAYERED-EXTENSION-ARCHITECTURE.md
@@ -244,7 +244,7 @@ specify upgrade --templates-only
 
 ```bash
 # Install CLI
-uv tool install specify-cli --from git+https://github.com/jpoley/flowspec.git
+uv tool install flowspec-cli --from git+https://github.com/jpoley/flowspec.git
 
 # Initialize project with two-stage download
 specify init my-project --ai claude
@@ -339,7 +339,7 @@ specify upgrade --base-version 0.0.20 --extension-version 0.0.20
 
 Just use the standard workflow:
 ```bash
-uv tool install specify-cli --from git+https://github.com/jpoley/flowspec.git
+uv tool install flowspec-cli --from git+https://github.com/jpoley/flowspec.git
 specify init my-project --ai claude
 ```
 

--- a/build-docs/adr/design-command-migration-path.md
+++ b/build-docs/adr/design-command-migration-path.md
@@ -531,7 +531,7 @@ specify --version
 
 # Should be v2.0.0 or later
 # If not, upgrade:
-pip install --upgrade specify-cli
+pip install --upgrade flowspec-cli
 ```
 
 ---
@@ -578,7 +578,7 @@ If critical issues arise during migration:
 
 ### Emergency Rollback (Month 0-11)
 
-1. **Revert version**: `pip install specify-cli==1.x.x`
+1. **Revert version**: `pip install flowspec-cli==1.x.x`
 2. **Old commands still work**: Aliases remain functional
 3. **No data loss**: Migration only affects command names
 

--- a/build-docs/adr/upgrade-commands-plan.md
+++ b/build-docs/adr/upgrade-commands-plan.md
@@ -13,7 +13,7 @@ The `specify` CLI has a confusing upgrade story:
 The tools are installed per-user:
 | Tool | Installation Method | Location |
 |------|---------------------|----------|
-| flowspec | `uv tool install specify-cli --from git+...` | `~/.local/bin/specify` |
+| flowspec | `uv tool install flowspec-cli --from git+...` | `~/.local/bin/specify` |
 | spec-kit | `uv tool install spec-kit` | uv managed |
 | backlog.md | `pnpm add -g backlog-md` | npm global |
 
@@ -34,7 +34,7 @@ specify upgrade-tools --dry-run          # Preview changes
 ```
 
 Implementation:
-- flowspec: `uv tool upgrade specify-cli`
+- flowspec: `uv tool upgrade flowspec-cli`
 - backlog.md: `pnpm add -g backlog-md@latest` (or npm)
 - Verify version after upgrade
 

--- a/build-docs/evaluations/claude-review.md
+++ b/build-docs/evaluations/claude-review.md
@@ -174,8 +174,8 @@ Two parallel command suites exist with similar purposes:
 ### 3.1 Current Installation Flow
 
 ```bash
-# Step 1: Install specify-cli (requires uv + Python 3.11+)
-uv tool install specify-cli --from git+https://github.com/jpoley/flowspec.git
+# Step 1: Install flowspec-cli (requires uv + Python 3.11+)
+uv tool install flowspec-cli --from git+https://github.com/jpoley/flowspec.git
 
 # Step 2: Install backlog.md (requires Node.js + pnpm/npm)
 pnpm i -g backlog.md
@@ -205,7 +205,7 @@ The following scenarios lack clear error handling:
 
 1. **User has Python 3.10:** Silent failure or unclear error
 2. **GitHub rate limiting:** Authentication hints provided but could be clearer
-3. **Missing pnpm/npm:** No guidance in specify-cli
+3. **Missing pnpm/npm:** No guidance in flowspec-cli
 4. **Backlog.md version mismatch:** Warning shown but no auto-fix
 5. **Non-Git directory:** Git init skipped silently
 
@@ -214,7 +214,7 @@ The following scenarios lack clear error handling:
 1. **Unified installer script:**
    ```bash
    curl -fsSL https://flowspec.dev/install.sh | bash
-   # Handles: uv, specify-cli, backlog.md, verification
+   # Handles: uv, flowspec-cli, backlog.md, verification
    ```
 
 2. **Pre-flight checks with clear remediation:**

--- a/build-docs/platform/flowspec-security-platform.md
+++ b/build-docs/platform/flowspec-security-platform.md
@@ -221,7 +221,7 @@ jobs:
       - name: Install Flowspec
         run: |
           pip install uv
-          uv tool install specify-cli
+          uv tool install flowspec-cli
 
       - name: Cache Semgrep
         uses: actions/cache@v4
@@ -411,7 +411,7 @@ git commit --no-verify -m "fix: critical production bug (bypass security scan)"
 | **Semgrep** | ~50MB | LGPL 2.1 | pip install, cache binary |
 | **CodeQL** | ~400MB (CLI) + ~1.5GB (DB) | GitHub Terms | Download on-demand, optional |
 | **Python** | N/A | PSF | System dependency (3.11+) |
-| **uv** | ~10MB | Apache 2.0 | Included in specify-cli |
+| **uv** | ~10MB | Apache 2.0 | Included in flowspec-cli |
 
 ### 4.2 Semgrep Installation Strategy
 
@@ -496,7 +496,7 @@ def ensure_codeql_available():
 
 **Semgrep Version Pinning:**
 ```toml
-# pyproject.toml (specify-cli)
+# pyproject.toml (flowspec-cli)
 [project.dependencies]
 semgrep = "==1.50.0"  # Pin exact version for reproducibility
 ```
@@ -999,8 +999,8 @@ RUN pip install --no-cache-dir \
     uv \
     semgrep==1.50.0
 
-# Install specify-cli via uv
-RUN uv tool install specify-cli
+# Install flowspec-cli via uv
+RUN uv tool install flowspec-cli
 
 # Create working directory
 WORKDIR /src
@@ -1116,8 +1116,8 @@ backlog task create "Track DORA Metrics for Security Scanning" \
 #### Task 7: Docker Image for Security Scanner
 ```bash
 backlog task create "Build and Publish Security Scanner Docker Image" \
-  -d "Create Docker image with Semgrep and specify-cli for air-gapped environments" \
-  --ac "Create Dockerfile with Python 3.11, Semgrep, uv, specify-cli" \
+  -d "Create Docker image with Semgrep and flowspec-cli for air-gapped environments" \
+  --ac "Create Dockerfile with Python 3.11, Semgrep, uv, flowspec-cli" \
   --ac "Optimize image size (<200MB)" \
   --ac "Publish to GHCR (ghcr.io/yourusername/flowspeckit-security-scanner)" \
   --ac "Add image to CI/CD pipeline as alternative scan method" \

--- a/build-docs/platform/muckross-security-platform-plan-v2.md
+++ b/build-docs/platform/muckross-security-platform-plan-v2.md
@@ -689,7 +689,7 @@ jobs:
       - name: Install tools
         run: |
           pip install uv
-          uv tool install specify-cli
+          uv tool install flowspec-cli
           pip install semgrep
 
       - name: Run Security Scan
@@ -782,8 +782,8 @@ RUN pip install --no-cache-dir \
     uv \
     semgrep==1.50.0
 
-# Install specify-cli
-RUN uv tool install specify-cli
+# Install flowspec-cli
+RUN uv tool install flowspec-cli
 
 # NO ANTHROPIC SDK
 # NO API KEY HANDLING
@@ -1026,7 +1026,7 @@ MCP_TOOL_INVOCATIONS.labels(tool_name='security_triage').inc()
 1. **Create Dockerfile** with:
    - Python 3.11
    - Semgrep
-   - specify-cli (uv tool install)
+   - flowspec-cli (uv tool install)
    - **NO Anthropic SDK**
 
 2. **Publish to GHCR**

--- a/build-docs/platform/security-cicd-integration.md
+++ b/build-docs/platform/security-cicd-integration.md
@@ -35,7 +35,7 @@ jobs:
       - name: Install Flowspec
         run: |
           pip install uv
-          uv tool install specify-cli
+          uv tool install flowspec-cli
 
       - name: Run Security Scan
         run: |
@@ -124,7 +124,7 @@ jobs:
       - name: Install Tools
         run: |
           pip install uv
-          uv tool install specify-cli
+          uv tool install flowspec-cli
           pip install semgrep==1.50.0
 
       - name: Run Security Scan
@@ -233,7 +233,7 @@ jobs:
       - name: Install Tools
         run: |
           pip install uv
-          uv tool install specify-cli
+          uv tool install flowspec-cli
 
       - name: Full Security Scan
         run: |
@@ -502,7 +502,7 @@ security-scan:
   image: python:3.11-slim
   before_script:
     - pip install uv
-    - uv tool install specify-cli
+    - uv tool install flowspec-cli
   script:
     - specify security scan --fail-on critical,high --format json,sarif
   artifacts:
@@ -530,7 +530,7 @@ pipeline {
             steps {
                 sh '''
                     pip install uv
-                    uv tool install specify-cli
+                    uv tool install flowspec-cli
                     specify security scan --fail-on critical,high --format sarif
                 '''
             }
@@ -579,7 +579,7 @@ jobs:
           name: Install Tools
           command: |
             pip install uv
-            uv tool install specify-cli
+            uv tool install flowspec-cli
 
       - run:
           name: Run Security Scan
@@ -791,7 +791,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - run: pip install uv && uv tool install specify-cli
+      - run: pip install uv && uv tool install flowspec-cli
       - run: specify security scan --fail-on critical,high
 ```
 
@@ -810,7 +810,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - run: npm install -g specify-cli
+      - run: npm install -g flowspec-cli
       - run: specify security scan --path src --fail-on critical,high
 ```
 

--- a/build-docs/prd/MARKETPLACE.md
+++ b/build-docs/prd/MARKETPLACE.md
@@ -429,10 +429,10 @@ Requires Claude Code 2.0.0 or higher.
 
 ```bash
 # Install via pip
-pip install specify-cli
+pip install flowspec-cli
 
 # Or use uvx (recommended)
-uvx specify-cli init my-project
+uvx flowspec-cli init my-project
 ```
 
 **Both provide the same core workflow commands!** Choose based on your needs.

--- a/build-docs/research/opcode.md
+++ b/build-docs/research/opcode.md
@@ -124,7 +124,7 @@ pub struct CheckpointManager {
 ### Core Architecture
 
 Flowspec is a **CLI toolkit** for Spec-Driven Development:
-- **CLI**: Python (`specify-cli` package via uv)
+- **CLI**: Python (`flowspec-cli` package via uv)
 - **Templates**: Markdown templates for artifacts
 - **Configuration**: YAML-based workflow definitions
 - **Integration**: backlog.md MCP server for task management
@@ -410,7 +410,7 @@ Teams can share workflow configurations. Opcode is inherently single-user.
 │  - Transitions           │  - Acceptance criteria        │
 │  - Agent assignments     │  - Status tracking            │
 ├──────────────────────────────────────────────────────────┤
-│  specify-cli (Python)    │  templates/                   │
+│  flowspec-cli (Python)    │  templates/                   │
 │  - Project init          │  - Artifact templates         │
 │  - Workflow validation   │  - Command templates          │
 │  - Feature detection     │  - Skill templates            │

--- a/build-docs/research/spec-kitty.md
+++ b/build-docs/research/spec-kitty.md
@@ -39,7 +39,7 @@
 | **Version** | 0.6.4 | 0.2.358 |
 | **Python** | 3.11+ | 3.11+ |
 | **CLI Command** | `spec-kitty` | `specify` |
-| **PyPI Package** | `spec-kitty-cli` | `specify-cli` |
+| **PyPI Package** | `spec-kitty-cli` | `flowspec-cli` |
 | **Primary Focus** | Real-time visibility & multi-agent | Security & workflow governance |
 | **Core Innovation** | Live kanban dashboard | Unified security scanning |
 

--- a/build-docs/research/version-management-research.md
+++ b/build-docs/research/version-management-research.md
@@ -185,7 +185,7 @@ Analysis:
 
 **Impact**:
 - Users see wrong version: `specify --version` returns 0.2.328, actual tag is v0.2.337
-- `uv tool install specify-cli` installs from PyPI (may differ from git)
+- `uv tool install flowspec-cli` installs from PyPI (may differ from git)
 - Developers cannot determine actual version from source
 
 **Recovery**: Manual PR to sync versions (not automated)

--- a/build-docs/specs/architecture-enhancements-functional.md
+++ b/build-docs/specs/architecture-enhancements-functional.md
@@ -121,7 +121,7 @@ This functional specification defines behaviors for 10 architecture enhancement 
 - **Errors**: Fall back to "ALL STACKS" if terminal not interactive
 
 **FR-STACK-002**: Stack Definitions
-- **Input**: STACK_CONFIG in specify-cli
+- **Input**: STACK_CONFIG in flowspec-cli
 - **Output**: 9 predefined stacks with file lists
 - **Rules**: Include React+Go, React+Python, Full-Stack TS, etc.
 - **Errors**: N/A (static configuration)


### PR DESCRIPTION
## Summary
Replace all `specify-cli` references with `flowspec-cli` in build-docs/ directory.

- **Files Updated**: 13
- **Replacements**: 37 occurrences

## Tracking
- Beads: spec-l8o.2
- Backlog: task-002

## Test Plan
- [x] `grep -r "specify-cli" build-docs/` returns no matches
- [x] All markdown files remain valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)