### PR TITLE
docs(user-docs): Replace specify-cli with flowspec-cli

### DIFF
--- a/user-docs/installation.md
+++ b/user-docs/installation.md
@@ -29,7 +29,7 @@ uvx --from git+https://github.com/jpoley/flowspec.git specify init --here
 Alternatively, install persistently once and use everywhere:
 
 ```bash
-uv tool install specify-cli --from git+https://github.com/jpoley/flowspec.git
+uv tool install flowspec-cli --from git+https://github.com/jpoley/flowspec.git
 specify init <PROJECT_NAME>
 ```
 

--- a/user-docs/user-guides/backlog-user-guide.md
+++ b/user-docs/user-guides/backlog-user-guide.md
@@ -74,7 +74,7 @@ Completed Feature
 
 ### Prerequisites
 
-- Flowspec installed: `uv tool install specify-cli --from git+https://github.com/jpoley/flowspec.git`
+- Flowspec installed: `uv tool install flowspec-cli --from git+https://github.com/jpoley/flowspec.git`
 - Node.js 18+ or npm/pnpm
 - Git repository initialized
 - Claude Code (optional, for AI integration)

--- a/user-docs/user-guides/constitution-validation.md
+++ b/user-docs/user-guides/constitution-validation.md
@@ -131,7 +131,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install specify
-        run: pip install specify-cli
+        run: pip install flowspec-cli
       - name: Validate constitution
         run: specify constitution validate
 ```

--- a/user-docs/user-guides/release-workflow-fix.md
+++ b/user-docs/user-guides/release-workflow-fix.md
@@ -43,7 +43,7 @@ FAILS: "GitHub Actions is not permitted to create or approve pull requests"
 
 ```toml
 [project]
-name = "specify-cli"
+name = "flowspec-cli"
 dynamic = ["version"]  # Version comes from git tags
 description = "..."
 

--- a/user-docs/user-guides/security-cicd-integration.md
+++ b/user-docs/user-guides/security-cicd-integration.md
@@ -96,7 +96,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install tools
-        run: pip install specify-cli semgrep
+        run: pip install flowspec-cli semgrep
 
       - name: Run scan
         id: scan
@@ -125,7 +125,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install tools
-        run: pip install specify-cli
+        run: pip install flowspec-cli
 
       - name: Download scan results
         uses: actions/download-artifact@v4
@@ -160,7 +160,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install tools
-        run: pip install specify-cli
+        run: pip install flowspec-cli
 
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -227,7 +227,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install tools
-        run: pip install specify-cli semgrep
+        run: pip install flowspec-cli semgrep
 
       - name: Scan changed files
         if: steps.changed.outputs.files != ''
@@ -253,7 +253,7 @@ variables:
 .security-base:
   image: python:3.11
   before_script:
-    - pip install specify-cli semgrep
+    - pip install flowspec-cli semgrep
   cache:
     paths:
       - .pip-cache/
@@ -327,7 +327,7 @@ flowspec-security:
   stage: test
   image: python:3.11
   script:
-    - pip install specify-cli semgrep
+    - pip install flowspec-cli semgrep
     - specify security scan --format json --output gl-sast-report.json
   artifacts:
     reports:
@@ -354,7 +354,7 @@ pipeline {
     stages {
         stage('Setup') {
             steps {
-                sh 'pip install specify-cli semgrep'
+                sh 'pip install flowspec-cli semgrep'
             }
         }
 
@@ -459,7 +459,7 @@ pipeline {
                     stage('Scan') {
                         steps {
                             sh """
-                                pip install specify-cli ${SCANNER}
+                                pip install flowspec-cli ${SCANNER}
                                 specify security scan \
                                     --scanner ${SCANNER} \
                                     --format json \
@@ -510,7 +510,7 @@ stages:
               versionSpec: '$(pythonVersion)'
 
           - script: |
-              pip install specify-cli semgrep
+              pip install flowspec-cli semgrep
             displayName: 'Install tools'
 
           - script: |
@@ -538,7 +538,7 @@ stages:
               artifactName: 'SecurityResults'
 
           - script: |
-              pip install specify-cli
+              pip install flowspec-cli
               specify security audit \
                 $(System.ArtifactsDirectory)/SecurityResults/scan-results.json \
                 --format html \
@@ -574,7 +574,7 @@ jobs:
       - checkout
       - python/install-packages:
           pkg-manager: pip
-          packages: specify-cli semgrep
+          packages: flowspec-cli semgrep
       - run:
           name: Run security scan
           command: |
@@ -596,7 +596,7 @@ jobs:
           at: .
       - python/install-packages:
           pkg-manager: pip
-          packages: specify-cli
+          packages: flowspec-cli
       - run:
           name: AI triage
           command: |
@@ -614,7 +614,7 @@ jobs:
           at: .
       - python/install-packages:
           pkg-manager: pip
-          packages: specify-cli
+          packages: flowspec-cli
       - run:
           name: Generate report
           command: |
@@ -630,7 +630,7 @@ jobs:
       - checkout
       - python/install-packages:
           pkg-manager: pip
-          packages: specify-cli semgrep
+          packages: flowspec-cli semgrep
       - run:
           name: Security gate
           command: specify security scan --fail-on critical
@@ -663,7 +663,7 @@ repos:
         name: Security Scan
         entry: specify security scan --quick --fail-on critical
         language: python
-        additional_dependencies: [specify-cli, semgrep]
+        additional_dependencies: [flowspec-cli, semgrep]
         pass_filenames: false
         stages: [commit]
 ```
@@ -679,7 +679,7 @@ repos:
         name: Security Scan (Python)
         entry: specify security scan --scanner semgrep --quick --fail-on high
         language: python
-        additional_dependencies: [specify-cli, semgrep]
+        additional_dependencies: [flowspec-cli, semgrep]
         types: [python]
         pass_filenames: false
 

--- a/user-docs/user-guides/security-dast.md
+++ b/user-docs/user-guides/security-dast.md
@@ -19,7 +19,7 @@ Install DAST dependencies:
 
 ```bash
 # Install with DAST extras
-pip install 'specify-cli[dast]'
+pip install 'flowspec-cli[dast]'
 
 # Or install Playwright separately
 pip install playwright
@@ -404,7 +404,7 @@ ImportError: Playwright is not installed
 **Solution:**
 
 ```bash
-pip install 'specify-cli[dast]'
+pip install 'flowspec-cli[dast]'
 playwright install chromium
 ```
 

--- a/user-docs/user-guides/workflow-customization.md
+++ b/user-docs/user-guides/workflow-customization.md
@@ -697,7 +697,7 @@ If all else fails, restore the default configuration:
 
 ```bash
 # Copy from template (Flowspec installation)
-cp ~/.local/share/specify-cli/templates/flowspec_workflow.yml ./flowspec_workflow.yml
+cp ~/.local/share/flowspec-cli/templates/flowspec_workflow.yml ./flowspec_workflow.yml
 ```
 
 ## Related Documentation

--- a/user-docs/user-guides/workflow-troubleshooting.md
+++ b/user-docs/user-guides/workflow-troubleshooting.md
@@ -47,11 +47,11 @@ Searched locations:
 **Solution 1: Create default configuration**
 ```bash
 # Copy from Flowspec templates
-cp ~/.local/share/specify-cli/templates/flowspec_workflow.yml ./flowspec_workflow.yml
+cp ~/.local/share/flowspec-cli/templates/flowspec_workflow.yml ./flowspec_workflow.yml
 
 # Or create in memory/ directory
 mkdir -p memory
-cp ~/.local/share/specify-cli/templates/flowspec_workflow.yml memory/flowspec_workflow.yml
+cp ~/.local/share/flowspec-cli/templates/flowspec_workflow.yml memory/flowspec_workflow.yml
 ```
 
 **Solution 2: Check current directory**
@@ -617,7 +617,7 @@ cp flowspec_workflow.yml.backup.* flowspec_workflow.yml
 mv flowspec_workflow.yml flowspec_workflow.yml.broken
 
 # 2. Copy default configuration
-cp ~/.local/share/specify-cli/templates/flowspec_workflow.yml ./flowspec_workflow.yml
+cp ~/.local/share/flowspec-cli/templates/flowspec_workflow.yml ./flowspec_workflow.yml
 
 # Or from project templates
 cp flowspec_workflow.yml


### PR DESCRIPTION
## Summary
Replace all `specify-cli` references with `flowspec-cli` in user-docs/ directory.

- **Files Updated**: 8
- **Replacements**: 26 occurrences

## Tracking
- Beads: spec-l8o.3
- Backlog: task-003

## Test Plan
- [x] `grep -r "specify-cli" user-docs/` returns no matches
- [x] All markdown files remain valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)