### PR TITLE
docs: Replace specify-cli with flowspec-cli in root documentation

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -243,9 +243,9 @@ Pre-commit hook is included but disabled by default. To enable:
 
 **CLI Installation**:
 ```bash
-pip install specify-cli
+pip install flowspec-cli
 # or
-uvx specify-cli init my-project
+uvx flowspec-cli init my-project
 ```
 
 Both distributions provide the same core functionality!

--- a/.spec-kit-compatibility.yml
+++ b/.spec-kit-compatibility.yml
@@ -55,7 +55,7 @@ flowspec:
   # Installation methods
   installation:
     uv:
-      method: "uv tool install specify-cli --from git+https://github.com/jpoley/flowspec.git"
+      method: "uv tool install flowspec-cli --from git+https://github.com/jpoley/flowspec.git"
       supports_upgrade: true
     
     git:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,7 +269,7 @@ Always provide both bash and PowerShell versions for cross-platform support.
 
 ```bash
 # Reinstall
-uv tool uninstall specify-cli
+uv tool uninstall flowspec-cli
 uv tool install . --force
 
 # Check installation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Project Overview
 
 **Flowspec** is a toolkit for Spec-Driven Development (SDD):
-- **Specify CLI**: Command-line tool to bootstrap projects (`specify-cli` package)
+- **Specify CLI**: Command-line tool to bootstrap projects (`flowspec-cli` package)
 - **Templates**: SDD templates for multiple AI agents
 - **Documentation**: Comprehensive guides in `docs/`
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Open in VS Code → "Reopen in Container". The image includes:
 
 ```bash
 # Specify CLI (project initialization)
-uv tool install specify-cli --from git+https://github.com/jpoley/flowspec.git
+uv tool install flowspec-cli --from git+https://github.com/jpoley/flowspec.git
 
 # Backlog.md (task management)
 pnpm i -g backlog.md


### PR DESCRIPTION
## Summary
Replace all `specify-cli` references with `flowspec-cli` in root documentation files.

**Files Updated**:
- README.md
- CLAUDE.md
- AGENTS.md
- .spec-kit-compatibility.yml
- .claude-plugin/README.md

**Replacements**: 6 occurrences

## Tracking
- Beads: spec-l8o.5
- Backlog: task-005

## Test Plan
- [x] No `specify-cli` references remain in target files
- [x] All files remain valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)