### PR TITLE
fix: Replace remaining specify-cli references with flowspec-cli

### DIFF
--- a/scripts/bash/install-flowspec-latest.sh
+++ b/scripts/bash/install-flowspec-latest.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Install specify-cli from the latest tag of a PRIVATE GitHub repo
+# Install flowspec-cli from the latest tag of a PRIVATE GitHub repo
 # Resolves the latest tag using the most secure method available and installs via uv.
 #
 # Usage:
@@ -96,18 +96,18 @@ if [[ -z "$TAG" ]]; then
   exit 1
 fi
 
-echo "Installing specify-cli @ ${TAG} from ${OWNER}/${REPO} via ${METHOD}"
+echo "Installing flowspec-cli @ ${TAG} from ${OWNER}/${REPO} via ${METHOD}"
 
 if [[ "$METHOD" == "ssh" ]]; then
   UV_FROM="git+ssh://git@github.com/${OWNER}/${REPO}.git@${TAG}"
-  uv tool install specify-cli --from "$UV_FROM"
+  uv tool install flowspec-cli --from "$UV_FROM"
 else
   if [[ -z "${GITHUB_TOKEN:-}" ]]; then
     echo "GITHUB_TOKEN not set for private HTTPS access. Export it and retry, or use --ssh." >&2
     exit 1
   fi
   UV_FROM="git+https://x-access-token:${GITHUB_TOKEN}@github.com/${OWNER}/${REPO}.git@${TAG}"
-  uv tool install specify-cli --from "$UV_FROM"
+  uv tool install flowspec-cli --from "$UV_FROM"
 fi
 
 echo "Done. Run: specify --help"

--- a/src/flowspec_cli/.spec-kit-compatibility.yml
+++ b/src/flowspec_cli/.spec-kit-compatibility.yml
@@ -55,7 +55,7 @@ flowspec:
   # Installation methods
   installation:
     uv:
-      method: "uv tool install specify-cli --from git+https://github.com/jpoley/flowspec.git"
+      method: "uv tool install flowspec-cli --from git+https://github.com/jpoley/flowspec.git"
       supports_upgrade: true
     
     git:

--- a/src/flowspec_cli/__init__.py
+++ b/src/flowspec_cli/__init__.py
@@ -13,12 +13,12 @@
 Specify CLI - Setup tool for Specify projects
 
 Usage:
-    uvx specify-cli.py init <project-name>
-    uvx specify-cli.py init .
-    uvx specify-cli.py init --here
+    uvx flowspec-cli.py init <project-name>
+    uvx flowspec-cli.py init .
+    uvx flowspec-cli.py init --here
 
 Or install globally:
-    uv tool install --from specify-cli.py specify-cli
+    uv tool install --from flowspec-cli.py flowspec-cli
     specify init <project-name>
     specify init .
     specify init --here
@@ -80,7 +80,7 @@ def _github_headers(cli_token: str | None = None, *, skip_auth: bool = False) ->
     """
     headers = {
         "Accept": "application/vnd.github+json",
-        "User-Agent": "flowspec/specify-cli",
+        "User-Agent": "flowspec/flowspec-cli",
         "X-GitHub-Api-Version": "2022-11-28",
     }
     if not skip_auth:
@@ -3942,7 +3942,7 @@ def _get_installed_jp_spec_kit_version() -> Optional[str]:
 def _upgrade_jp_spec_kit(
     dry_run: bool = False, target_version: str | None = None
 ) -> tuple[bool, str]:
-    """Upgrade flowspec (specify-cli) via uv tool.
+    """Upgrade flowspec (flowspec-cli) via uv tool.
 
     Args:
         dry_run: If True, only show what would be done
@@ -3991,7 +3991,7 @@ def _upgrade_jp_spec_kit(
     if not target_version:
         try:
             result = subprocess.run(
-                ["uv", "tool", "upgrade", "specify-cli"],
+                ["uv", "tool", "upgrade", "flowspec-cli"],
                 capture_output=True,
                 text=True,
                 check=False,
@@ -4014,7 +4014,7 @@ def _upgrade_jp_spec_kit(
                 "tool",
                 "install",
                 "--force",
-                "specify-cli",
+                "flowspec-cli",
                 "--from",
                 git_url,
             ],
@@ -4111,7 +4111,7 @@ def _upgrade_spec_kit(dry_run: bool = False) -> tuple[bool, str]:
                 "tool",
                 "install",
                 "--force",
-                "specify-cli",
+                "flowspec-cli",
                 "--from",
                 "git+https://github.com/jpoley/flowspec.git",
             ],
@@ -4207,7 +4207,7 @@ def upgrade_tools(
     It does NOT upgrade repository templates (use 'specify upgrade-repo' for that).
 
     Tools upgraded:
-    - flowspec (specify-cli): via uv tool upgrade
+    - flowspec (flowspec-cli): via uv tool upgrade
     - spec-kit: base templates bundled in flowspec (triggers flowspec reinstall)
     - backlog-md: via npm/pnpm global install
 

--- a/src/flowspec_cli/security/adapters/dast.py
+++ b/src/flowspec_cli/security/adapters/dast.py
@@ -110,7 +110,7 @@ class DASTAdapter(ScannerAdapter):
         if not self.is_available():
             msg = (
                 "Playwright is not available. Install with: "
-                "pip install 'specify-cli[dast]' or pip install playwright && "
+                "pip install 'flowspec-cli[dast]' or pip install playwright && "
                 "playwright install chromium"
             )
             raise RuntimeError(msg)
@@ -157,7 +157,7 @@ class DASTAdapter(ScannerAdapter):
         return """To install Playwright for DAST scanning:
 
 1. Install the Python package:
-   pip install 'specify-cli[dast]'
+   pip install 'flowspec-cli[dast]'
 
    Or install Playwright separately:
    pip install playwright
@@ -204,7 +204,7 @@ class DASTAdapterAsync(DASTAdapter):
         if not self.is_available():
             msg = (
                 "Playwright is not available. Install with: "
-                "pip install 'specify-cli[dast]' or pip install playwright && "
+                "pip install 'flowspec-cli[dast]' or pip install playwright && "
                 "playwright install chromium"
             )
             raise RuntimeError(msg)

--- a/src/flowspec_cli/security/dast/crawler.py
+++ b/src/flowspec_cli/security/dast/crawler.py
@@ -120,7 +120,7 @@ class PlaywrightCrawler:
         except ImportError as e:
             msg = (
                 "Playwright is not installed. Install with: "
-                "pip install 'specify-cli[dast]' or pip install playwright"
+                "pip install 'flowspec-cli[dast]' or pip install playwright"
             )
             raise ImportError(msg) from e
 

--- a/src/flowspec_cli/security/dast/scanner.py
+++ b/src/flowspec_cli/security/dast/scanner.py
@@ -103,7 +103,7 @@ class DASTScanner:
         except ImportError as e:
             msg = (
                 "Playwright is not installed. Install with: "
-                "pip install 'specify-cli[dast]' or pip install playwright && "
+                "pip install 'flowspec-cli[dast]' or pip install playwright && "
                 "playwright install chromium"
             )
             raise ImportError(msg) from e

--- a/src/flowspec_cli/security/exporters/sarif.py
+++ b/src/flowspec_cli/security/exporters/sarif.py
@@ -111,7 +111,7 @@ class SARIFExporter(BaseExporter):
                 "driver": {
                     "name": scanner,
                     "version": self.tool_version,
-                    "informationUri": f"https://specify-cli.dev/security/{scanner}",
+                    "informationUri": f"https://flowspec-cli.dev/security/{scanner}",
                     "rules": list(rules.values()),
                 }
             },

--- a/src/flowspec_cli/security/integrations/cicd.py
+++ b/src/flowspec_cli/security/integrations/cicd.py
@@ -75,7 +75,7 @@ class CICDIntegration:
         steps.append(
             {
                 "name": "Install dependencies",
-                "run": "pip install specify-cli semgrep bandit",
+                "run": "pip install flowspec-cli semgrep bandit",
             }
         )
 
@@ -122,7 +122,7 @@ class CICDIntegration:
                 "stage": "security",
                 "image": f"python:{self.python_version}",
                 "before_script": [
-                    "pip install specify-cli semgrep bandit",
+                    "pip install flowspec-cli semgrep bandit",
                 ],
                 "script": [
                     f"specify security scan --fail-on {self.fail_on_severity} --output gl-sast-report.json --format json",
@@ -162,7 +162,7 @@ class CICDIntegration:
                     "inputs": {"versionSpec": self.python_version},
                 },
                 {
-                    "script": "pip install specify-cli semgrep bandit",
+                    "script": "pip install flowspec-cli semgrep bandit",
                     "displayName": "Install security tools",
                 },
                 {

--- a/tests/security/test_security_workflows.py
+++ b/tests/security/test_security_workflows.py
@@ -110,8 +110,8 @@ class TestSecurityScanWorkflow:
         assert "uv pip install --system ." in workflow_content, (
             "Should use 'uv pip install --system .' for local installation"
         )
-        assert "uv tool install specify-cli" not in workflow_content, (
-            "Should not use 'uv tool install specify-cli'"
+        assert "uv tool install flowspec-cli" not in workflow_content, (
+            "Should not use 'uv tool install flowspec-cli'"
         )
 
     def test_jq_has_error_handling(self, workflow_content):

--- a/tests/test_github_auth.py
+++ b/tests/test_github_auth.py
@@ -95,7 +95,7 @@ class TestGitHubHeaders:
         headers = _github_headers(None)
         assert "Authorization" not in headers
         assert headers["Accept"] == "application/vnd.github+json"
-        assert headers["User-Agent"] == "flowspec/specify-cli"
+        assert headers["User-Agent"] == "flowspec/flowspec-cli"
         assert headers["X-GitHub-Api-Version"] == "2022-11-28"
 
     def test_headers_with_valid_token(self):
@@ -132,7 +132,7 @@ class TestGitHubHeaders:
             assert "Authorization" not in headers
             # Other headers should still be present
             assert headers["Accept"] == "application/vnd.github+json"
-            assert headers["User-Agent"] == "flowspec/specify-cli"
+            assert headers["User-Agent"] == "flowspec/flowspec-cli"
 
     def test_skip_auth_with_cli_token_still_skips(self):
         """skip_auth=True ignores cli token too."""


### PR DESCRIPTION
## Summary

Final cleanup of `specify-cli` references in code and scripts.

## Changes

| File | Change |
|------|--------|
| `src/flowspec_cli/__init__.py` | User-Agent, upgrade commands, docstrings |
| `src/flowspec_cli/security/*.py` | pip install instructions |
| `src/flowspec_cli/.spec-kit-compatibility.yml` | uv tool install command |
| `tests/test_github_auth.py` | Test assertions |
| `tests/security/test_security_workflows.py` | Test assertions |
| `scripts/bash/install-flowspec-latest.sh` | Renamed from install-specify-latest.sh |

## Test plan

- [x] All 53 affected tests pass
- [x] Ruff lint/format passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)