### PR TITLE
docs(CLAUDE.md): add INITIAL doc guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,54 @@ backlog task edit 42 -s Done     # Complete task
 /qa:review          # Generate checklist
 ```
 
+## INITIAL Document Workflow
+
+**CRITICAL**: Before running `/flow:assess` or `/flow:specify`, ALWAYS look for and read the INITIAL document for the feature.
+
+### What is an INITIAL Document?
+
+INITIAL documents are the **primary source of high-level context** for features. They provide structured, comprehensive context that flows into PRDs, PRPs, and implementation tasks.
+
+### Location and Naming
+
+- **Location**: `docs/features/<feature-slug>-initial.md`
+- **Template**: `templates/docs/initial/initial-feature-template.md`
+- **Example**: `docs/features/backlog-task-management-initial.md`
+
+### When to Read INITIAL Documents
+
+**ALWAYS** check for an INITIAL document before running:
+- `/flow:assess` - Assessment requires understanding the full feature context
+- `/flow:specify` - PRD creation builds directly from INITIAL document content
+
+### What INITIAL Documents Contain
+
+Each INITIAL document includes:
+1. **FEATURE**: Problem statement, desired outcome, constraints, business impact
+2. **EXAMPLES**: Relevant example files, usage patterns, expected behaviors
+3. **DOCUMENTATION**: Links to PRDs, ADRs, external specs, related tasks
+4. **OTHER CONSIDERATIONS**: Gotchas, failures, dependencies, security, performance
+
+### Workflow Integration
+
+```bash
+# 1. Check for INITIAL document
+ls docs/features/*-initial.md
+
+# 2. Read the INITIAL document FIRST
+# (Use Read tool to load docs/features/<feature-slug>-initial.md)
+
+# 3. THEN run assessment or specification
+/flow:assess    # With full context from INITIAL doc
+/flow:specify   # Building PRD from INITIAL doc content
+```
+
+### Key Principle
+
+The INITIAL document is the **canonical source** for feature context. All downstream artifacts (assessments, PRDs, PRPs, tasks) should reference and build upon the context established in the INITIAL document.
+
+If no INITIAL document exists and the user requests `/flow:assess` or `/flow:specify`, suggest creating one first using `/flow:intake` or by manually copying the template.
+
 ## Engineering Subagents
 
 Flowspec includes specialized engineering subagents for implementation tasks. These agents are invoked during `/flow:implement` and provide focused expertise:

--- a/backlog/tasks/task-490 - claude-improves-again-Update-CLAUDE.md-to-prefer-INITIAL-docs.md
+++ b/backlog/tasks/task-490 - claude-improves-again-Update-CLAUDE.md-to-prefer-INITIAL-docs.md
@@ -5,7 +5,7 @@ status: To Do
 assignee:
   - '@muckross'
 created_date: '2025-12-14 03:06'
-updated_date: '2025-12-15 01:50'
+updated_date: '2025-12-17 01:25'
 labels:
   - context-engineering
   - documentation
@@ -24,8 +24,8 @@ Source: docs/research/archon-inspired.md Task 3
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 CLAUDE.md updated with INITIAL doc guidance
-- [ ] #2 Instructions state: read INITIAL doc before /flow:assess or /flow:specify
-- [ ] #3 Documents that INITIAL doc is primary source for feature context
-- [ ] #4 References the INITIAL template location
+- [x] #1 CLAUDE.md updated with INITIAL doc guidance
+- [x] #2 Instructions state: read INITIAL doc before /flow:assess or /flow:specify
+- [x] #3 Documents that INITIAL doc is primary source for feature context
+- [x] #4 References the INITIAL template location
 <!-- AC:END -->


### PR DESCRIPTION
## Summary

Adds comprehensive guidance to CLAUDE.md instructing Claude to read INITIAL documents before running `/flow:assess` or `/flow:specify` commands. This ensures that feature context is properly established from the canonical source before creating assessments or PRDs.

## Changes

- **New Section**: "INITIAL Document Workflow" added after Slash Commands section
- **Location Documentation**: Documents INITIAL doc location pattern `docs/features/<feature-slug>-initial.md`
- **Template Reference**: Points to `templates/docs/initial/initial-feature-template.md`
- **Workflow Integration**: Explains when and how to read INITIAL docs
- **Key Principle**: Establishes INITIAL doc as the canonical source for feature context

## Test Plan

- [x] AC 1: CLAUDE.md updated with INITIAL doc guidance
- [x] AC 2: Instructions state to read INITIAL doc before /flow:assess or /flow:specify
- [x] AC 3: Documents that INITIAL doc is primary source for feature context
- [x] AC 4: References the INITIAL template location
- [x] Ruff linting passed
- [x] Ruff formatting passed
- [x] All acceptance criteria marked complete

## Context

This change improves the SDD workflow by ensuring that Claude always checks for and reads INITIAL documents (the canonical source of feature context) before creating downstream artifacts like assessments and PRDs.

Related to task-490.

Generated with [Claude Code](https://claude.com/claude-code)