### PR TITLE
docs(prd-template): make examples section required

### DIFF
--- a/backlog/tasks/task-498 - claude-improves-again-Require-examples-in-PRDs.md
+++ b/backlog/tasks/task-498 - claude-improves-again-Require-examples-in-PRDs.md
@@ -5,7 +5,7 @@ status: To Do
 assignee:
   - '@muckross'
 created_date: '2025-12-14 03:06'
-updated_date: '2025-12-15 01:50'
+updated_date: '2025-12-17 01:25'
 labels:
   - context-engineering
   - templates
@@ -24,9 +24,9 @@ Source: docs/research/archon-inspired.md Task 11
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 /flow:specify template includes required Examples section
-- [ ] #2 Section lists relevant files from examples directory
-- [ ] #3 Each example has short explanation of relevance to feature
-- [ ] #4 Guidance states specs without examples are incomplete
-- [ ] #5 Template provides example format for referencing examples
+- [x] #1 /flow:specify template includes required Examples section
+- [x] #2 Section lists relevant files from examples directory
+- [x] #3 Each example has short explanation of relevance to feature
+- [x] #4 Guidance states specs without examples are incomplete
+- [x] #5 Template provides example format for referencing examples
 <!-- AC:END -->

--- a/templates/commands/flow/specify.md
+++ b/templates/commands/flow/specify.md
@@ -267,6 +267,29 @@ Please ensure the PRD is:
 - Traceable (requirements -> tasks -> tests -> outcomes)
 - Aligned with business objectives
 - Ready for engineering implementation
+- **INCLUDES AT LEAST ONE EXAMPLE REFERENCE** - PRDs without examples are incomplete
+
+## CRITICAL: Example Requirements
+
+**Every PRD MUST include at least one relevant example from the `examples/` directory.**
+
+Before writing the PRD:
+1. Search the `examples/` directory for relevant code samples
+2. Identify which examples demonstrate patterns or approaches applicable to this feature
+3. Include specific example references in the "All Needed Context > Examples" section
+
+**Good example references**:
+- Specify exact files: `examples/mcp/claude_security_agent.py`
+- Explain relevance: "Demonstrates MCP server setup pattern applicable to our API integration"
+- Reference specific patterns: "Shows error handling approach we should adopt"
+
+**Examples help implementers**:
+- Understand existing patterns and conventions
+- See working code they can adapt
+- Maintain consistency across the codebase
+- Avoid reinventing solutions
+
+If no relevant examples exist, note this explicitly and suggest creating one as part of the implementation.
 ```
 
 ### Output

--- a/templates/prd-template.md
+++ b/templates/prd-template.md
@@ -123,13 +123,29 @@ As a {user role}, I want {goal} so that {benefit}.
 
 ### Examples
 
+<!-- REQUIRED: PRDs without at least one example reference are considered incomplete -->
+<!-- Examples help implementers understand patterns, expected behavior, and best practices -->
 <!-- List example files that demonstrate patterns or expected behavior -->
-<!-- Format: | Example | Location | Relevance | -->
+
+**Requirement**: Every PRD MUST reference at least one relevant example from the `examples/` directory. Examples provide concrete implementations that guide development and ensure consistency.
+
+**Good Example Reference Criteria**:
+- **Relevance**: Example directly relates to the feature's technical domain or pattern
+- **Specificity**: Clear explanation of which parts of the example apply to this feature
+- **Actionable**: Implementer can extract specific patterns or approaches from the example
+
+**Format**: | Example Name | Location | Relevance to This Feature |
 
 | Example | Location | Relevance to This Feature |
 |---------|----------|---------------------------|
-| {Example name} | `examples/{path}` | {How this example relates to the feature} |
-| {Example name} | `examples/{path}` | {How this example relates to the feature} |
+| {Example name} | `examples/{path}` | {How this example relates - be specific about which patterns/functions/approaches apply} |
+| {Example name} | `examples/{path}` | {How this example relates - be specific about which patterns/functions/approaches apply} |
+
+**Example of a Good Reference**:
+| MCP Security Agent | `examples/mcp/claude_security_agent.py` | Demonstrates MCP server setup and tool registration pattern that applies to our feature's API integration |
+
+**Example of a Poor Reference** (too vague):
+| Security Example | `examples/mcp/` | Shows security stuff |
 
 ### Gotchas / Prior Failures
 


### PR DESCRIPTION
## Summary
- Updated PRD template to require at least one example reference
- Enhanced /flow:specify command to emphasize example requirements
- Added clear guidance on what makes a good example reference

## Changes

### PRD Template (`templates/prd-template.md`)
- Made Examples section explicitly REQUIRED
- Added note: "PRDs without at least one example reference are considered incomplete"
- Provided criteria for good example references (Relevance, Specificity, Actionable)
- Included concrete examples of good vs poor example documentation
- Enhanced format guidance with specific examples

### Specify Command (`templates/commands/flow/specify.md`)
- Added CRITICAL section on example requirements
- Emphasized examples requirement in the agent checklist
- Provided step-by-step guidance for finding relevant examples
- Explained the value examples provide to implementers

## Rationale

Examples are critical for:
- Understanding existing patterns and conventions
- Seeing working code that can be adapted
- Maintaining consistency across the codebase
- Reducing ambiguity in specifications

By making examples mandatory, we ensure every PRD provides concrete references that guide implementation and improve specification quality.

## Test Plan
- [x] AC1: /flow:specify template includes required Examples section
- [x] AC2: Section lists relevant files from examples directory
- [x] AC3: Each example has short explanation of relevance to feature
- [x] AC4: Guidance states specs without examples are incomplete
- [x] AC5: Template provides example format for referencing examples

Closes task-498

🤖 Generated with [Claude Code](https://claude.com/claude-code)