### PR TITLE
docs(prd-template): make examples section required (v10)

### DIFF
--- a/.github/agents/flow-specify.agent.md
+++ b/.github/agents/flow-specify.agent.md
@@ -607,6 +607,29 @@ Please ensure the PRD is:
 - Traceable (requirements -> tasks -> tests -> outcomes)
 - Aligned with business objectives
 - Ready for engineering implementation
+- **INCLUDES AT LEAST ONE EXAMPLE REFERENCE** - PRDs without examples are incomplete
+
+## CRITICAL: Example Requirements
+
+**Every PRD MUST include at least one relevant example from the `examples/` directory.**
+
+Before writing the PRD:
+1. Search the `examples/` directory for relevant code samples
+2. Identify which examples demonstrate patterns or approaches applicable to this feature
+3. Include specific example references in the "All Needed Context > Examples" section
+
+**Good example references**:
+- Specify exact files: `examples/mcp/claude_security_agent.py`
+- Explain relevance: "Demonstrates MCP server setup pattern applicable to our API integration"
+- Reference specific patterns: "Shows error handling approach we should adopt"
+
+**Examples help implementers**:
+- Understand existing patterns and conventions
+- See working code they can adapt
+- Maintain consistency across the codebase
+- Avoid reinventing solutions
+
+If no relevant examples exist, note this explicitly and suggest creating one as part of the implementation.
 ```
 
 ### Output

--- a/backlog/tasks/task-498 - claude-improves-again-Require-examples-in-PRDs.md
+++ b/backlog/tasks/task-498 - claude-improves-again-Require-examples-in-PRDs.md
@@ -5,7 +5,7 @@ status: To Do
 assignee:
   - '@muckross'
 created_date: '2025-12-14 03:06'
-updated_date: '2025-12-15 01:50'
+updated_date: '2025-12-17 01:25'
 labels:
   - context-engineering
   - templates
@@ -24,9 +24,9 @@ Source: docs/research/archon-inspired.md Task 11
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 /flow:specify template includes required Examples section
-- [ ] #2 Section lists relevant files from examples directory
-- [ ] #3 Each example has short explanation of relevance to feature
-- [ ] #4 Guidance states specs without examples are incomplete
-- [ ] #5 Template provides example format for referencing examples
+- [x] #1 /flow:specify template includes required Examples section
+- [x] #2 Section lists relevant files from examples directory
+- [x] #3 Each example has short explanation of relevance to feature
+- [x] #4 Guidance states specs without examples are incomplete
+- [x] #5 Template provides example format for referencing examples
 <!-- AC:END -->

--- a/templates/commands/flow/specify.md
+++ b/templates/commands/flow/specify.md
@@ -271,6 +271,29 @@ Please ensure the PRD is:
 - Traceable (requirements -> tasks -> tests -> outcomes)
 - Aligned with business objectives
 - Ready for engineering implementation
+- **INCLUDES AT LEAST ONE EXAMPLE REFERENCE** - PRDs without examples are incomplete
+
+## CRITICAL: Example Requirements
+
+**Every PRD MUST include at least one relevant example from the `examples/` directory.**
+
+Before writing the PRD:
+1. Search the `examples/` directory for relevant code samples
+2. Identify which examples demonstrate patterns or approaches applicable to this feature
+3. Include specific example references in the "All Needed Context > Examples" section
+
+**Good example references**:
+- Specify exact files: `examples/mcp/claude_security_agent.py`
+- Explain relevance: "Demonstrates MCP server setup pattern applicable to our API integration"
+- Reference specific patterns: "Shows error handling approach we should adopt"
+
+**Examples help implementers**:
+- Understand existing patterns and conventions
+- See working code they can adapt
+- Maintain consistency across the codebase
+- Avoid reinventing solutions
+
+If no relevant examples exist, note this explicitly and suggest creating one as part of the implementation.
 ```
 
 ### Output

--- a/templates/prd-template.md
+++ b/templates/prd-template.md
@@ -123,13 +123,33 @@ As a {user role}, I want {goal} so that {benefit}.
 
 ### Examples
 
+<!-- REQUIRED: PRDs without at least one example reference are considered incomplete -->
+<!-- Examples help implementers understand patterns, expected behavior, and best practices -->
 <!-- List example files that demonstrate patterns or expected behavior -->
-<!-- Format: | Example | Location | Relevance | -->
+
+**Requirement**: Every PRD MUST reference at least one relevant example from the `examples/` directory. Examples provide concrete implementations that guide development and ensure consistency.
+
+**Good Example Reference Criteria**:
+- **Relevance**: Example directly relates to the feature's technical domain or pattern
+- **Specificity**: Clear explanation of which parts of the example apply to this feature
+- **Actionable**: Implementer can extract specific patterns or approaches from the example
 
 | Example | Location | Relevance to This Feature |
 |---------|----------|---------------------------|
-| {Example name} | `examples/{path}` | {How this example relates to the feature} |
-| {Example name} | `examples/{path}` | {How this example relates to the feature} |
+| {Example name} | `examples/{path}` | {How this example relates - be specific about which patterns/functions/approaches apply} |
+| {Example name} | `examples/{path}` | {How this example relates - be specific about which patterns/functions/approaches apply} |
+
+<!-- Example of a Good Reference (wrapped in HTML comment to prevent validator from counting it):
+| Example | Location | Relevance to This Feature |
+|---------|----------|---------------------------|
+| MCP Security Agent | `examples/mcp/claude_security_agent.py` | Demonstrates MCP server setup and tool registration pattern that applies to our feature's API integration |
+-->
+
+<!-- Example of a Poor Reference - too vague (wrapped in HTML comment):
+| Example | Location | Relevance to This Feature |
+|---------|----------|---------------------------|
+| Security Example | `examples/mcp/README.md` | Shows security stuff |
+-->
 
 ### Gotchas / Prior Failures
 

--- a/tests/test_prd_validator.py
+++ b/tests/test_prd_validator.py
@@ -128,6 +128,14 @@ System must respond within 200ms.
 ## Success Metrics
 
 - Login success rate > 99%
+
+## All Needed Context
+
+### Examples
+
+| Example | Location | Relevance to This Feature |
+|---------|----------|---------------------------|
+| Auth Example | `examples/auth/login.py` | Demonstrates authentication patterns |
 """
 
     @pytest.fixture
@@ -184,6 +192,14 @@ NFR.
 ## Success Metrics
 
 Metrics.
+
+## All Needed Context
+
+### Examples
+
+| Example | Location | Relevance to This Feature |
+|---------|----------|---------------------------|
+| Auth Example | `examples/auth/login.py` | Example authentication patterns |
 """
 
     def test_validate_valid_prd(
@@ -263,6 +279,144 @@ Metrics.
         assert not result.is_valid
         assert any("user stories" in e.lower() for e in result.errors)
 
+    def test_validate_missing_all_needed_context(
+        self,
+        validator: PRDValidator,
+        tmp_path: Path,
+    ) -> None:
+        """Test validating PRD missing All Needed Context section (includes Examples)."""
+        content = """# PRD: Auth
+
+## Executive Summary
+
+Summary.
+
+## Problem Statement
+
+Problem.
+
+## User Stories
+
+As a user, I want to login so that I can access.
+
+## Functional Requirements
+
+Requirements.
+
+## Non-Functional Requirements
+
+NFR.
+
+## Success Metrics
+
+Metrics.
+"""
+        prd_file = tmp_path / "auth.md"
+        prd_file.write_text(content)
+
+        result = validator.validate_prd(prd_file)
+
+        assert not result.is_valid
+        assert any("all needed context" in e.lower() for e in result.errors)
+
+    def test_validate_missing_example_references(
+        self,
+        validator: PRDValidator,
+        tmp_path: Path,
+    ) -> None:
+        """Test validating PRD with All Needed Context but no example references."""
+        content = """# PRD: Auth
+
+## Executive Summary
+
+Summary.
+
+## Problem Statement
+
+Problem.
+
+## User Stories
+
+As a user, I want to login so that I can access.
+
+## Functional Requirements
+
+Requirements.
+
+## Non-Functional Requirements
+
+NFR.
+
+## Success Metrics
+
+Metrics.
+
+## All Needed Context
+
+### Examples
+
+No examples provided yet.
+"""
+        prd_file = tmp_path / "auth.md"
+        prd_file.write_text(content)
+
+        result = validator.validate_prd(prd_file)
+
+        assert not result.is_valid
+        assert any("example references" in e.lower() for e in result.errors)
+        assert result.example_count == 0
+
+    def test_validate_placeholder_example_references_excluded(
+        self,
+        validator: PRDValidator,
+        tmp_path: Path,
+    ) -> None:
+        """Test that placeholder rows with curly braces are excluded from example count."""
+        content = """# PRD: Auth
+
+## Executive Summary
+
+Summary.
+
+## Problem Statement
+
+Problem.
+
+## User Stories
+
+As a user, I want to login so that I can access.
+
+## Functional Requirements
+
+Requirements.
+
+## Non-Functional Requirements
+
+NFR.
+
+## Success Metrics
+
+Metrics.
+
+## All Needed Context
+
+### Examples
+
+| Example | Location | Relevance to This Feature |
+|---------|----------|---------------------------|
+| {Example name} | `examples/{path}` | {How this example relates} |
+| {Another example} | examples/{another/path} | {Description} |
+"""
+        prd_file = tmp_path / "auth.md"
+        prd_file.write_text(content)
+
+        result = validator.validate_prd(prd_file)
+
+        # Placeholder rows should be excluded, so example_count should be 0
+        assert result.example_count == 0
+        assert not result.is_valid
+        assert any("example references" in e.lower() for e in result.errors)
+
     def test_validate_empty_section(
         self,
         validator: PRDValidator,
@@ -292,6 +446,14 @@ NFR.
 ## Success Metrics
 
 Metrics.
+
+## All Needed Context
+
+### Examples
+
+| Example | Location | Relevance to This Feature |
+|---------|----------|---------------------------|
+| Auth Example | `examples/auth/login.py` | Example authentication patterns |
 """
         prd_file = tmp_path / "auth.md"
         prd_file.write_text(content)
@@ -367,6 +529,14 @@ NFR.
 ## Success Metrics
 
 Metrics.
+
+## All Needed Context
+
+### Examples
+
+| Example | Location | Relevance to This Feature |
+|---------|----------|---------------------------|
+| Auth Example | `examples/auth/login.py` | Example authentication patterns |
 """
         prd_file = tmp_path / "auth.md"
         prd_file.write_text(content)
@@ -416,6 +586,14 @@ NFR.
 ## Success Metrics
 
 Metrics.
+
+## All Needed Context
+
+### Examples
+
+| Example | Location | Relevance to This Feature |
+|---------|----------|---------------------------|
+| Auth Example | `examples/auth/login.py` | Example authentication patterns |
 """
         prd_file = tmp_path / "auth.md"
         prd_file.write_text(content)
@@ -462,6 +640,14 @@ NFR.
 ## Success Metrics
 
 Metrics.
+
+## All Needed Context
+
+### Examples
+
+| Example | Location | Relevance to This Feature |
+|---------|----------|---------------------------|
+| Auth Example | `examples/auth/login.py` | Example authentication patterns |
 """
         (prd_dir / "auth.md").write_text(content)
 


### PR DESCRIPTION
## Summary

- Make the Examples section within "All Needed Context" a required PRD component
- Add programmatic validation requiring at least one example reference
- Regex excludes placeholder rows with curly braces like {path}
- Demo tables (good/poor reference) wrapped in HTML comments
- Updated module docstring to list All Needed Context
- Added test for placeholder exclusion (22 tests total)

## Changes from v9
- Wrapped demonstration tables in HTML comments to prevent validator counting them

## Test plan
- [x] All 22 PRD validator tests pass
- [x] Regex correctly excludes placeholder patterns
- [x] Demo tables in HTML comments won't be counted

🤖 Generated with [Claude Code](https://claude.com/claude-code)