### PR TITLE
fix(ci): auto-fix agent drift in PRs instead of failing

### DIFF
--- a/.github/workflows/validate-agent-sync.yml
+++ b/.github/workflows/validate-agent-sync.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   # First job: Auto-fix drift on PRs (ubuntu only)
   auto-fix-drift:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

Eliminates the manual sync-and-push cycle when working on template changes by having CI auto-fix drift.

### The Problem

When working on `templates/commands/` files:
1. Make template changes
2. Push PR
3. CI detects drift between templates and `.github/agents/`
4. CI fails ❌
5. Manually run `sync-copilot-agents.sh --force`
6. Commit and push
7. CI passes ✅

This is especially painful after rebasing from main when template PRs were merged.

### The Solution

CI now auto-fixes drift:
1. `auto-fix-drift` job (ubuntu-only) runs first on PRs
2. If drift detected, syncs agents and commits back to PR branch
3. Validation jobs are skipped (new CI run triggered by push)
4. Second run passes with no drift ✅

### Flow Diagram

```
PR Push
  │
  ▼
auto-fix-drift (ubuntu)
  │
  ├─ No drift? → validate-agent-sync (all platforms)
  │
  └─ Drift? → Sync → Commit → Push → [Re-run triggered]
                                         │
                                         ▼
                                    auto-fix-drift
                                         │
                                         └─ No drift → validate-agent-sync ✅
```

### Key Changes

- Add `auto-fix-drift` job that runs before validation on PRs
- Add `contents: write` permission for commit/push
- Skip `validate-agent-sync` if auto-fix pushed (re-run will validate)
- Add concurrency group to cancel in-progress runs

Supersedes #964.

🤖 Generated with [Claude Code](https://claude.com/claude-code)