### PR TITLE
fix(cli): fix upgrade-tools bug + add version tracking

### DIFF
--- a/src/flowspec_cli/__init__.py
+++ b/src/flowspec_cli/__init__.py
@@ -965,6 +965,119 @@ def get_all_component_versions() -> dict:
     }
 
 
+def write_version_tracking_file(
+    project_path: Path,
+    flowspec_version: str | None = None,
+    backlog_version: str | None = None,
+    beads_version: str | None = None,
+    is_upgrade: bool = False,
+) -> None:
+    """Write or update the .flowspec/.version tracking file.
+
+    Args:
+        project_path: Path to the project root
+        flowspec_version: flowspec version to record (uses __version__ if None)
+        backlog_version: backlog-md version to record (auto-detects if None)
+        beads_version: beads version to record (auto-detects if None)
+        is_upgrade: True if this is an upgrade operation (updates upgraded_at timestamp)
+    """
+    flowspec_dir = project_path / ".flowspec"
+    version_file = flowspec_dir / ".version"
+
+    # Get current versions if not provided
+    if flowspec_version is None:
+        flowspec_version = __version__
+    if backlog_version is None:
+        backlog_version = check_backlog_installed_version()
+    if beads_version is None:
+        beads_version = check_beads_installed_version()
+
+    # Load existing data if file exists
+    existing_data = {}
+    if version_file.exists():
+        try:
+            with open(version_file, "r") as f:
+                existing_data = yaml.safe_load(f) or {}
+        except Exception:
+            # If we can't read the file, start fresh
+            pass
+
+    # Build the version data
+    versions = {"flowspec": flowspec_version or "unknown"}
+    if backlog_version:
+        versions["backlog"] = backlog_version
+    if beads_version:
+        versions["beads"] = beads_version
+
+    # Build metadata
+    now = datetime.now().isoformat()
+    metadata = existing_data.get("metadata", {})
+
+    if not metadata.get("installed_at"):
+        metadata["installed_at"] = now
+
+    if is_upgrade:
+        metadata["upgraded_at"] = now
+    else:
+        # For init, set both installed_at and last_checked
+        metadata["installed_at"] = now
+        metadata["last_checked"] = now
+
+    # Write to file in TOML-like format (using YAML which is compatible)
+    flowspec_dir.mkdir(parents=True, exist_ok=True)
+
+    # Write as YAML but format it to look TOML-like for readability
+    with open(version_file, "w") as f:
+        f.write("[versions]\n")
+        for key, value in versions.items():
+            f.write(f'{key} = "{value}"\n')
+        f.write("\n[metadata]\n")
+        for key, value in metadata.items():
+            f.write(f'{key} = "{value}"\n')
+
+
+def read_version_tracking_file(project_path: Path) -> dict | None:
+    """Read the .flowspec/.version tracking file.
+
+    Args:
+        project_path: Path to the project root
+
+    Returns:
+        Dictionary with versions and metadata, or None if file doesn't exist
+    """
+    version_file = project_path / ".flowspec" / ".version"
+    if not version_file.exists():
+        return None
+
+    try:
+        # Read the TOML-like file manually since we wrote it in a simple format
+        versions = {}
+        metadata = {}
+        current_section = None
+
+        with open(version_file, "r") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                if line == "[versions]":
+                    current_section = "versions"
+                elif line == "[metadata]":
+                    current_section = "metadata"
+                elif "=" in line and current_section:
+                    key, value = line.split("=", 1)
+                    key = key.strip()
+                    value = value.strip().strip('"')
+                    if current_section == "versions":
+                        versions[key] = value
+                    elif current_section == "metadata":
+                        metadata[key] = value
+
+        return {"versions": versions, "metadata": metadata}
+    except Exception:
+        return None
+
+
 def _has_upgrade(versions: dict) -> bool:
     """Check if a component has an available upgrade.
 
@@ -1791,6 +1904,120 @@ def callback(
 def version():
     """Show detailed version information for all components."""
     show_version_info(detailed=True)
+
+
+@app.command(name="repo-version")
+def repo_version():
+    """Show version information for tools installed in the current repository.
+
+    Reads the .flowspec/.version file to show which versions of flowspec,
+    backlog-md, and beads were used to initialize or upgrade this repository.
+
+    This is useful for troubleshooting version mismatches or understanding
+    what tools were used to set up the project.
+    """
+    show_banner()
+
+    # Detect project root
+    project_path = Path.cwd()
+    version_data = read_version_tracking_file(project_path)
+
+    if not version_data:
+        console.print("[yellow]No version tracking file found.[/yellow]")
+        console.print()
+        console.print("This could mean:")
+        console.print("  • This repository was not initialized with flowspec")
+        console.print(
+            "  • The repository was initialized before version tracking was added"
+        )
+        console.print("  • You are not in a flowspec-initialized directory")
+        console.print()
+        console.print(
+            "[cyan]Run 'flowspec upgrade-repo' to update and create version tracking.[/cyan]"
+        )
+        return
+
+    versions = version_data.get("versions", {})
+    metadata = version_data.get("metadata", {})
+
+    # Build version table
+    table = Table(show_header=True, box=None, padding=(0, 2))
+    table.add_column("Component", style="cyan")
+    table.add_column("Version", style="green")
+
+    # Add rows for each component
+    if "flowspec" in versions:
+        table.add_row("flowspec", versions["flowspec"])
+    if "backlog" in versions:
+        table.add_row("backlog-md", versions["backlog"])
+    if "beads" in versions:
+        table.add_row("beads", versions["beads"])
+
+    console.print()
+    console.print(table)
+    console.print()
+
+    # Show metadata if available
+    if metadata:
+        meta_table = Table(show_header=True, box=None, padding=(0, 2))
+        meta_table.add_column("Metadata", style="cyan")
+        meta_table.add_column("Value", style="dim")
+
+        if "installed_at" in metadata:
+            meta_table.add_row("Installed at", metadata["installed_at"])
+        if "upgraded_at" in metadata:
+            meta_table.add_row("Last upgraded", metadata["upgraded_at"])
+        if "last_checked" in metadata:
+            meta_table.add_row("Last checked", metadata["last_checked"])
+
+        console.print(meta_table)
+        console.print()
+
+    # Show comparison with currently installed tools
+    console.print("[cyan]Currently installed tools:[/cyan]")
+    current_table = Table(show_header=True, box=None, padding=(0, 2))
+    current_table.add_column("Component", style="cyan")
+    current_table.add_column("Installed", style="green")
+    current_table.add_column("In Repo", style="dim")
+    current_table.add_column("Status", style="yellow")
+
+    # Check flowspec
+    current_flowspec = __version__
+    repo_flowspec = versions.get("flowspec", "-")
+    if current_flowspec == repo_flowspec:
+        status = "[green]✓ Match[/green]"
+    elif current_flowspec and repo_flowspec != "-":
+        status = "[yellow]⚠ Mismatch[/yellow]"
+    else:
+        status = "[dim]-[/dim]"
+    current_table.add_row("flowspec", current_flowspec, repo_flowspec, status)
+
+    # Check backlog
+    current_backlog = check_backlog_installed_version() or "-"
+    repo_backlog = versions.get("backlog", "-")
+    if current_backlog == repo_backlog:
+        status = "[green]✓ Match[/green]"
+    elif current_backlog != "-" and repo_backlog != "-":
+        status = "[yellow]⚠ Mismatch[/yellow]"
+    else:
+        status = "[dim]-[/dim]"
+    current_table.add_row("backlog-md", current_backlog, repo_backlog, status)
+
+    # Check beads
+    current_beads = check_beads_installed_version() or "-"
+    repo_beads = versions.get("beads", "-")
+    if current_beads == repo_beads:
+        status = "[green]✓ Match[/green]"
+    elif current_beads != "-" and repo_beads != "-":
+        status = "[yellow]⚠ Mismatch[/yellow]"
+    else:
+        status = "[dim]-[/dim]"
+    current_table.add_row("beads", current_beads, repo_beads, status)
+
+    console.print(current_table)
+    console.print()
+
+    console.print("[dim]Use 'flowspec version' to see available updates[/dim]")
 
 
 def run_command(
@@ -3662,6 +3889,10 @@ def init(
     console.print()
     console.print("[green]Generated flowspec_workflow.yml[/green]")
 
+    # Write version tracking file
+    write_version_tracking_file(project_path, is_upgrade=False)
+    console.print("[green]Created version tracking file[/green]")
+
     # Display validation summary
     display_validation_summary(transition_modes)
 
@@ -3954,6 +4185,9 @@ def upgrade_repo(
     console.print("\n[bold green]Upgrade completed successfully![/bold green]")
     console.print(f"[dim]Backup of previous templates: {backup_dir}[/dim]")
 
+    # Update version tracking file
+    write_version_tracking_file(project_path, is_upgrade=True)
+
     # Check and offer to sync backlog-md version
     current_backlog_version = check_backlog_installed_version()
     recommended_version = get_backlog_validated_version()
@@ -4117,23 +4351,8 @@ def _upgrade_jp_spec_kit(
             f"Would install version {install_version} (current: {current_version})",
         )
 
-    # For specific versions, always use direct git install (skip uv upgrade)
-    # For latest, try uv upgrade first
-    if not target_version:
-        try:
-            result = subprocess.run(
-                ["uv", "tool", "upgrade", "flowspec-cli"],
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-            if result.returncode == 0:
-                new_version = _get_installed_jp_spec_kit_version()
-                if new_version and compare_semver(new_version, current_version) > 0:
-                    return True, f"Upgraded from {current_version} to {new_version}"
-        except FileNotFoundError:
-            # uv not found - fall through to git-based installation below
-            pass
+    # Always use git-based installation since flowspec-cli is installed from git, not PyPI
+    # Using 'uv tool upgrade' returns 0 but doesn't actually upgrade git-sourced packages
 
     # Install from git at the specific release tag
     git_url = f"git+https://github.com/{EXTENSION_REPO_OWNER}/{EXTENSION_REPO_NAME}.git"
@@ -4156,7 +4375,7 @@ def _upgrade_jp_spec_kit(
         )
         # After successful install, trust the version we just installed
         # rather than re-detecting which may return stale results due to shell caching
-        return True, f"Installed version {install_version} (was: {current_version})"
+        return True, f"Upgraded from {current_version} to {install_version}"
     except subprocess.CalledProcessError as e:
         return False, f"Install failed: {e.stderr}"
     except FileNotFoundError:


### PR DESCRIPTION
## Summary

This PR fixes task-310 (upgrade-tools reports success but doesn't upgrade) and adds version tracking to help prevent similar issues in the future.

### Bug Fix: upgrade-tools

**Problem:**
- `flowspec upgrade-tools` reported "Upgraded successfully" but version didn't change
- Root cause: `uv tool upgrade flowspec-cli` returns exit code 0 even when it doesn't upgrade
- Why: flowspec-cli is installed from git, not PyPI, so `uv upgrade` doesn't work

**Solution:**
- Skip `uv tool upgrade` entirely
- Always use `uv tool install --force` with git URL for upgrades
- Changed success message from "Installed version X (was: Y)" to "Upgraded from X to Y"
- Works for both targeted (`--version X.X.X`) and latest upgrades

### Version Tracking Feature

**New `.flowspec/.version` file:**
```toml
[versions]
flowspec = "0.3.007"
backlog = "0.5.2"
beads = "0.2.1"

[metadata]
installed_at = "2025-12-19T14:00:00Z"
upgraded_at = "2025-12-19T15:00:00Z"
```

**When created/updated:**
- Created during `flowspec init`
- Updated during `flowspec upgrade-repo`
- Tracks flowspec, backlog-md, and beads versions
- Records installation and upgrade timestamps

**New `flowspec repo-version` command:**
- Shows versions of tools used to initialize/upgrade repository
- Displays comparison with currently installed tools
- Helps troubleshoot version mismatches

Example output:
```
Component    Version
flowspec     0.3.007
backlog-md   0.5.2
beads        0.2.1

Metadata          Value
Installed at      2025-12-19T14:00:00Z
Last upgraded     2025-12-19T15:00:00Z

Currently installed tools:
Component    Installed    In Repo    Status
flowspec     0.3.007      0.3.007    ✓ Match
backlog-md   0.5.3        0.5.2      ⚠ Mismatch
beads        0.2.1        0.2.1      ✓ Match
```

## Test Plan

- [x] Fixed 2 upgrade-tools tests to reflect new behavior
- [x] All 38 upgrade command tests passing
- [x] All 30 version display tests passing
- [x] Linter and formatter pass (ruff check/format)
- [x] Manual testing of upgrade-tools command
- [x] Manual testing of repo-version command

## Changes

**Modified files:**
- `src/flowspec_cli/__init__.py`:
  - Fixed `_upgrade_jp_spec_kit()` to use git install directly
  - Added `write_version_tracking_file()` helper
  - Added `read_version_tracking_file()` helper
  - Hooked version tracking into `init()` command
  - Hooked version tracking into `upgrade_repo()` command
  - Added new `repo_version()` command

- `tests/test_upgrade_commands.py`:
  - Updated `test_uv_upgrade_fallback_when_version_unchanged()`
  - Updated `test_uv_not_found_fallback()`

## Resolves

- Fixes task-310

🤖 Generated with [Claude Code](https://claude.com/claude-code)