### PR TITLE
fix(cli): fix upgrade-tools bug + add version tracking

### DIFF
--- a/src/flowspec_cli/__init__.py
+++ b/src/flowspec_cli/__init__.py
@@ -1036,9 +1036,24 @@ def write_version_tracking_file(
             f.write("\n[metadata]\n")
             for key, value in metadata.items():
                 f.write(f'{key} = "{value}"\n')
+    except PermissionError as e:
+        # Don't fail init/upgrade if version tracking fails - just log warning
+        logger.warning(
+            "Could not write version tracking file (permission denied): %s",
+            e,
+        )
+    except FileNotFoundError as e:
+        # Underlying directory structure is missing or inaccessible
+        logger.warning(
+            "Could not write version tracking file (path not found): %s",
+            e,
+        )
     except OSError as e:
         # Don't fail init/upgrade if version tracking fails - just log warning
-        logger.warning(f"Could not write version tracking file: {e}")
+        logger.warning(
+            "Could not write version tracking file (OS error): %s",
+            e,
+        )
 
 
 def read_version_tracking_file(project_path: Path) -> dict | None:


### PR DESCRIPTION
## Summary

- **Fixed upgrade-tools bug**: The command now properly performs upgrades instead of just reporting success
- **Added `.flowspec/.version` tracking file**: Records installed versions of flowspec, backlog, and beads with UTC timestamps

## Implementation Details

- Use `datetime.now(timezone.utc).isoformat()` for timezone-aware timestamps
- Use Python 3.11+ built-in `tomllib` for robust TOML parsing
- Comprehensive error handling - version tracking never blocks init/upgrade
- Set `installed_at` if missing during upgrade (for pre-existing repos)
- 8 unit tests for version tracking functions

## Changes

- `src/flowspec_cli/__init__.py`:
  - Added `import tomllib` for robust TOML parsing
  - Added `from datetime import timezone` for UTC timestamps
  - Implemented `write_version_tracking_file()` with full error handling
  - Implemented `read_version_tracking_file()` using tomllib

- `tests/test_upgrade_commands.py`:
  - Added `TestVersionTrackingFile` class with 8 unit tests

## Test plan

- [x] All 46 upgrade command tests pass
- [x] Version tracking tests cover: write, read, upgrade, missing installed_at, UTC timestamps, invalid TOML, write errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)