### PR TITLE
fix(cli): fix upgrade-tools bug + add version tracking

### DIFF
--- a/src/flowspec_cli/__init__.py
+++ b/src/flowspec_cli/__init__.py
@@ -1036,9 +1036,24 @@ def write_version_tracking_file(
             f.write("\n[metadata]\n")
             for key, value in metadata.items():
                 f.write(f'{key} = "{value}"\n')
+    except PermissionError as e:
+        # Don't fail init/upgrade if version tracking fails - just log warning
+        logger.warning(
+            "Could not write version tracking file (permission denied): %s",
+            e,
+        )
+    except FileNotFoundError as e:
+        # Underlying directory structure is missing or inaccessible
+        logger.warning(
+            "Could not write version tracking file (path not found): %s",
+            e,
+        )
     except OSError as e:
         # Don't fail init/upgrade if version tracking fails - just log warning
-        logger.warning(f"Could not write version tracking file: {e}")
+        logger.warning(
+            "Could not write version tracking file (OS error): %s",
+            e,
+        )
 
 
 def read_version_tracking_file(project_path: Path) -> dict | None:


### PR DESCRIPTION
## Summary
- Fix upgrade-tools command that reported success but didn't actually upgrade
- Add `.flowspec/.version` tracking file with TOML format
- Use UTC timestamps and proper error handling
- Add 8 comprehensive unit tests

## Changes
- `write_version_tracking_file()` - Creates/updates version file with UTC timestamps
- `read_version_tracking_file()` - Reads using Python 3.11+ `tomllib`
- Specific exception handling (PermissionError, FileNotFoundError, OSError)
- Cross-platform test compatibility (Windows skipif decorator)

## Test plan
- [x] All 46 tests pass
- [x] Version file created on init
- [x] Version file updated on upgrade (preserves installed_at)
- [x] UTC timestamps verified
- [x] Error handling verified (non-raising)

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)