### PR TITLE
fix(release): copy include files instead of processing them

### DIFF
--- a/.github/workflows/scripts/create-release-packages.sh
+++ b/.github/workflows/scripts/create-release-packages.sh
@@ -117,6 +117,23 @@ generate_commands() {
       local name description script_command agent_script_command body
       name=$(basename "$template" .md)
 
+      # Include files (starting with _) should be copied as-is, not processed as commands
+      # They are referenced by other commands using {{INCLUDE:...}} at runtime
+      if [[ "$name" == _* ]]; then
+        case $ext in
+          md)
+            mkdir -p "$output_dir/flow"
+            cp "$template" "$output_dir/flow/$name.md"
+            echo "  Copied include file: $name.md"
+            ;;
+          *)
+            # Skip include files for non-md formats (toml, prompt.md)
+            # as they embed content directly in the command
+            ;;
+        esac
+        continue
+      fi
+
       # Normalize line endings
       file_content=$(tr -d '\r' < "$template")
 


### PR DESCRIPTION
## Summary

- Fix broken pipe error in release workflow caused by `_*.md` include files
- Include files have no YAML frontmatter, causing SIGPIPE when processing large files
- Now copies include files directly instead of trying to process them as commands

## Root Cause

The `_rigor-rules.md` file (38KB, 1,278 lines) was introduced after v0.3.006 and has no YAML frontmatter. When the release script tries to extract a description using `printf | awk`, the pipeline causes SIGPIPE because awk exits immediately without finding `description:`.

## Fix

Detect include files by their `_` prefix and copy them as-is to the output directory. They're referenced at runtime via `{{INCLUDE:...}}` directives.

## Files Changed

- `.github/workflows/scripts/create-release-packages.sh` - Add include file detection and copy logic

## Test Plan

- [ ] Merge this PR
- [ ] Delete orphaned tags: `git push origin --delete v0.3.007 v0.3.008`
- [ ] Re-run release: `./scripts/release.py 0.3.009`
- [ ] Verify release completes successfully
- [ ] Verify include files are present in release archives

🤖 Generated with [Claude Code](https://claude.com/claude-code)