### PR TITLE
chore: close task-310 family - already implemented

### DIFF
--- a/backlog/tasks/task-310 - Fix-upgrade-tools-Reports-success-but-doesn't-actually-upgrade.md
+++ b/backlog/tasks/task-310 - Fix-upgrade-tools-Reports-success-but-doesn't-actually-upgrade.md
@@ -1,11 +1,11 @@
 ---
 id: task-310
 title: 'Fix upgrade-tools: Reports success but doesn''t actually upgrade'
-status: To Do
+status: Done
 assignee:
   - '@adare'
 created_date: '2025-12-08 01:40'
-updated_date: '2025-12-15 01:48'
+updated_date: '2025-12-29 12:12'
 labels:
   - bug
   - cli
@@ -86,9 +86,15 @@ git_url = f"{git_url}@v{install_version}"
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 When Available > Current version, `specify upgrade-tools` actually installs the new version
-- [ ] #2 Status message shows correct 'Upgraded from X to Y' (not same version twice)
-- [ ] #3 Version detection after install correctly reads new version
-- [ ] #4 Works for both targeted (--version X.X.X) and latest upgrades
-- [ ] #5 Unit tests cover the upgrade flow scenarios
+- [x] #1 When Available > Current version, `specify upgrade-tools` actually installs the new version
+- [x] #2 Status message shows correct 'Upgraded from X to Y' (not same version twice)
+- [x] #3 Version detection after install correctly reads new version
+- [x] #4 Works for both targeted (--version X.X.X) and latest upgrades
+- [x] #5 Unit tests cover the upgrade flow scenarios
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+All subtasks (310.01, 310.02, 310.03) verified complete - fix was already implemented
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-310.01 - Fix-version-detection-after-upgrade-install.md
+++ b/backlog/tasks/task-310.01 - Fix-version-detection-after-upgrade-install.md
@@ -1,11 +1,11 @@
 ---
 id: task-310.01
 title: Fix version detection after upgrade install
-status: To Do
+status: Done
 assignee:
   - '@adare'
 created_date: '2025-12-08 01:41'
-updated_date: '2025-12-15 02:17'
+updated_date: '2025-12-29 12:12'
 labels:
   - bug
   - cli
@@ -32,6 +32,12 @@ Fix `_get_installed_jp_spec_kit_version()` to correctly detect the newly install
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Version detection returns correct version after fresh install
-- [ ] #2 No reliance on shell PATH cache
+- [x] #1 Version detection returns correct version after fresh install
+- [x] #2 No reliance on shell PATH cache
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Already implemented - code trusts install_version directly instead of re-detecting (lines 5157-5159)
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-310.02 - Remove-unnecessary-uv-tool-upgrade-attempt.md
+++ b/backlog/tasks/task-310.02 - Remove-unnecessary-uv-tool-upgrade-attempt.md
@@ -1,11 +1,11 @@
 ---
 id: task-310.02
 title: Remove unnecessary uv tool upgrade attempt
-status: To Do
+status: Done
 assignee:
   - '@adare'
 created_date: '2025-12-08 01:41'
-updated_date: '2025-12-15 01:48'
+updated_date: '2025-12-29 12:11'
 labels:
   - bug
   - cli
@@ -32,6 +32,12 @@ Remove or skip the `uv tool upgrade flowspec-cli` attempt at lines 3973-3986.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 uv tool upgrade is not called for git-installed packages
-- [ ] #2 Git install is used directly for upgrades
+- [x] #1 uv tool upgrade is not called for git-installed packages
+- [x] #2 Git install is used directly for upgrades
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Already implemented - code goes directly to git install, no uv tool upgrade call exists
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-310.03 - Add-unit-tests-for-upgrade-tools-scenarios.md
+++ b/backlog/tasks/task-310.03 - Add-unit-tests-for-upgrade-tools-scenarios.md
@@ -1,11 +1,11 @@
 ---
 id: task-310.03
 title: Add unit tests for upgrade-tools scenarios
-status: To Do
+status: Done
 assignee:
   - '@galway'
 created_date: '2025-12-08 01:41'
-updated_date: '2025-12-15 02:17'
+updated_date: '2025-12-29 12:12'
 labels:
   - test
   - cli
@@ -32,8 +32,14 @@ Add comprehensive unit tests for `_upgrade_jp_spec_kit()` covering:
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Tests cover upgrade success path
-- [ ] #2 Tests cover already-at-latest path
-- [ ] #3 Tests cover error scenarios
-- [ ] #4 Tests use mocking for subprocess calls
+- [x] #1 Tests cover upgrade success path
+- [x] #2 Tests cover already-at-latest path
+- [x] #3 Tests cover error scenarios
+- [x] #4 Tests use mocking for subprocess calls
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Tests already exist in tests/test_upgrade_commands.py covering all scenarios
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary
- Close task-310 (upgrade-tools bug) and subtasks 310.01, 310.02, 310.03
- All were already fixed in previous commits - code uses direct git install and trusts install_version

## Verified
- Code at `src/flowspec_cli/__init__.py:5135-5159` shows fix is in place
- Tests in `tests/test_upgrade_commands.py` cover all scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)