### PR TITLE
docs: strengthen Copilot review success criteria in submit-n-watch-pr

### DIFF
--- a/.github/agents/flow-submit-n-watch-pr.agent.md
+++ b/.github/agents/flow-submit-n-watch-pr.agent.md
@@ -17,6 +17,27 @@ tools:
 
 Submit a PR and autonomously monitor CI checks and Copilot code review feedback. Iteratively fix issues and resubmit until the PR is approval-ready with zero Copilot comments.
 
+## 🚨 CRITICAL SUCCESS CRITERIA 🚨
+
+**Your PR is ONLY ready for merge when you see BOTH:**
+
+1. **All CI checks pass** - No failures, no pending checks
+2. **Copilot reports "reviewed N files and generated no comments"** - where N matches the count of your changed files
+
+**Example of successful Copilot review:**
+```
+Copilot reviewed 5 files in this pull request and generated no comments.
+```
+
+**If you do NOT see this message OR any CI check fails:**
+- ❌ **DO NOT merge the PR**
+- ❌ **DO NOT request human review**
+- ✅ **Close the PR**
+- ✅ **Rework the branch** (fix issues, rebase if needed)
+- ✅ **Create a NEW PR** with clean history
+
+**There are NO exceptions to this rule.** A PR with Copilot comments or CI failures is NOT ready.
+
 ## User Input
 
 ```text

--- a/templates/commands/flow/submit-n-watch-pr.md
+++ b/templates/commands/flow/submit-n-watch-pr.md
@@ -10,6 +10,27 @@ loop: outer
 
 Submit a PR and autonomously monitor CI checks and Copilot code review feedback. Iteratively fix issues and resubmit until the PR is approval-ready with zero Copilot comments.
 
+## 🚨 CRITICAL SUCCESS CRITERIA 🚨
+
+**Your PR is ONLY ready for merge when you see BOTH:**
+
+1. **All CI checks pass** - No failures, no pending checks
+2. **Copilot reports "reviewed N files and generated no comments"** - where N matches the count of your changed files
+
+**Example of successful Copilot review:**
+```
+Copilot reviewed 5 files in this pull request and generated no comments.
+```
+
+**If you do NOT see this message OR any CI check fails:**
+- ❌ **DO NOT merge the PR**
+- ❌ **DO NOT request human review**
+- ✅ **Close the PR**
+- ✅ **Rework the branch** (fix issues, rebase if needed)
+- ✅ **Create a NEW PR** with clean history
+
+**There are NO exceptions to this rule.** A PR with Copilot comments or CI failures is NOT ready.
+
 ## User Input
 
 ```text


### PR DESCRIPTION
## Summary

- Add explicit requirement that PRs must show "Copilot reviewed N files and generated no comments" message before merge
- Clarify that if this message is NOT seen OR any CI check fails, the PR must be:
  - Closed
  - Branch reworked
  - New PR created with clean history

This strengthens the language in `/flow:submit-n-watch-pr` to prevent premature merges when Copilot has identified issues.

## Test plan

- [x] Template syntax valid
- [x] Agent sync successful
- [ ] CI passes
- [ ] Copilot review generates no comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)