### PR TITLE
docs: add caveat about Outdated comments in submit-n-watch-pr

### DIFF
--- a/.github/agents/flow-submit-n-watch-pr.agent.md
+++ b/.github/agents/flow-submit-n-watch-pr.agent.md
@@ -38,6 +38,23 @@ Copilot reviewed 5 files in this pull request and generated no comments.
 
 **There are NO exceptions to this rule.** A PR with Copilot comments or CI failures is NOT ready.
 
+## ⚠️ "Outdated" Comments = Wrong Approach ⚠️
+
+**If you see "Outdated" labels on Copilot review comments, you are doing it wrong.**
+
+This happens when you push fixes to an existing PR instead of creating a new one. The problem:
+- Copilot marks old comments as "Outdated" but **does NOT re-run its review**
+- You won't get fresh feedback on your fixes
+- The PR will never reach the "reviewed N files and generated no comments" state
+
+**Correct approach when you need to fix issues:**
+1. ❌ **DO NOT** push more commits to the existing PR
+2. ✅ **Close the current PR** (`gh pr close #123`)
+3. ✅ **Create a NEW PR** with your fixes
+4. ✅ Copilot will run a fresh review on the new PR
+
+This is why the workflow creates new PRs rather than iterating on existing ones.
+
 ## User Input
 
 ```text

--- a/templates/commands/flow/submit-n-watch-pr.md
+++ b/templates/commands/flow/submit-n-watch-pr.md
@@ -31,6 +31,23 @@ Copilot reviewed 5 files in this pull request and generated no comments.
 
 **There are NO exceptions to this rule.** A PR with Copilot comments or CI failures is NOT ready.
 
+## ⚠️ "Outdated" Comments = Wrong Approach ⚠️
+
+**If you see "Outdated" labels on Copilot review comments, you are doing it wrong.**
+
+This happens when you push fixes to an existing PR instead of creating a new one. The problem:
+- Copilot marks old comments as "Outdated" but **does NOT re-run its review**
+- You won't get fresh feedback on your fixes
+- The PR will never reach the "reviewed N files and generated no comments" state
+
+**Correct approach when you need to fix issues:**
+1. ❌ **DO NOT** push more commits to the existing PR
+2. ✅ **Close the current PR** (`gh pr close #123`)
+3. ✅ **Create a NEW PR** with your fixes
+4. ✅ Copilot will run a fresh review on the new PR
+
+This is why the workflow creates new PRs rather than iterating on existing ones.
+
 ## User Input
 
 ```text


### PR DESCRIPTION
## Summary

Adds a prominent warning to `/flow:submit-n-watch-pr` documentation explaining that "Outdated" labels on Copilot review comments indicate the wrong approach is being used.

## Problem

When agents push fixes to an existing PR:
- Copilot marks old comments as "Outdated" but **does NOT re-run its review**
- The PR can never reach the clean "reviewed N files and generated no comments" state
- Agents get stuck in an infinite loop trying to address comments

## Solution

Added a new `⚠️ "Outdated" Comments = Wrong Approach ⚠️` section that:
- Explains why "Outdated" labels appear
- Clarifies that Copilot doesn't re-review after pushing fixes
- Provides the correct approach: close old PR → create new PR

## Files Changed

- `templates/commands/flow/submit-n-watch-pr.md` - Command template
- `.github/agents/flow-submit-n-watch-pr.agent.md` - GitHub agent

## Test Plan

- [x] Documentation reads correctly
- [x] Warning is prominently placed after Critical Success Criteria

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)