### PR TITLE
fix: detect and warn about duplicate flowspec installations (v3)

### DIFF
--- a/src/flowspec_cli/__init__.py
+++ b/src/flowspec_cli/__init__.py
@@ -5666,7 +5666,7 @@ def _detect_duplicate_flowspec_installations() -> list[tuple[str, str]]:
 
     Returns:
         List of (path, source) tuples for each installation found.
-        Example: [("/Users/x/.local/bin/flowspec", "uv"), ("/Users/x/.pyenv/.../flowspec", "pip")]
+        Example: [("/Users/x/.local/bin/flowspec", "uv"), ("/Users/x/.pyenv/.../flowspec", "pip/pyenv")]
     """
     installations: list[tuple[str, str]] = []
     seen_paths: set[str] = set()

--- a/tests/test_upgrade_commands.py
+++ b/tests/test_upgrade_commands.py
@@ -990,3 +990,5 @@ class TestDuplicateInstallationDetection:
         # Should only have the resolved pyenv path, not the shim
         paths = [inst[0] for inst in installations]
         assert "/Users/test/.pyenv/shims/flowspec" not in paths
+        # Verify the resolved pyenv path is properly detected
+        assert "/Users/test/.pyenv/versions/3.11.0/bin/flowspec" in paths


### PR DESCRIPTION
## Summary

- Adds duplicate installation detection to warn users when multiple flowspec installations exist (uv tools vs pip/pyenv)
- Prevents version conflicts where `flowspec upgrade-tools` reports success but PATH precedence causes old version to remain active

## Changes

- Added `_detect_duplicate_flowspec_installations()` function with:
  - Cross-platform support using `shutil.which()` instead of Unix `which` command
  - `UV_TOOL_BIN_DIR` environment variable support for custom uv tools locations
  - Pyenv shim resolution to actual binary paths (avoids duplicate detection)
  - Proper path deduplication

- Added `_warn_duplicate_installations()` to display clear warnings with paths and sources

- Integrated warning into `_run_upgrade_tools()` flow

- Added 9 comprehensive tests covering all edge cases

## Test plan

- [x] Run `pytest tests/test_upgrade_commands.py -v` - all tests pass
- [x] Run `ruff check . && ruff format .` - no issues
- [x] Verify DCO signoff included

## Addresses Copilot feedback from PRs #1100 and #1101

- ✅ Use `shutil.which()` instead of Unix `which` command
- ✅ Check `UV_TOOL_BIN_DIR` environment variable
- ✅ Resolve pyenv shims to actual paths
- ✅ Add explanatory comments for except clauses
- ✅ Make warning message more generic
- ✅ Add test coverage (9 tests)
- ✅ Docstring example matches implementation ("pip/pyenv")
- ✅ Test verifies resolved pyenv path IS included

🤖 Generated with [Claude Code](https://claude.com/claude-code)