### PR TITLE
fix: detect and warn about duplicate flowspec installations (v5)

### DIFF
--- a/src/flowspec_cli/__init__.py
+++ b/src/flowspec_cli/__init__.py
@@ -5656,6 +5656,118 @@ def _get_installed_jp_spec_kit_version() -> Optional[str]:
     return None
 
 
+def _detect_duplicate_flowspec_installations() -> list[tuple[str, str]]:
+    """Detect multiple flowspec installations that could cause version conflicts.
+
+    Checks for flowspec in:
+    - uv tools (respects UV_TOOL_BIN_DIR, defaults to ~/.local/bin)
+    - pip/pyenv installations (resolves shims to actual paths)
+    - Other PATH locations
+
+    Returns:
+        List of (path, source) tuples for each installation found.
+        Example: [("/Users/x/.local/bin/flowspec", "uv"), ("/Users/x/.pyenv/.../flowspec", "pip/pyenv")]
+    """
+    installations: list[tuple[str, str]] = []
+    seen_paths: set[str] = set()
+
+    # Check uv tools locations - respect UV_TOOL_BIN_DIR if set
+    uv_tool_bin_dir = os.environ.get("UV_TOOL_BIN_DIR")
+    uv_candidates: list[Path] = []
+
+    if uv_tool_bin_dir:
+        uv_candidates.append(Path(uv_tool_bin_dir) / "flowspec")
+
+    # Also check the default uv tools location
+    uv_candidates.append(Path.home() / ".local" / "bin" / "flowspec")
+
+    for candidate in uv_candidates:
+        if candidate.exists():
+            try:
+                resolved_candidate = candidate.resolve()
+            except OSError:
+                # Path resolution can fail if the target was removed, is a broken symlink,
+                # or is inaccessible due to permissions; fall back to the raw candidate.
+                resolved_candidate = candidate
+            candidate_str = str(resolved_candidate)
+            if candidate_str not in seen_paths:
+                seen_paths.add(candidate_str)
+                installations.append((candidate_str, "uv"))
+
+    # Check if pyenv has flowspec - resolve shim to actual path
+    try:
+        result = subprocess.run(
+            ["pyenv", "which", "flowspec"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            pyenv_path_raw = result.stdout.strip()
+            # Normalize and resolve the path to match PATH-based resolution
+            try:
+                pyenv_path = str(Path(pyenv_path_raw).resolve())
+            except OSError:
+                # Path resolution can fail if target was removed or is inaccessible
+                pyenv_path = pyenv_path_raw
+            if pyenv_path not in seen_paths:
+                seen_paths.add(pyenv_path)
+                installations.append((pyenv_path, "pip/pyenv"))
+    except FileNotFoundError:
+        # pyenv not installed - this is normal on many systems
+        pass
+
+    # Check PATH using cross-platform shutil.which()
+    which_path = shutil.which("flowspec")
+    if which_path:
+        # Resolve symlinks and normalize path
+        try:
+            resolved_path = str(Path(which_path).resolve())
+        except OSError:
+            # Path resolution can fail if the target was removed, is a broken symlink,
+            # or is inaccessible due to permissions; fall back to the raw PATH entry.
+            resolved_path = which_path
+
+        # If this is a pyenv shim, try to resolve to actual path
+        if ".pyenv/shims" in which_path or ".pyenv\\shims" in which_path:
+            # Already handled by pyenv which above, skip to avoid duplicates
+            pass
+        elif resolved_path not in seen_paths:
+            seen_paths.add(resolved_path)
+            installations.append((resolved_path, "PATH"))
+
+    return installations
+
+
+def _warn_duplicate_installations() -> bool:
+    """Check for and warn about duplicate flowspec installations.
+
+    Returns:
+        True if duplicates were found and warning was shown.
+    """
+    installations = _detect_duplicate_flowspec_installations()
+
+    if len(installations) <= 1:
+        return False
+
+    console.print(
+        "[yellow]⚠ Warning: Multiple flowspec installations detected![/yellow]\n"
+    )
+
+    for path, source in installations:
+        console.print(f"  • {path} [dim]({source})[/dim]")
+
+    console.print()
+    console.print(
+        "[dim]This can cause version conflicts. The first one in PATH takes precedence.[/dim]"
+    )
+    console.print(
+        "[dim]To fix: remove the unwanted installation based on the paths above.[/dim]\n"
+    )
+
+    return True
+
+
 def _upgrade_jp_spec_kit(
     dry_run: bool = False,
     target_version: str | None = None,
@@ -6079,6 +6191,10 @@ def _run_upgrade_tools(
 
     if branch:
         console.print(f"[cyan]Installing from branch: {branch}[/cyan]\n")
+
+    # Check for duplicate installations that could cause version conflicts
+    if not component or component == "flowspec":
+        _warn_duplicate_installations()
 
     # Validate component if specified
     if component and component not in UPGRADE_TOOLS_COMPONENTS:

--- a/tests/test_upgrade_commands.py
+++ b/tests/test_upgrade_commands.py
@@ -17,12 +17,14 @@ import pytest
 from typer.testing import CliRunner
 
 from flowspec_cli import (
+    _detect_duplicate_flowspec_installations,
     UPGRADE_TOOLS_COMPONENTS,
     _get_installed_jp_spec_kit_version,
     _run_npm_global_install,
     _upgrade_backlog_md,
     _upgrade_jp_spec_kit,
     _upgrade_spec_kit,
+    _warn_duplicate_installations,
     app,
 )
 
@@ -820,3 +822,173 @@ class TestVersionTrackingFile:
         finally:
             # Restore permissions for cleanup
             flowspec_dir.chmod(0o755)
+
+
+class TestDuplicateInstallationDetection:
+    """Tests for duplicate flowspec installation detection."""
+
+    def test_single_uv_installation_no_warning(self, tmp_path, monkeypatch):
+        """No warning when only uv installation exists."""
+        # Create fake uv installation
+        uv_bin = tmp_path / ".local" / "bin"
+        uv_bin.mkdir(parents=True)
+        flowspec_bin = uv_bin / "flowspec"
+        flowspec_bin.touch()
+
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        monkeypatch.setenv("UV_TOOL_BIN_DIR", "")
+        monkeypatch.setattr("shutil.which", lambda x: None)
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *args, **kwargs: MagicMock(returncode=1, stdout=""),
+        )
+
+        installations = _detect_duplicate_flowspec_installations()
+        assert len(installations) == 1
+        assert installations[0][1] == "uv"
+
+    def test_no_installations_empty_list(self, tmp_path, monkeypatch):
+        """Returns empty list when no flowspec installations found."""
+        # Use empty tmp_path as home - no flowspec binary exists
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        monkeypatch.setenv("UV_TOOL_BIN_DIR", "")
+        monkeypatch.setattr("shutil.which", lambda x: None)
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *args, **kwargs: MagicMock(returncode=1, stdout=""),
+        )
+
+        installations = _detect_duplicate_flowspec_installations()
+        assert len(installations) == 0
+
+    def test_respects_uv_tool_bin_dir_env_var(self, tmp_path, monkeypatch):
+        """Checks UV_TOOL_BIN_DIR environment variable for uv installation."""
+        custom_bin = tmp_path / "custom" / "bin"
+        custom_bin.mkdir(parents=True)
+        flowspec_bin = custom_bin / "flowspec"
+        flowspec_bin.touch()
+
+        monkeypatch.setenv("UV_TOOL_BIN_DIR", str(custom_bin))
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "empty")
+        monkeypatch.setattr("shutil.which", lambda x: None)
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *args, **kwargs: MagicMock(returncode=1, stdout=""),
+        )
+
+        installations = _detect_duplicate_flowspec_installations()
+        assert len(installations) == 1
+        assert str(custom_bin) in installations[0][0]
+        assert installations[0][1] == "uv"
+
+    def test_pyenv_not_installed_no_error(self, tmp_path, monkeypatch):
+        """Handles pyenv not being installed gracefully."""
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        monkeypatch.setenv("UV_TOOL_BIN_DIR", "")
+        monkeypatch.setattr("shutil.which", lambda x: None)
+
+        def mock_run(*args, **kwargs):
+            if args[0] == ["pyenv", "which", "flowspec"]:
+                raise FileNotFoundError("pyenv not found")
+            return MagicMock(returncode=1, stdout="")
+
+        monkeypatch.setattr("subprocess.run", mock_run)
+
+        # Should not raise
+        installations = _detect_duplicate_flowspec_installations()
+        assert isinstance(installations, list)
+
+    def test_duplicate_detection_with_pyenv(self, tmp_path, monkeypatch):
+        """Detects both uv and pyenv installations."""
+        # Create fake uv installation
+        uv_bin = tmp_path / ".local" / "bin"
+        uv_bin.mkdir(parents=True)
+        (uv_bin / "flowspec").touch()
+
+        pyenv_path = "/Users/test/.pyenv/versions/3.11.0/bin/flowspec"
+
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        monkeypatch.setenv("UV_TOOL_BIN_DIR", "")
+        monkeypatch.setattr("shutil.which", lambda x: None)
+
+        def mock_run(*args, **kwargs):
+            if args[0] == ["pyenv", "which", "flowspec"]:
+                return MagicMock(returncode=0, stdout=pyenv_path)
+            return MagicMock(returncode=1, stdout="")
+
+        monkeypatch.setattr("subprocess.run", mock_run)
+
+        installations = _detect_duplicate_flowspec_installations()
+        assert len(installations) == 2
+        sources = {inst[1] for inst in installations}
+        assert "uv" in sources
+        assert "pip/pyenv" in sources
+
+    def test_warn_duplicate_returns_false_single_install(self, monkeypatch):
+        """_warn_duplicate_installations returns False for single installation."""
+        monkeypatch.setattr(
+            "flowspec_cli._detect_duplicate_flowspec_installations",
+            lambda: [("/path/to/flowspec", "uv")],
+        )
+        result = _warn_duplicate_installations()
+        assert result is False
+
+    def test_warn_duplicate_returns_true_multiple_installs(self, monkeypatch, capsys):
+        """_warn_duplicate_installations returns True and prints warning."""
+        monkeypatch.setattr(
+            "flowspec_cli._detect_duplicate_flowspec_installations",
+            lambda: [
+                ("/path/uv/flowspec", "uv"),
+                ("/path/pyenv/flowspec", "pip/pyenv"),
+            ],
+        )
+        result = _warn_duplicate_installations()
+        assert result is True
+
+    def test_shutil_which_used_for_path_detection(self, tmp_path, monkeypatch):
+        """Uses shutil.which for cross-platform PATH detection."""
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        monkeypatch.setenv("UV_TOOL_BIN_DIR", "")
+
+        which_called = []
+
+        def mock_which(name):
+            which_called.append(name)
+            return "/usr/local/bin/flowspec"
+
+        monkeypatch.setattr("shutil.which", mock_which)
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *args, **kwargs: MagicMock(returncode=1, stdout=""),
+        )
+
+        _detect_duplicate_flowspec_installations()
+        assert "flowspec" in which_called
+
+    def test_pyenv_shim_path_excluded(self, tmp_path, monkeypatch):
+        """Pyenv shim paths are excluded from PATH detection to avoid duplicates."""
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        monkeypatch.setenv("UV_TOOL_BIN_DIR", "")
+
+        # shutil.which returns a pyenv shim path
+        monkeypatch.setattr(
+            "shutil.which", lambda x: "/Users/test/.pyenv/shims/flowspec"
+        )
+
+        def mock_run(*args, **kwargs):
+            if args[0] == ["pyenv", "which", "flowspec"]:
+                # pyenv resolves shim to actual path
+                return MagicMock(
+                    returncode=0,
+                    stdout="/Users/test/.pyenv/versions/3.11.0/bin/flowspec",
+                )
+            return MagicMock(returncode=1, stdout="")
+
+        monkeypatch.setattr("subprocess.run", mock_run)
+
+        installations = _detect_duplicate_flowspec_installations()
+        # Should only have the resolved pyenv path, not the shim
+        paths = [inst[0] for inst in installations]
+        assert "/Users/test/.pyenv/shims/flowspec" not in paths
+        # Verify the resolved pyenv path is properly detected
+        assert "/Users/test/.pyenv/versions/3.11.0/bin/flowspec" in paths


### PR DESCRIPTION
## Summary

- Adds duplicate installation detection to warn users when multiple flowspec installations exist (uv tools vs pip/pyenv)
- Prevents version conflicts where `flowspec upgrade-tools` reports success but PATH precedence causes old version to remain active

## Changes

- Added `_detect_duplicate_flowspec_installations()` function with:
  - Cross-platform support using `shutil.which()` instead of Unix `which` command
  - `UV_TOOL_BIN_DIR` environment variable support for custom uv tools locations
  - **Proper order of operations**: check exists() BEFORE resolve() (v5 fix)
  - Consistent path resolution across all sources (UV, pyenv, PATH)
  - Pyenv shim detection and resolution to actual binary paths
  - Proper path deduplication

- Added `_warn_duplicate_installations()` to display clear warnings with paths and sources

- Integrated warning into `_run_upgrade_tools()` flow

- Added 9 comprehensive tests covering all edge cases

## Addresses ALL Copilot feedback from PRs #1100-1103

- ✅ Use `shutil.which()` instead of Unix `which` command
- ✅ Check `UV_TOOL_BIN_DIR` environment variable
- ✅ Resolve UV paths before comparing
- ✅ Resolve pyenv paths before comparing
- ✅ Add explanatory comments for OSError handlers
- ✅ **Check exists() before resolve()** (v5 fix)
- ✅ Make warning message more generic
- ✅ Add test coverage (9 tests)
- ✅ Docstring example matches implementation ("pip/pyenv")
- ✅ Test verifies resolved pyenv path IS included
- ✅ **Removed unrelated log file** (v5 fix)

## Test plan

- [x] Run `pytest tests/test_upgrade_commands.py -v` - all 9 tests pass
- [x] Run `ruff check . && ruff format .` - no issues
- [x] Verify DCO signoff included

🤖 Generated with [Claude Code](https://claude.com/claude-code)