### PR TITLE
fix: align pyproject.toml version format with __init__.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "flowspec-cli"
 
-version = "0.3.0.018"
+version = "0.3.018"
 
 
 


### PR DESCRIPTION
## Summary

Fixes version format mismatch that broke CI version-check workflow.

**Problem:**
- `pyproject.toml`: `0.3.0.018` (4-part version - invalid)
- `__init__.py`: `0.3.018` (3-part version - valid)

CI workflow requires 3-part `MAJOR.MINOR.PATCH` format. The 4-part version in pyproject.toml likely came from a release script error.

**Fix:**
Changed pyproject.toml from `0.3.0.018` to `0.3.018` to match __init__.py.

## Root Cause

The release script's `bump_version()` function produces 3-part versions but somehow a 4-part version got committed. This should be investigated to prevent recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)