### PR TITLE
feat: add GitHub PR safety hook to prevent merge/update operations

### DIFF
--- a/.claude/hooks/pre-tool-use-github-pr-safety.py
+++ b/.claude/hooks/pre-tool-use-github-pr-safety.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""
+PreToolUse hook: GitHub PR Safety Guard
+
+Prevents Claude from performing potentially destructive GitHub PR operations:
+1. Merging PRs to main/master (default: blocked)
+2. Updating any PR (default: blocked)
+
+Configuration via environment variables:
+- FLOWSPEC_BLOCK_PR_MERGE=true|false (default: true)
+  Blocks mcp__github__merge_pull_request entirely
+
+- FLOWSPEC_BLOCK_PR_MERGE_TO_MAIN=true|false (default: true)
+  Only blocks merges when target is main/master (if BLOCK_PR_MERGE is false)
+
+- FLOWSPEC_BLOCK_PR_UPDATES=true|false (default: true)
+  Blocks PR update operations (update_pull_request_branch, create_pull_request_review)
+
+Configuration file: .flowspec/github-pr-safety.json
+{
+    "block_pr_merge": true,
+    "block_pr_merge_to_main": true,
+    "block_pr_updates": true
+}
+
+Returns JSON decision: deny, ask, or allow
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# Add hooks directory to Python path for logging_helper import
+sys.path.insert(0, str(Path(__file__).parent))
+
+from logging_helper import setup_hook_logging
+
+# Default configuration - secure by default
+DEFAULT_CONFIG = {
+    "block_pr_merge": True,
+    "block_pr_merge_to_main": True,
+    "block_pr_updates": True,
+}
+
+# MCP GitHub tools that merge PRs
+MERGE_TOOLS = [
+    "mcp__github__merge_pull_request",
+]
+
+# MCP GitHub tools that update PRs
+UPDATE_TOOLS = [
+    "mcp__github__update_pull_request_branch",
+    "mcp__github__create_pull_request_review",
+    "mcp__github__update_issue",  # Issues and PRs share API
+]
+
+# Protected branches for merge-to-main blocking
+PROTECTED_BRANCHES = ["main", "master"]
+
+
+def load_config() -> dict:
+    """
+    Load configuration from environment variables and config file.
+    Environment variables take precedence over config file.
+    """
+    config = DEFAULT_CONFIG.copy()
+
+    # Try to load from config file
+    config_file = Path(".flowspec/github-pr-safety.json")
+    if config_file.exists():
+        try:
+            with open(config_file) as f:
+                file_config = json.load(f)
+                config.update(file_config)
+        except (json.JSONDecodeError, IOError):
+            pass  # Use defaults on error
+
+    # Environment variables override config file
+    env_mappings = {
+        "FLOWSPEC_BLOCK_PR_MERGE": "block_pr_merge",
+        "FLOWSPEC_BLOCK_PR_MERGE_TO_MAIN": "block_pr_merge_to_main",
+        "FLOWSPEC_BLOCK_PR_UPDATES": "block_pr_updates",
+    }
+
+    for env_var, config_key in env_mappings.items():
+        env_value = os.getenv(env_var)
+        if env_value is not None:
+            config[config_key] = env_value.lower() == "true"
+
+    return config
+
+
+def check_merge_safety(
+    tool_name: str, tool_input: dict, config: dict
+) -> tuple[str, str, str]:
+    """
+    Check if a merge operation should be blocked.
+
+    Returns:
+        (decision, reason, additional_context) tuple
+        decision is one of: "deny", "ask", "allow"
+    """
+    if tool_name not in MERGE_TOOLS:
+        return "allow", "", ""
+
+    # Check if all merges are blocked
+    if config["block_pr_merge"]:
+        return (
+            "deny",
+            "PR merge operations are blocked by safety policy",
+            "This Claude instance is configured to prevent PR merges.\n\n"
+            "To allow PR merges, set FLOWSPEC_BLOCK_PR_MERGE=false\n"
+            "or update .flowspec/github-pr-safety.json",
+        )
+
+    # Check if merge to main/master is blocked
+    if config["block_pr_merge_to_main"]:
+        # Try to determine the PR's base branch from tool_input.
+        # Different tool schemas might use different field names.
+        base_branch = (
+            tool_input.get("base")
+            or tool_input.get("base_branch")
+            or tool_input.get("baseRef")
+            or tool_input.get("target_branch")
+        )
+
+        if isinstance(base_branch, str):
+            normalized_base = base_branch.strip().lower()
+        else:
+            normalized_base = None
+
+        # Check if base branch is a protected branch
+        protected_set = {b.lower() for b in PROTECTED_BRANCHES}
+
+        if normalized_base and normalized_base in protected_set:
+            # Base branch is protected (e.g., main/master) - deny the merge
+            return (
+                "deny",
+                f"PR merge to protected branch '{base_branch}' is blocked",
+                f"This Claude instance is configured to prevent PR merges to protected branches.\n\n"
+                f"Detected base branch: {base_branch}\n"
+                f"Protected branches: {', '.join(PROTECTED_BRANCHES)}\n\n"
+                "To allow merges to protected branches, set FLOWSPEC_BLOCK_PR_MERGE_TO_MAIN=false\n"
+                "or update .flowspec/github-pr-safety.json",
+            )
+
+        if normalized_base:
+            # Base branch is known and not protected - allow the merge
+            return "allow", "", ""
+
+        # Cannot determine the base branch - be conservative and require confirmation
+        return (
+            "ask",
+            "PR merge to protected branch may be blocked",
+            "This Claude instance is configured to require confirmation for PR merges.\n\n"
+            "The target branch could not be determined from tool_input.\n"
+            "Please confirm this is not merging to main/master.\n"
+            "For safety, consider using the GitHub web UI for merges.",
+        )
+
+    return "allow", "", ""
+
+
+def check_update_safety(
+    tool_name: str, tool_input: dict, config: dict
+) -> tuple[str, str, str]:
+    """
+    Check if a PR update operation should be blocked.
+
+    Returns:
+        (decision, reason, additional_context) tuple
+        decision is one of: "deny", "ask", "allow"
+    """
+    if tool_name not in UPDATE_TOOLS:
+        return "allow", "", ""
+
+    if not config["block_pr_updates"]:
+        return "allow", "", ""
+
+    tool_descriptions = {
+        "mcp__github__update_pull_request_branch": "Update PR branch",
+        "mcp__github__create_pull_request_review": "Create PR review",
+        "mcp__github__update_issue": "Update issue/PR",
+    }
+
+    operation = tool_descriptions.get(tool_name, tool_name)
+
+    return (
+        "deny",
+        f"PR update operation blocked: {operation}",
+        f"This Claude instance is configured to prevent PR modifications.\n\n"
+        f"Blocked operation: {operation}\n"
+        f"Tool: {tool_name}\n\n"
+        f"To allow PR updates, set FLOWSPEC_BLOCK_PR_UPDATES=false\n"
+        f"or update .flowspec/github-pr-safety.json",
+    )
+
+
+def main():
+    logger = setup_hook_logging("pre-tool-use-github-pr-safety")
+
+    try:
+        # Read JSON input from stdin
+        input_data = json.load(sys.stdin)
+
+        if logger:
+            logger.info(
+                f"Checking GitHub PR safety for tool: {input_data.get('tool_name', 'unknown')}"
+            )
+
+        tool_name = input_data.get("tool_name", "")
+        tool_input = input_data.get("tool_input", {})
+
+        # Only check MCP GitHub tools
+        if not tool_name.startswith("mcp__github__"):
+            print(
+                json.dumps(
+                    {
+                        "decision": "allow",
+                        "reason": f"Tool {tool_name} not subject to GitHub PR safety checks",
+                    }
+                )
+            )
+            return 0
+
+        # Load configuration
+        config = load_config()
+
+        if logger:
+            logger.info(f"Config: {config}")
+
+        # Check merge safety first
+        decision, reason, context = check_merge_safety(tool_name, tool_input, config)
+        if decision != "allow":
+            if logger:
+                logger.warning(f"Blocked merge operation: {tool_name}")
+            print(
+                json.dumps(
+                    {
+                        "decision": decision,
+                        "reason": reason,
+                        "additionalContext": context,
+                    }
+                )
+            )
+            return 0
+
+        # Check update safety
+        decision, reason, context = check_update_safety(tool_name, tool_input, config)
+        if decision != "allow":
+            if logger:
+                logger.warning(f"Blocked update operation: {tool_name}")
+            print(
+                json.dumps(
+                    {
+                        "decision": decision,
+                        "reason": reason,
+                        "additionalContext": context,
+                    }
+                )
+            )
+            return 0
+
+        # Allow operation
+        print(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "reason": "GitHub PR operation allowed by safety policy",
+                }
+            )
+        )
+        return 0
+
+    except Exception as e:
+        # On error, default to "deny" for safety-critical operations
+        # This is different from other hooks that fail-open
+        print(
+            json.dumps(
+                {
+                    "decision": "deny",
+                    "reason": f"Hook error (defaulting to deny for safety): {str(e)}",
+                }
+            )
+        )
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/test-github-pr-safety.py
+++ b/.claude/hooks/test-github-pr-safety.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+"""
+Test suite for pre-tool-use-github-pr-safety.py hook.
+
+Run with: python .claude/hooks/test-github-pr-safety.py
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+HOOK_PATH = Path(__file__).parent / "pre-tool-use-github-pr-safety.py"
+CONFIG_PATH = Path(".flowspec/github-pr-safety.json")
+
+
+def run_hook(
+    tool_name: str, tool_input: dict = None, env_overrides: dict = None
+) -> dict:
+    """Run the hook with given input and return the parsed JSON response."""
+    input_data = {"tool_name": tool_name, "tool_input": tool_input or {}}
+
+    env = os.environ.copy()
+    if env_overrides:
+        env.update(env_overrides)
+
+    result = subprocess.run(
+        ["python3", str(HOOK_PATH)],
+        input=json.dumps(input_data),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return {"error": result.stdout, "stderr": result.stderr}
+
+
+def test_non_github_tools_allowed():
+    """Non-GitHub MCP tools should be allowed."""
+    print("Test: Non-GitHub tools allowed...", end=" ")
+
+    for tool in ["Bash", "Read", "Write", "mcp__other__something"]:
+        response = run_hook(tool)
+        assert response.get("decision") == "allow", f"Tool {tool} should be allowed"
+
+    print("PASS")
+
+
+def test_merge_blocked_by_default():
+    """PR merge should be blocked by default."""
+    print("Test: Merge blocked by default...", end=" ")
+
+    response = run_hook(
+        "mcp__github__merge_pull_request",
+        {"owner": "test", "repo": "test", "pull_number": 1},
+    )
+
+    assert response.get("decision") == "deny", f"Expected deny, got {response}"
+    assert "blocked" in response.get("reason", "").lower()
+
+    print("PASS")
+
+
+def test_merge_allowed_when_disabled():
+    """PR merge should be allowed when FLOWSPEC_BLOCK_PR_MERGE=false."""
+    print("Test: Merge allowed when disabled...", end=" ")
+
+    response = run_hook(
+        "mcp__github__merge_pull_request",
+        {"owner": "test", "repo": "test", "pull_number": 1},
+        env_overrides={
+            "FLOWSPEC_BLOCK_PR_MERGE": "false",
+            "FLOWSPEC_BLOCK_PR_MERGE_TO_MAIN": "false",
+        },
+    )
+
+    assert response.get("decision") == "allow", f"Expected allow, got {response}"
+
+    print("PASS")
+
+
+def test_merge_asks_for_main_protection():
+    """When merge is allowed but main protection is on and base branch unknown, should ask."""
+    print("Test: Merge asks for main protection (unknown base)...", end=" ")
+
+    response = run_hook(
+        "mcp__github__merge_pull_request",
+        {"owner": "test", "repo": "test", "pull_number": 1},
+        env_overrides={
+            "FLOWSPEC_BLOCK_PR_MERGE": "false",
+            "FLOWSPEC_BLOCK_PR_MERGE_TO_MAIN": "true",
+        },
+    )
+
+    assert response.get("decision") == "ask", f"Expected ask, got {response}"
+
+    print("PASS")
+
+
+def test_merge_denied_to_main_branch():
+    """When merge to main is blocked and base branch IS main, should deny."""
+    print("Test: Merge denied to main branch...", end=" ")
+
+    response = run_hook(
+        "mcp__github__merge_pull_request",
+        {"owner": "test", "repo": "test", "pull_number": 1, "base": "main"},
+        env_overrides={
+            "FLOWSPEC_BLOCK_PR_MERGE": "false",
+            "FLOWSPEC_BLOCK_PR_MERGE_TO_MAIN": "true",
+        },
+    )
+
+    assert response.get("decision") == "deny", f"Expected deny, got {response}"
+    assert "main" in response.get("reason", "").lower()
+
+    print("PASS")
+
+
+def test_merge_denied_to_master_branch():
+    """When merge to main is blocked and base branch IS master, should deny."""
+    print("Test: Merge denied to master branch...", end=" ")
+
+    response = run_hook(
+        "mcp__github__merge_pull_request",
+        {"owner": "test", "repo": "test", "pull_number": 1, "base": "master"},
+        env_overrides={
+            "FLOWSPEC_BLOCK_PR_MERGE": "false",
+            "FLOWSPEC_BLOCK_PR_MERGE_TO_MAIN": "true",
+        },
+    )
+
+    assert response.get("decision") == "deny", f"Expected deny, got {response}"
+    assert "master" in response.get("reason", "").lower()
+
+    print("PASS")
+
+
+def test_merge_allowed_to_feature_branch():
+    """When merge to main is blocked but base branch is NOT protected, should allow."""
+    print("Test: Merge allowed to feature branch...", end=" ")
+
+    response = run_hook(
+        "mcp__github__merge_pull_request",
+        {"owner": "test", "repo": "test", "pull_number": 1, "base": "feature-branch"},
+        env_overrides={
+            "FLOWSPEC_BLOCK_PR_MERGE": "false",
+            "FLOWSPEC_BLOCK_PR_MERGE_TO_MAIN": "true",
+        },
+    )
+
+    assert response.get("decision") == "allow", f"Expected allow, got {response}"
+
+    print("PASS")
+
+
+def test_update_branch_blocked_by_default():
+    """Update PR branch should be blocked by default."""
+    print("Test: Update branch blocked by default...", end=" ")
+
+    response = run_hook(
+        "mcp__github__update_pull_request_branch",
+        {"owner": "test", "repo": "test", "pull_number": 1},
+    )
+
+    assert response.get("decision") == "deny", f"Expected deny, got {response}"
+
+    print("PASS")
+
+
+def test_create_review_blocked_by_default():
+    """Create PR review should be blocked by default."""
+    print("Test: Create review blocked by default...", end=" ")
+
+    response = run_hook(
+        "mcp__github__create_pull_request_review",
+        {
+            "owner": "test",
+            "repo": "test",
+            "pull_number": 1,
+            "body": "LGTM",
+            "event": "APPROVE",
+        },
+    )
+
+    assert response.get("decision") == "deny", f"Expected deny, got {response}"
+
+    print("PASS")
+
+
+def test_update_issue_blocked_by_default():
+    """Update issue (can be PR) should be blocked by default."""
+    print("Test: Update issue blocked by default...", end=" ")
+
+    response = run_hook(
+        "mcp__github__update_issue",
+        {"owner": "test", "repo": "test", "issue_number": 1},
+    )
+
+    assert response.get("decision") == "deny", f"Expected deny, got {response}"
+
+    print("PASS")
+
+
+def test_updates_allowed_when_disabled():
+    """PR updates should be allowed when FLOWSPEC_BLOCK_PR_UPDATES=false."""
+    print("Test: Updates allowed when disabled...", end=" ")
+
+    for tool in [
+        "mcp__github__update_pull_request_branch",
+        "mcp__github__create_pull_request_review",
+        "mcp__github__update_issue",
+    ]:
+        response = run_hook(
+            tool,
+            {"owner": "test", "repo": "test", "pull_number": 1},
+            env_overrides={"FLOWSPEC_BLOCK_PR_UPDATES": "false"},
+        )
+        assert response.get("decision") == "allow", f"Tool {tool} should be allowed"
+
+    print("PASS")
+
+
+def test_safe_github_operations_allowed():
+    """Read-only GitHub operations should always be allowed."""
+    print("Test: Safe GitHub operations allowed...", end=" ")
+
+    safe_tools = [
+        "mcp__github__get_pull_request",
+        "mcp__github__list_pull_requests",
+        "mcp__github__get_issue",
+        "mcp__github__list_issues",
+        "mcp__github__get_file_contents",
+        "mcp__github__search_repositories",
+        "mcp__github__search_code",
+        "mcp__github__list_commits",
+    ]
+
+    for tool in safe_tools:
+        response = run_hook(tool, {"owner": "test", "repo": "test"})
+        assert response.get("decision") == "allow", f"Tool {tool} should be allowed"
+
+    print("PASS")
+
+
+def test_create_pr_allowed():
+    """Creating a PR should be allowed (not the same as merging)."""
+    print("Test: Create PR allowed...", end=" ")
+
+    response = run_hook(
+        "mcp__github__create_pull_request",
+        {
+            "owner": "test",
+            "repo": "test",
+            "title": "Test PR",
+            "head": "feature",
+            "base": "main",
+        },
+    )
+
+    assert response.get("decision") == "allow", f"Expected allow, got {response}"
+
+    print("PASS")
+
+
+def test_config_file_respected():
+    """Configuration file should be respected."""
+    print("Test: Config file respected...", end=" ")
+
+    # Create temp config
+    config_path = Path(".flowspec/github-pr-safety.json")
+    backup_path = Path(".flowspec/github-pr-safety.json.bak")
+
+    # Backup existing config if present
+    if config_path.exists():
+        config_path.rename(backup_path)
+
+    try:
+        # Write permissive config
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(
+            json.dumps(
+                {
+                    "block_pr_merge": False,
+                    "block_pr_merge_to_main": False,
+                    "block_pr_updates": False,
+                }
+            )
+        )
+
+        # Clear env vars to ensure config file is used
+        response = run_hook(
+            "mcp__github__merge_pull_request",
+            {"owner": "test", "repo": "test", "pull_number": 1},
+            env_overrides={
+                "FLOWSPEC_BLOCK_PR_MERGE": "",
+                "FLOWSPEC_BLOCK_PR_MERGE_TO_MAIN": "",
+                "FLOWSPEC_BLOCK_PR_UPDATES": "",
+            },
+        )
+
+        assert response.get("decision") == "allow", (
+            f"Expected allow with permissive config, got {response}"
+        )
+
+    finally:
+        # Restore original config
+        config_path.unlink(missing_ok=True)
+        if backup_path.exists():
+            backup_path.rename(config_path)
+
+    print("PASS")
+
+
+def test_env_overrides_config():
+    """Environment variables should override config file."""
+    print("Test: Env overrides config...", end=" ")
+
+    # Even if config file says allow, env var should block
+    response = run_hook(
+        "mcp__github__merge_pull_request",
+        {"owner": "test", "repo": "test", "pull_number": 1},
+        env_overrides={"FLOWSPEC_BLOCK_PR_MERGE": "true"},
+    )
+
+    assert response.get("decision") == "deny", (
+        f"Expected deny with env override, got {response}"
+    )
+
+    print("PASS")
+
+
+def main():
+    """Run all tests."""
+    print("=" * 60)
+    print("GitHub PR Safety Hook Tests")
+    print("=" * 60)
+    print()
+
+    tests = [
+        test_non_github_tools_allowed,
+        test_merge_blocked_by_default,
+        test_merge_allowed_when_disabled,
+        test_merge_asks_for_main_protection,
+        test_merge_denied_to_main_branch,
+        test_merge_denied_to_master_branch,
+        test_merge_allowed_to_feature_branch,
+        test_update_branch_blocked_by_default,
+        test_create_review_blocked_by_default,
+        test_update_issue_blocked_by_default,
+        test_updates_allowed_when_disabled,
+        test_safe_github_operations_allowed,
+        test_create_pr_allowed,
+        test_config_file_respected,
+        test_env_overrides_config,
+    ]
+
+    passed = 0
+    failed = 0
+
+    for test in tests:
+        try:
+            test()
+            passed += 1
+        except AssertionError as e:
+            print(f"FAIL: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"ERROR: {e}")
+            failed += 1
+
+    print()
+    print("=" * 60)
+    print(f"Results: {passed} passed, {failed} failed")
+    print("=" * 60)
+
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/test-hooks.sh
+++ b/.claude/hooks/test-hooks.sh
@@ -210,7 +210,39 @@ run_test \
     "allow" \
     "Should allow non-git commands"
 
-# Test 17: Pre-implementation quality gates
+# Test 17: GitHub PR Safety - merge blocked
+run_test \
+    "GitHub PR - merge blocked" \
+    "pre-tool-use-github-pr-safety.py" \
+    '{"session_id": "test", "hook_event_name": "PreToolUse", "tool_name": "mcp__github__merge_pull_request", "tool_input": {"owner": "test", "repo": "test", "pull_number": 1}}' \
+    "deny" \
+    "Should deny PR merge by default"
+
+# Test 18: GitHub PR Safety - update blocked
+run_test \
+    "GitHub PR - update blocked" \
+    "pre-tool-use-github-pr-safety.py" \
+    '{"session_id": "test", "hook_event_name": "PreToolUse", "tool_name": "mcp__github__update_pull_request_branch", "tool_input": {"owner": "test", "repo": "test", "pull_number": 1}}' \
+    "deny" \
+    "Should deny PR update by default"
+
+# Test 19: GitHub PR Safety - read operations allowed
+run_test \
+    "GitHub PR - read allowed" \
+    "pre-tool-use-github-pr-safety.py" \
+    '{"session_id": "test", "hook_event_name": "PreToolUse", "tool_name": "mcp__github__get_pull_request", "tool_input": {"owner": "test", "repo": "test", "pull_number": 1}}' \
+    "allow" \
+    "Should allow reading PR details"
+
+# Test 20: GitHub PR Safety - create PR allowed
+run_test \
+    "GitHub PR - create allowed" \
+    "pre-tool-use-github-pr-safety.py" \
+    '{"session_id": "test", "hook_event_name": "PreToolUse", "tool_name": "mcp__github__create_pull_request", "tool_input": {"owner": "test", "repo": "test", "title": "Test", "head": "feature", "base": "main"}}' \
+    "allow" \
+    "Should allow creating new PRs"
+
+# Test 21: Pre-implementation quality gates
 echo ""
 echo "========================================"
 echo "Running Pre-Implementation Quality Gates Test Suite"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -104,6 +104,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "mcp__github__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/run-hook.sh python3 .claude/hooks/pre-tool-use-github-pr-safety.py",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/.flowspec/github-pr-safety.json
+++ b/.flowspec/github-pr-safety.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "GitHub PR Safety Configuration for Claude Code hooks",
+  "_docs": "See .claude/hooks/pre-tool-use-github-pr-safety.py for details",
+
+  "block_pr_merge": true,
+  "block_pr_merge_to_main": true,
+  "block_pr_updates": true
+}

--- a/memory/claude-hooks.md
+++ b/memory/claude-hooks.md
@@ -42,7 +42,39 @@ Asks for confirmation before modifying sensitive files:
 
 **Behavior**: Returns `"decision": "ask"` for sensitive files, prompting Claude to get user confirmation.
 
-### 3. Git Command Safety Validator (PreToolUse)
+### 3. GitHub PR Safety Guard (PreToolUse)
+
+**Hook**: `.claude/hooks/pre-tool-use-github-pr-safety.py`
+
+Prevents Claude from performing potentially destructive GitHub PR operations:
+
+**Blocked Operations (by default):**
+- `mcp__github__merge_pull_request` - Merging PRs
+- `mcp__github__update_pull_request_branch` - Updating PR branches
+- `mcp__github__create_pull_request_review` - Creating PR reviews (can approve/request changes)
+- `mcp__github__update_issue` - Updating issues/PRs
+
+**Configuration**: `.flowspec/github-pr-safety.json`
+```json
+{
+  "block_pr_merge": true,
+  "block_pr_merge_to_main": true,
+  "block_pr_updates": true
+}
+```
+
+**Environment Variables** (override config file):
+- `FLOWSPEC_BLOCK_PR_MERGE=true|false` - Block all PR merges
+- `FLOWSPEC_BLOCK_PR_MERGE_TO_MAIN=true|false` - Block merges to main/master only
+- `FLOWSPEC_BLOCK_PR_UPDATES=true|false` - Block PR update operations
+
+**Behavior**: Returns `"decision": "deny"` for blocked operations. Unlike other hooks, this hook defaults to DENY on errors (fail-closed) for safety.
+
+**GitHub Copilot Equivalent**: GitHub Copilot uses repository branch protection rules via Settings > Rules > Rulesets to control merge permissions. Copilot Automatic Code Review can be configured to block merges, though it operates at the repository level rather than the client level.
+
+**Testing**: Run `python .claude/hooks/test-github-pr-safety.py` (12 tests).
+
+### 4. Git Command Safety Validator (PreToolUse)
 
 **Hook**: `.claude/hooks/pre-tool-use-git-safety.py`
 
@@ -170,6 +202,9 @@ echo '{"tool_name": "Write", "tool_input": {"file_path": ".env"}}' | \
 
 # Test Stop quality gate hook
 python .claude/hooks/test-stop-quality-gate.py
+
+# Test GitHub PR safety hook
+python .claude/hooks/test-github-pr-safety.py
 ```
 
 ## Customizing Hook Behavior

--- a/src/flowspec_cli/safety/__init__.py
+++ b/src/flowspec_cli/safety/__init__.py
@@ -1,0 +1,23 @@
+"""Safety configuration for Claude Code hooks.
+
+This module handles configuration for GitHub PR safety guards and other
+safety-related settings that prevent Claude from performing destructive operations.
+"""
+
+from .github_pr import (
+    GITHUB_PR_SAFETY_DEFAULTS,
+    configure_github_pr_safety,
+    get_github_pr_safety_config,
+    has_github_pr_safety_config,
+    prompt_github_pr_safety,
+    resolve_pr_safety_settings,
+)
+
+__all__ = [
+    "GITHUB_PR_SAFETY_DEFAULTS",
+    "configure_github_pr_safety",
+    "get_github_pr_safety_config",
+    "has_github_pr_safety_config",
+    "prompt_github_pr_safety",
+    "resolve_pr_safety_settings",
+]

--- a/src/flowspec_cli/safety/github_pr.py
+++ b/src/flowspec_cli/safety/github_pr.py
@@ -1,0 +1,221 @@
+"""GitHub PR Safety configuration for Claude Code hooks.
+
+This module handles configuration for GitHub PR safety guards that prevent
+Claude from performing destructive PR operations like merging or updating PRs.
+
+Configuration file: .flowspec/github-pr-safety.json
+
+GitHub Copilot Equivalent:
+- Repository branch protection rules via Settings > Rules > Rulesets
+- Copilot Automatic Code Review can block merges at repository level
+- Unlike Claude hooks, Copilot operates server-side at repository level
+"""
+
+import json
+import sys
+from pathlib import Path
+
+# Default configuration - secure by default
+GITHUB_PR_SAFETY_DEFAULTS = {
+    "block_pr_merge": True,
+    "block_pr_merge_to_main": True,
+    "block_pr_updates": True,
+}
+
+# Configuration file path relative to project root
+CONFIG_FILE = ".flowspec/github-pr-safety.json"
+
+
+def get_config_path(project_root: Path) -> Path:
+    """Get the path to the GitHub PR safety configuration file."""
+    return project_root / CONFIG_FILE
+
+
+def has_github_pr_safety_config(project_root: Path) -> bool:
+    """Check if GitHub PR safety configuration exists.
+
+    Args:
+        project_root: Root directory of the project
+
+    Returns:
+        True if configuration file exists
+    """
+    return get_config_path(project_root).exists()
+
+
+def get_github_pr_safety_config(project_root: Path) -> dict:
+    """Load GitHub PR safety configuration.
+
+    Args:
+        project_root: Root directory of the project
+
+    Returns:
+        Configuration dictionary, or defaults if file doesn't exist
+    """
+    config_path = get_config_path(project_root)
+
+    if not config_path.exists():
+        return GITHUB_PR_SAFETY_DEFAULTS.copy()
+
+    try:
+        with open(config_path) as f:
+            config = json.load(f)
+            # Merge with defaults for any missing keys
+            result = GITHUB_PR_SAFETY_DEFAULTS.copy()
+            result.update(config)
+            return result
+    except (json.JSONDecodeError, IOError):
+        return GITHUB_PR_SAFETY_DEFAULTS.copy()
+
+
+def configure_github_pr_safety(
+    project_root: Path,
+    block_pr_merge: bool = True,
+    block_pr_merge_to_main: bool = True,
+    block_pr_updates: bool = True,
+) -> Path:
+    """Write GitHub PR safety configuration to file.
+
+    Args:
+        project_root: Root directory of the project
+        block_pr_merge: Block all PR merge operations
+        block_pr_merge_to_main: Block merges to main/master branches
+        block_pr_updates: Block PR update operations
+
+    Returns:
+        Path to the created configuration file
+    """
+    config_path = get_config_path(project_root)
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    config = {
+        "_comment": "GitHub PR Safety Configuration for Claude Code hooks",
+        "_docs": "See .claude/hooks/pre-tool-use-github-pr-safety.py for details",
+        "block_pr_merge": block_pr_merge,
+        "block_pr_merge_to_main": block_pr_merge_to_main,
+        "block_pr_updates": block_pr_updates,
+    }
+
+    with open(config_path, "w") as f:
+        json.dump(config, f, indent=2)
+        f.write("\n")
+
+    return config_path
+
+
+def resolve_pr_safety_settings(
+    block_pr_merge: bool | None,
+    block_pr_updates: bool | None,
+    no_prompts: bool,
+    console=None,
+    prompt_func=None,
+) -> tuple[bool, bool]:
+    """Resolve PR safety settings from CLI flags, prompts, or defaults.
+
+    This function handles the logic for determining PR safety settings,
+    consolidating duplicated code from init and upgrade_repo commands.
+
+    Args:
+        block_pr_merge: CLI flag value (None if not provided)
+        block_pr_updates: CLI flag value (None if not provided)
+        no_prompts: If True, skip prompts and use secure defaults
+        console: Rich console for output (required if prompting)
+        prompt_func: Function to call for interactive prompts (optional override)
+
+    Returns:
+        Tuple of (block_pr_merge, block_pr_updates) settings
+    """
+    pr_merge_setting = block_pr_merge
+    pr_updates_setting = block_pr_updates
+
+    # If both settings are already provided, return them directly
+    if pr_merge_setting is not None and pr_updates_setting is not None:
+        return pr_merge_setting, pr_updates_setting
+
+    # Need to resolve missing settings
+    if no_prompts:
+        # Use secure defaults for missing values
+        pr_merge_setting = True if pr_merge_setting is None else pr_merge_setting
+        pr_updates_setting = True if pr_updates_setting is None else pr_updates_setting
+    elif sys.stdin.isatty() and console is not None:
+        # Interactive mode - prompt for missing values
+        actual_prompt_func = prompt_func or prompt_github_pr_safety
+        pr_merge_prompt, pr_updates_prompt = actual_prompt_func(
+            console,
+            default_block_merge=True,
+            default_block_updates=True,
+        )
+        pr_merge_setting = (
+            pr_merge_setting if pr_merge_setting is not None else pr_merge_prompt
+        )
+        pr_updates_setting = (
+            pr_updates_setting if pr_updates_setting is not None else pr_updates_prompt
+        )
+    else:
+        # Non-interactive: use secure defaults
+        pr_merge_setting = True if pr_merge_setting is None else pr_merge_setting
+        pr_updates_setting = True if pr_updates_setting is None else pr_updates_setting
+
+    return pr_merge_setting, pr_updates_setting
+
+
+def prompt_github_pr_safety(
+    console, default_block_merge: bool = True, default_block_updates: bool = True
+) -> tuple[bool, bool]:
+    """Interactive prompts for GitHub PR safety configuration.
+
+    Args:
+        console: Rich console for output
+        default_block_merge: Default value for blocking PR merges
+        default_block_updates: Default value for blocking PR updates
+
+    Returns:
+        Tuple of (block_pr_merge, block_pr_updates)
+    """
+    import typer
+
+    console.print()
+    console.print("[cyan]GitHub PR Safety Configuration[/cyan]")
+    console.print()
+    console.print(
+        "Claude Code can perform GitHub operations via MCP tools. These settings\n"
+        "control which PR operations Claude is allowed to perform.\n"
+    )
+
+    # Only prompt if in interactive mode
+    if not sys.stdin.isatty():
+        return default_block_merge, default_block_updates
+
+    console.print(
+        "[dim]GitHub Copilot equivalent: Repository branch protection rules[/dim]"
+    )
+    console.print()
+
+    # Prompt for blocking PR merges
+    console.print(
+        "[yellow]Block PR Merges:[/yellow] Prevents Claude from merging pull requests."
+    )
+    console.print(
+        "  This is the safest option - merges should typically be done by humans."
+    )
+    block_merge = typer.confirm(
+        "Block Claude from merging PRs?",
+        default=default_block_merge,
+    )
+
+    console.print()
+
+    # Prompt for blocking PR updates
+    console.print(
+        "[yellow]Block PR Updates:[/yellow] Prevents Claude from updating PRs "
+        "(branch updates, reviews, issue updates)."
+    )
+    console.print(
+        "  Enable this to ensure all PR modifications go through human review."
+    )
+    block_updates = typer.confirm(
+        "Block Claude from updating PRs?",
+        default=default_block_updates,
+    )
+
+    return block_merge, block_updates


### PR DESCRIPTION
## Summary

Add a Claude Code PreToolUse hook that blocks potentially destructive GitHub PR operations by default, with proper main branch enforcement.

## Changes

### Hook (`pre-tool-use-github-pr-safety.py`)
- **Blocks PR merges**: `mcp__github__merge_pull_request`
- **Blocks PR updates**: `update_pull_request_branch`, `create_pull_request_review`, `update_issue`
- **Configurable** via `.flowspec/github-pr-safety.json` or environment variables
- **Fail-closed**: Defaults to deny on errors (unlike other hooks that fail-open)
- **Main branch enforcement**: Actually checks `base` field against `PROTECTED_BRANCHES` list

### Main Branch Enforcement (Fixed from #1116)
When `block_pr_merge_to_main` is enabled:
- **Deny** merge if base branch is `main` or `master`
- **Allow** merge if base branch is a non-protected branch (e.g., `feature-branch`)
- **Ask** if base branch cannot be determined from tool_input

### CLI Integration
- `flowspec init`: Prompts for PR safety settings during project setup
- `flowspec upgrade-repo`: Prompts if PR safety not already configured
- New flags:
  - `--block-pr-merge / --allow-pr-merge`
  - `--block-pr-updates / --allow-pr-updates`
  - `--no-pr-safety-prompts` (skip prompts, use secure defaults)
- **Helper function**: `resolve_pr_safety_settings()` consolidates duplicated logic

## Test plan

- [x] Hook tests: 15 tests all passing (`python .claude/hooks/test-github-pr-safety.py`)
- [x] Full hook suite: 34 tests all passing (`.claude/hooks/test-hooks.sh`)
- [x] Lint checks pass (`ruff check . && ruff format .`)
- [ ] CI checks pass

## Changes from PR #1116

This PR supersedes #1116 with all Copilot review comments addressed:

1. ✅ Removed unrelated `default_editor` config change
2. ✅ **Fixed main branch enforcement** - `PROTECTED_BRANCHES` is now actually used
3. ✅ Extracted duplicated PR safety logic into helper function
4. ✅ Added 3 new tests for main/master branch enforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)