### PR TITLE
fix: standalone download - remove two-stage logic and rename assets

### DIFF
--- a/.github/workflows/scripts/create-github-release.sh
+++ b/.github/workflows/scripts/create-github-release.sh
@@ -16,31 +16,31 @@ VERSION="$1"
 VERSION_NO_V=${VERSION#v}
 
 gh release create "$VERSION" \
-  .genreleases/spec-kit-template-copilot-sh-"$VERSION".zip \
-  .genreleases/spec-kit-template-copilot-ps-"$VERSION".zip \
-  .genreleases/spec-kit-template-claude-sh-"$VERSION".zip \
-  .genreleases/spec-kit-template-claude-ps-"$VERSION".zip \
-  .genreleases/spec-kit-template-gemini-sh-"$VERSION".zip \
-  .genreleases/spec-kit-template-gemini-ps-"$VERSION".zip \
-  .genreleases/spec-kit-template-cursor-agent-sh-"$VERSION".zip \
-  .genreleases/spec-kit-template-cursor-agent-ps-"$VERSION".zip \
-  .genreleases/spec-kit-template-opencode-sh-"$VERSION".zip \
-  .genreleases/spec-kit-template-opencode-ps-"$VERSION".zip \
-  .genreleases/spec-kit-template-qwen-sh-"$VERSION".zip \
-  .genreleases/spec-kit-template-qwen-ps-"$VERSION".zip \
-  .genreleases/spec-kit-template-windsurf-sh-"$VERSION".zip \
-  .genreleases/spec-kit-template-windsurf-ps-"$VERSION".zip \
-  .genreleases/spec-kit-template-codex-sh-"$VERSION".zip \
-  .genreleases/spec-kit-template-codex-ps-"$VERSION".zip \
-  .genreleases/spec-kit-template-kilocode-sh-"$VERSION".zip \
-  .genreleases/spec-kit-template-kilocode-ps-"$VERSION".zip \
-  .genreleases/spec-kit-template-auggie-sh-"$VERSION".zip \
-  .genreleases/spec-kit-template-auggie-ps-"$VERSION".zip \
-  .genreleases/spec-kit-template-roo-sh-"$VERSION".zip \
-  .genreleases/spec-kit-template-roo-ps-"$VERSION".zip \
-  .genreleases/spec-kit-template-codebuddy-sh-"$VERSION".zip \
-  .genreleases/spec-kit-template-codebuddy-ps-"$VERSION".zip \
-  .genreleases/spec-kit-template-q-sh-"$VERSION".zip \
-  .genreleases/spec-kit-template-q-ps-"$VERSION".zip \
+  .genreleases/flowspec-template-copilot-sh-"$VERSION".zip \
+  .genreleases/flowspec-template-copilot-ps-"$VERSION".zip \
+  .genreleases/flowspec-template-claude-sh-"$VERSION".zip \
+  .genreleases/flowspec-template-claude-ps-"$VERSION".zip \
+  .genreleases/flowspec-template-gemini-sh-"$VERSION".zip \
+  .genreleases/flowspec-template-gemini-ps-"$VERSION".zip \
+  .genreleases/flowspec-template-cursor-agent-sh-"$VERSION".zip \
+  .genreleases/flowspec-template-cursor-agent-ps-"$VERSION".zip \
+  .genreleases/flowspec-template-opencode-sh-"$VERSION".zip \
+  .genreleases/flowspec-template-opencode-ps-"$VERSION".zip \
+  .genreleases/flowspec-template-qwen-sh-"$VERSION".zip \
+  .genreleases/flowspec-template-qwen-ps-"$VERSION".zip \
+  .genreleases/flowspec-template-windsurf-sh-"$VERSION".zip \
+  .genreleases/flowspec-template-windsurf-ps-"$VERSION".zip \
+  .genreleases/flowspec-template-codex-sh-"$VERSION".zip \
+  .genreleases/flowspec-template-codex-ps-"$VERSION".zip \
+  .genreleases/flowspec-template-kilocode-sh-"$VERSION".zip \
+  .genreleases/flowspec-template-kilocode-ps-"$VERSION".zip \
+  .genreleases/flowspec-template-auggie-sh-"$VERSION".zip \
+  .genreleases/flowspec-template-auggie-ps-"$VERSION".zip \
+  .genreleases/flowspec-template-roo-sh-"$VERSION".zip \
+  .genreleases/flowspec-template-roo-ps-"$VERSION".zip \
+  .genreleases/flowspec-template-codebuddy-sh-"$VERSION".zip \
+  .genreleases/flowspec-template-codebuddy-ps-"$VERSION".zip \
+  .genreleases/flowspec-template-q-sh-"$VERSION".zip \
+  .genreleases/flowspec-template-q-ps-"$VERSION".zip \
   --title "flowspec - $VERSION_NO_V" \
   --notes-file release_notes.md

--- a/.github/workflows/scripts/create-release-packages.sh
+++ b/.github/workflows/scripts/create-release-packages.sh
@@ -371,8 +371,8 @@ build_variant() {
       mkdir -p "$base_dir/.amazonq/prompts"
       generate_commands q md "\$ARGUMENTS" "$base_dir/.amazonq/prompts" "$script" ;;
   esac
-  ( cd "$base_dir" && zip -r "../spec-kit-template-${agent}-${script}-${NEW_VERSION}.zip" . )
-  echo "Created $GENRELEASES_DIR/spec-kit-template-${agent}-${script}-${NEW_VERSION}.zip"
+  ( cd "$base_dir" && zip -r "../flowspec-template-${agent}-${script}-${NEW_VERSION}.zip" . )
+  echo "Created $GENRELEASES_DIR/flowspec-template-${agent}-${script}-${NEW_VERSION}.zip"
 }
 
 # Determine agent list
@@ -422,5 +422,5 @@ for agent in "${AGENT_LIST[@]}"; do
 done
 
 echo "Archives in $GENRELEASES_DIR:"
-ls -1 "$GENRELEASES_DIR"/spec-kit-template-*-"${NEW_VERSION}".zip
+ls -1 "$GENRELEASES_DIR"/flowspec-template-*-"${NEW_VERSION}".zip
 

--- a/build-docs/CONTRIBUTING-AGENTS.md
+++ b/build-docs/CONTRIBUTING-AGENTS.md
@@ -124,8 +124,8 @@ Modify `.github/workflows/scripts/create-github-release.sh` to include the new a
 ```bash
 gh release create "$VERSION" \
   # ... existing packages ...
-  .genreleases/spec-kit-template-windsurf-sh-"$VERSION".zip \
-  .genreleases/spec-kit-template-windsurf-ps-"$VERSION".zip \
+  .genreleases/flowspec-template-windsurf-sh-"$VERSION".zip \
+  .genreleases/flowspec-template-windsurf-ps-"$VERSION".zip \
   # Add new agent packages here
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "flowspec-cli"
 
-version = "0.4.00"
+version = "0.4.1"
 
 
 

--- a/tests/test_github_auth.py
+++ b/tests/test_github_auth.py
@@ -163,7 +163,7 @@ class TestGitHubAuthRetry:
             "tag_name": "v1.0.0",
             "assets": [
                 {
-                    "name": "spec-kit-template-claude-sh.zip",
+                    "name": "flowspec-template-claude-sh-v1.0.0.zip",
                     "browser_download_url": "https://example.com/t.zip",
                 }
             ],
@@ -204,7 +204,7 @@ class TestGitHubAuthRetry:
             "tag_name": "v1.0.0",
             "assets": [
                 {
-                    "name": "spec-kit-template-claude-sh.zip",
+                    "name": "flowspec-template-claude-sh-v1.0.0.zip",
                     "browser_download_url": "https://example.com/t.zip",
                 }
             ],
@@ -349,7 +349,7 @@ class TestGitHubAuthRetry:
             "tag_name": "v1.0.0",
             "assets": [
                 {
-                    "name": "spec-kit-template-claude-sh.zip",
+                    "name": "flowspec-template-claude-sh-v1.0.0.zip",
                     "browser_download_url": "https://example.com/t.zip",
                 }
             ],
@@ -376,6 +376,133 @@ class TestGitHubAuthRetry:
         for call in mock_client.get.call_args_list:
             headers = call[1]["headers"]
             assert "Authorization" in headers
+
+
+class TestLegacyAssetNamingFallback:
+    """Tests for backward compatibility with legacy spec-kit-template-* naming."""
+
+    @pytest.fixture
+    def temp_dir(self):
+        """Create a temporary directory for downloads."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    def test_legacy_asset_naming_fallback(self, temp_dir):
+        """Should find assets using legacy spec-kit-template-* naming."""
+        from flowspec_cli import download_template_from_github
+
+        mock_release_response = MagicMock()
+        mock_release_response.status_code = 200
+        # Simulate an older release with ONLY legacy naming (no new pattern)
+        mock_release_response.json.return_value = {
+            "tag_name": "v0.3.0",
+            "assets": [
+                {
+                    "name": "spec-kit-template-claude-sh-v0.3.0.zip",
+                    "browser_download_url": "https://example.com/legacy-asset.zip",
+                    "url": "https://api.example.com/legacy-asset",
+                    "size": 1000,
+                }
+            ],
+        }
+
+        # Track which URLs are requested
+        download_urls = []
+
+        def mock_get(url, **kwargs):
+            download_urls.append(url)
+            if "releases" in url:
+                return mock_release_response
+            # Simulate download failure for asset fetch
+            mock_download = MagicMock()
+            mock_download.status_code = 404
+            return mock_download
+
+        mock_client = MagicMock()
+        mock_client.get.side_effect = mock_get
+
+        with patch.dict("os.environ", {}, clear=True):
+            try:
+                download_template_from_github(
+                    ai_assistant="claude",
+                    download_dir=temp_dir,
+                    repo_owner="test",
+                    repo_name="repo",
+                    version="v0.3.0",
+                    client=mock_client,
+                    verbose=False,
+                )
+            except Exception:
+                pass  # Expected - actual download will fail
+
+        # Verify the legacy asset URL was selected for download
+        assert any("legacy-asset" in url for url in download_urls), (
+            f"Should have selected legacy asset URL, got: {download_urls}"
+        )
+
+    def test_new_asset_naming_preferred_over_legacy(self, temp_dir):
+        """Should prefer new flowspec-template-* naming when both exist."""
+        from flowspec_cli import download_template_from_github
+
+        mock_release_response = MagicMock()
+        mock_release_response.status_code = 200
+        # Release with both old and new naming - legacy appears FIRST
+        mock_release_response.json.return_value = {
+            "tag_name": "v1.0.0",
+            "assets": [
+                {
+                    "name": "spec-kit-template-claude-sh-v1.0.0.zip",
+                    "browser_download_url": "https://example.com/legacy.zip",
+                    "url": "https://api.example.com/legacy",
+                    "size": 1000,
+                },
+                {
+                    "name": "flowspec-template-claude-sh-v1.0.0.zip",
+                    "browser_download_url": "https://example.com/new.zip",
+                    "url": "https://api.example.com/new",
+                    "size": 1000,
+                },
+            ],
+        }
+
+        # Track which URL is requested for download
+        download_urls = []
+
+        def mock_get(url, **kwargs):
+            download_urls.append(url)
+            if "releases" in url:
+                return mock_release_response
+            # Simulate download failure for asset fetch
+            mock_download = MagicMock()
+            mock_download.status_code = 404
+            return mock_download
+
+        mock_client = MagicMock()
+        mock_client.get.side_effect = mock_get
+
+        with patch.dict("os.environ", {}, clear=True):
+            try:
+                download_template_from_github(
+                    ai_assistant="claude",
+                    download_dir=temp_dir,
+                    repo_owner="test",
+                    repo_name="repo",
+                    version="latest",
+                    client=mock_client,
+                    verbose=False,
+                )
+            except Exception:
+                pass  # Expected - download will fail but we're testing selection
+
+        # Verify new pattern URL was selected, not legacy (even though legacy appears first)
+        assert any("new" in url for url in download_urls), (
+            f"Should have selected new asset URL, got: {download_urls}"
+        )
+        # Also verify legacy URL was NOT used for downloads (only API call for release info)
+        download_attempts = [u for u in download_urls if "releases" not in u]
+        assert not any("legacy" in url for url in download_attempts), (
+            f"Should NOT have used legacy asset URL, got: {download_attempts}"
+        )
 
 
 class TestGitHubTokenEdgeCases:


### PR DESCRIPTION
## Summary
- Fixes upgrade-repo failure caused by two-stage download trying to use deleted zip file
- Renames release assets from `spec-kit-template-*` to `flowspec-template-*`
- Simplifies download to single-stage (one download per agent)
- Prefers new naming over legacy when both exist
- Adds robust tests with URL tracking assertions
- Version 0.4.1

## Test plan
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)