### PR TITLE
refactor(docs): slim CLAUDE.md to under 200 lines

### DIFF
--- a/.claude/rules/coding-style.md
+++ b/.claude/rules/coding-style.md
@@ -1,0 +1,105 @@
+# Code Standards
+
+## Python Standards
+
+- **Linter/Formatter**: Ruff (replaces Black, Flake8, isort)
+- **Line length**: 88 characters
+- **Type hints**: Required for public APIs
+- **File paths**: Use `pathlib`
+- **Imports**: All at module level (never inside functions)
+
+## File I/O (Critical)
+
+**Always use `encoding="utf-8"`** for all file operations:
+
+```python
+path.read_text(encoding="utf-8")
+path.write_text(content, encoding="utf-8")
+```
+
+**Always clean up temp files** with try-finally.
+
+## Naming (Avoid Shadowing)
+
+Never use Python built-in names as parameters or variables:
+- **Bad**: `id`, `type`, `list`, `dict`, `input`, `filter`, `map`, `hash`
+- **Good**: `finding_id`, `item_type`, `items`, `data`, `user_input`
+
+## Defensive Programming
+
+- **Clamp external inputs** to expected ranges
+- **Explicit type conversions** for clarity
+
+## YAGNI (You Aren't Gonna Need It)
+
+- Don't add config fields you don't use
+- Remove dead code, don't comment it out
+- If a feature isn't implemented, don't scaffold it
+
+## API-Calling Functions
+
+### Exception Handling - Never Silently Swallow
+
+```python
+# BAD
+except Exception:
+    pass
+
+# GOOD - Log all exceptions with context
+except httpx.TimeoutException:
+    logger.debug(f"Timeout fetching {url}")
+except httpx.HTTPError as e:
+    logger.debug(f"HTTP error fetching {url}: {e}")
+```
+
+### Test Coverage - All Failure Modes
+
+Every API function needs tests for:
+- Success case
+- Timeout case
+- Network error case
+- Invalid HTTP status code (4xx, 5xx)
+- Missing expected fields in response
+- Malformed response (JSON decode error)
+
+## Pre-PR Verification
+
+```bash
+# Run before every PR:
+uv run ruff format --check .
+uv run ruff check .
+uv run pytest tests/ -x -q
+```
+
+## Git & CI Compliance
+
+### Pre-Commit Checks
+
+```bash
+git fetch origin main && git rebase origin/main
+uv run ruff format --check .
+uv run ruff check .
+uv run pytest tests/ -x -q
+```
+
+**Common failure**: Running `ruff check .` but NOT `ruff format --check .` - these are DIFFERENT checks. CI runs both.
+
+### DCO Compliance
+
+**ALWAYS use `-s` flag when committing:**
+
+```bash
+git commit -s -m "feat: your message"
+```
+
+## Commits
+
+Follow conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
+
+## Consistency is Non-Negotiable
+
+**If a standard applies, it applies EVERYWHERE:**
+- Production code
+- Test code
+- Example code in docstrings
+- Template examples

--- a/.claude/rules/critical.md
+++ b/.claude/rules/critical.md
@@ -1,0 +1,125 @@
+# Critical Rules
+
+## NEVER DELETE TESTS (ABSOLUTE - NO EXCEPTIONS)
+
+**An AI agent MUST NEVER delete test files or test methods without EXPLICIT human instruction.**
+
+This is NON-NEGOTIABLE. No exceptions. No rationalizations.
+
+### What is NOT a valid reason to delete tests:
+- "The code is deprecated" - NO
+- "New tests replace them" - NO
+- "It's a refactor" - NO
+- "The tests are outdated" - NO
+- "The tests are failing" - NO (fix them instead)
+- "The commit message explains it" - NO
+
+### The ONLY valid reason:
+**Human explicitly says: "Delete these specific tests: [list]"**
+
+### If you think tests should be deleted:
+1. STOP
+2. ASK the human: "I believe tests X, Y, Z may need removal because [reason]. Do you approve?"
+3. WAIT for explicit "yes, delete them"
+4. Only then proceed
+
+### PR Requirements for ANY test deletion:
+If human approves test deletion, the PR MUST:
+1. Have **TEST DELETION** in the PR title
+2. List every deleted test file and method
+3. Show before/after test counts
+4. Explain why each deletion was human-approved
+
+---
+
+## Pre-PR Validation (MANDATORY - NO EXCEPTIONS)
+
+**BEFORE creating any PR, you MUST run and pass ALL THREE:**
+
+```bash
+uv run ruff format --check .  # Format check - MUST pass
+uv run ruff check .           # Lint check - MUST pass with zero errors
+uv run pytest tests/ -x -q    # Tests - MUST pass with zero failures
+```
+
+**DO NOT create a PR if ANY check fails.** Fix issues first.
+
+---
+
+## No Direct Commits to Main (ABSOLUTE - NO EXCEPTIONS)
+
+**NEVER commit directly to main.** All changes MUST go through a PR:
+
+1. Create branch -> 2. Make changes -> 3. **Run lint + tests locally** -> 4. Create PR -> 5. CI passes -> 6. Merge -> 7. Mark task Done
+
+Not for "urgent" fixes. Not for "small" changes. **NO EXCEPTIONS.**
+
+---
+
+## DCO Sign-off (Required)
+
+All commits MUST include sign-off:
+
+```bash
+git commit -s -m "feat: description"
+```
+
+---
+
+## Backlog.md Task Management
+
+**NEVER edit task files directly** - Use `backlog task edit` CLI commands only.
+Direct file editing breaks metadata sync, Git tracking, and relationships.
+
+---
+
+## Task Memory - Durable Context (CRITICAL)
+
+Task memory (`backlog/memory/task-XXX.md`) stores context that MUST survive:
+- Context resets/compaction
+- Session switches and machine changes
+- Agent handoffs between workflow phases
+
+### What MUST be in Task Memory
+
+**"Critical Context" section (NEVER DELETE):**
+1. **What**: Brief description of what we're building
+2. **Why**: Business value, user need, or problem being solved
+3. **Constraints**: Technical requirements, deadlines, dependencies
+4. **AC Status**: Which acceptance criteria are complete/incomplete
+
+**Key Decisions:**
+- Architecture choices with rationale
+- Trade-offs made and why
+- Rejected approaches and why they failed
+
+### When to Update Task Memory
+
+- **Session start**: Read memory, update "Current State"
+- **After decisions**: Record in "Key Decisions" immediately
+- **Before session end**: Update "Current State" with what's done/next
+- **After blocking issues**: Document in "Blocked/Open Questions"
+
+---
+
+## PR-Task Synchronization (Required)
+
+When a PR completes a backlog task, update the task **before or with** PR creation:
+
+```bash
+backlog task edit <task-id> --check-ac 1 --check-ac 2 -s Done \
+  --notes $'Completed via PR #<number>\n\nStatus: Pending CI verification'
+```
+
+**If PR fails CI**: Revert task to "In Progress" and uncheck incomplete ACs.
+
+---
+
+## Git Worktrees for Parallel Work
+
+Worktree name MUST match branch name:
+
+```bash
+git worktree add ../feature-auth feature-auth  # Correct
+git worktree add ../work1 feature-auth         # Wrong
+```

--- a/.claude/rules/rigor.md
+++ b/.claude/rules/rigor.md
@@ -1,0 +1,75 @@
+# Rigor Rules
+
+Rigor rules apply to ALL Flowspec users, enforcing workflow quality gates.
+
+## Enforcement Modes
+
+| Mode | Behavior | Use Case |
+|------|----------|----------|
+| **strict** | Block workflow if violated | Default for BLOCKING rules |
+| **warn** | Warn but allow continuation | Advisory rules |
+| **off** | Disable rule | Emergency use only |
+
+Configure in `.flowspec/rigor-config.yml` or accept defaults (all BLOCKING rules = strict).
+
+## Key Blocking Rules
+
+| Rule | Phase | Requirement |
+|------|-------|-------------|
+| SETUP-001 | Specify | Clear Plan Required |
+| SETUP-002 | Specify | Dependencies Mapped |
+| SETUP-003 | Specify | Testable Acceptance Criteria |
+| EXEC-001 | Implement | Git Worktree Required |
+| EXEC-002 | Implement | Branch Naming Convention |
+| EXEC-003 | Implement | Decision Logging Required |
+| EXEC-004 | Implement | Backlog Task Linkage |
+| VALID-005 | Validate | Acceptance Criteria Met |
+| PR-001 | PR | DCO Sign-off Required |
+
+## Branch Naming Convention
+
+Pattern: `{hostname}/task-{id}/{slug-description}`
+
+Example: `macbook-pro/task-541/rigor-rules-include`
+
+## Decision Logging
+
+All significant decisions MUST be logged:
+
+```bash
+./scripts/bash/rigor-decision-log.sh \
+  --task task-123 \
+  --phase execution \
+  --decision "Description" \
+  --rationale "Why" \
+  --actor "@backend-engineer"
+```
+
+## Common Violations and Fixes
+
+```bash
+# SETUP-001: Missing implementation plan
+backlog task edit <task-id> --plan $'1. Research\n2. Implement\n3. Test'
+
+# EXEC-001: Git worktree required
+BRANCH="$(hostname -s | tr '[:upper:]' '[:lower:]')/task-<task-id>/feature-slug"
+git worktree add "../$(basename $BRANCH)" "$BRANCH"
+
+# VALID-005: Unchecked acceptance criteria
+backlog task edit <task-id> --check-ac 1 --check-ac 2
+```
+
+## Workflow State Tracking
+
+Tasks MUST have both `workflow:Current` and `workflow-next:Next` labels.
+
+**Workflow States**: Assessed -> Specified -> Planned -> In Implementation -> Validated -> Deployed
+
+## Full Reference
+
+See `.claude/partials/flow/_rigor-rules.md` for complete rule documentation including:
+- All validation scripts
+- FREEZE phase rules
+- VALIDATION phase rules
+- PR phase rules
+- Utility scripts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,305 +1,76 @@
 # Flowspec - Claude Code Configuration
 
-## Project Overview
-
-**Flowspec** is a standalone toolkit for Spec-Driven Development (SDD):
-- **Flowspec CLI**: Command-line tool to bootstrap projects (`flowspec-cli` package)
-- **Templates**: SDD templates for multiple AI agents
-- **Documentation**: Comprehensive guides in `docs/`
+Standalone toolkit for Spec-Driven Development (SDD): CLI tool (`flowspec-cli`), templates for AI agents, and comprehensive documentation.
 
 ## Essential Commands
 
 ```bash
-# Development
 pytest tests/                    # Run tests
-ruff check . --fix               # Lint and auto-fix
-ruff format .                    # Format code
+ruff check . --fix && ruff format .  # Lint and format
 uv sync                          # Install dependencies
 uv tool install . --force        # Install CLI locally
+```
 
-# Backlog (NEVER edit task files directly!)
-backlog task list --plain        # List tasks (AI-friendly output)
+## Backlog Commands
+
+```bash
+backlog task list --plain        # List tasks (AI-friendly)
 backlog task 42 --plain          # View task details
 backlog task edit 42 -s "In Progress" -a @myself  # Start work
-backlog task edit 42 --check-ac 1  # Mark acceptance criterion done
+backlog task edit 42 --check-ac 1  # Mark AC done
 backlog task edit 42 -s Done     # Complete task
 ```
 
 ## Slash Commands
 
-```bash
-# Workflow Commands (stateful, sequential stages)
-/flow:assess    # Evaluate SDD workflow suitability
-/flow:specify   # Create/update feature specs
-/flow:research  # Research and validation (optional)
-/flow:plan      # Execute planning workflow
-/flow:implement # Implementation with code review
-/flow:validate  # QA, security, docs validation
+| Command | Purpose |
+|---------|---------|
+| `/flow:assess` | Evaluate SDD workflow suitability |
+| `/flow:specify` | Create/update feature specs |
+| `/flow:research` | Research and validation (optional) |
+| `/flow:plan` | Execute planning workflow |
+| `/flow:implement` | Implementation with code review |
+| `/flow:validate` | QA, security, docs validation |
+| `/flow:init` | Initialize constitution |
+| `/flow:intake` | Process INITIAL docs to create tasks |
+| `/vibe` | Casual mode - just logs and light docs |
 
-# Setup & Configuration Commands
-/flow:init      # Initialize constitution (greenfield/brownfield)
-/flow:reset     # Re-run workflow configuration prompts
-/flow:intake    # Process INITIAL docs to create backlog tasks with context
-/flow:generate-prp  # Generate PRP context bundle from task artifacts
-/flow:map-codebase  # Generate bounded directory tree listings for codebase areas
+## Default Mode
 
-# Casual Development
-/vibe           # Casual mode - just logs and light docs (see Default Development Mode)
-```
+When no `/flow:*` command is specified, default to **vibe mode**:
+- Quick fixes, prototypes, exploration: just code it
+- Log decisions to `.flowspec/logs/decisions/`
+- Escalate to full SDD if work grows complex
 
-## Default Development Mode
+## INITIAL Documents
 
-**When no explicit `/flow:*` command is specified**, default to **vibe mode** principles:
-
-| Situation | Approach |
-|-----------|----------|
-| Quick fix, small change | Just code it, log decisions to `.logs/` |
-| Exploring an idea | Use `/vibe` - minimal ceremony |
-| Prototyping | Use `/vibe` - fast iteration |
-| Learning/experimenting | Use `/vibe` - low overhead |
-| Feature with clear requirements | Start with `/flow:assess` |
-| Complex multi-session work | Use full SDD workflow |
-
-**Vibe mode always requires**:
-- Log significant decisions to `.logs/decisions/`
-- Log events to `.logs/events/`
-
-**Vibe mode does NOT require**:
-- Formal PRD or spec documents
-- Backlog task creation
-- Workflow state management
-- Constitution validation
-
-**When to escalate to full SDD**: If work grows larger than expected, involves multiple people, touches security/compliance, or needs formal requirements.
-
-## INITIAL Document Workflow
-
-**CRITICAL**: Before running `/flow:assess` or `/flow:specify`, ALWAYS look for and read the INITIAL document for the feature.
-
-### What is an INITIAL Document?
-
-INITIAL documents are the **primary source of high-level context** for features. They provide structured, comprehensive context that flows into PRDs, PRPs, and implementation tasks.
-
-### Location and Naming
-
-- **Location**: `docs/features/<feature-slug>-initial.md`
-- **Template**: `templates/docs/initial/initial-feature-template.md`
-- **Example**: `docs/features/backlog-task-management-initial.md`
-
-### When to Read INITIAL Documents
-
-**ALWAYS** check for an INITIAL document before running:
-- `/flow:assess` - Assessment requires understanding the full feature context
-- `/flow:specify` - PRD creation builds directly from INITIAL document content
-
-### What INITIAL Documents Contain
-
-Each INITIAL document includes:
-1. **FEATURE**: Problem statement, desired outcome, constraints, business impact
-2. **EXAMPLES**: Relevant example files, usage patterns, expected behaviors
-3. **DOCUMENTATION**: Links to PRDs, ADRs, external specs, related tasks
-4. **OTHER CONSIDERATIONS**: Gotchas, failures, dependencies, security, performance
-
-### Workflow Integration
-
-```bash
-# 1. Check for INITIAL document
-ls docs/features/*-initial.md
-
-# 2. Read the INITIAL document FIRST
-# (Use Read tool to load docs/features/<feature-slug>-initial.md)
-
-# 3. THEN run assessment or specification
-/flow:assess    # With full context from INITIAL doc
-/flow:specify   # Building PRD from INITIAL doc content
-```
-
-### Key Principle
-
-The INITIAL document is the **canonical source** for feature context. All downstream artifacts (assessments, PRDs, PRPs, tasks) should reference and build upon the context established in the INITIAL document.
-
-If no INITIAL document exists and the user requests `/flow:assess` or `/flow:specify`, suggest creating one first using `/flow:intake` or by manually copying the template.
+**ALWAYS** check for `docs/features/<feature-slug>-initial.md` before `/flow:assess` or `/flow:specify`. Contains feature context, examples, constraints.
 
 ## Engineering Subagents
 
-Flowspec includes specialized engineering subagents for implementation tasks. These agents are invoked during `/flow:implement` and provide focused expertise:
-
-### Backend Engineer
-**Location**: `.claude/agents/backend-engineer.md`
-
-**Expertise**:
-- Python 3.11+ (FastAPI, Flask)
-- APIs and REST endpoints
-- Database design (SQLAlchemy, PostgreSQL, SQLite)
-- Server-side business logic
-- pytest and test automation
-
-**Use for**: API development, database work, backend services, data processing
-
-### Frontend Engineer
-**Location**: `.claude/agents/frontend-engineer.md`
-
-**Expertise**:
-- React 18+ and Next.js 14+
-- TypeScript strict mode
-- UI components and styling (Tailwind CSS)
-- Accessibility (WCAG compliance)
-- Vitest, React Testing Library, Playwright
-
-**Use for**: React components, UI/UX, browser interactions, client-side logic
-
-### QA Engineer
-**Location**: `.claude/agents/qa-engineer.md`
-
-**Expertise**:
-- Test pyramid strategy (unit, integration, E2E)
-- pytest, Vitest, Playwright
-- Test coverage and quality metrics
-- Test automation and CI/CD integration
-- Property-based testing (hypothesis)
-
-**Use for**: Test creation, coverage analysis, E2E testing, quality validation
-
-### Security Reviewer
-**Location**: `.claude/agents/security-reviewer.md`
-
-**Expertise**:
-- OWASP Top 10 compliance
-- Vulnerability assessment
-- SLSA compliance (Levels 1-4)
-- Security scanning (bandit, npm audit, trivy)
-- Threat modeling and secure design
-
-**Use for**: Security reviews, vulnerability scanning, compliance checks, threat analysis
-
-**Note**: Security reviewer has **read-only** access to code. It analyzes and reports findings but does not make code changes directly.
-
-### Agent Invocation
-
-Agents are automatically invoked by `/flow:implement` based on task labels:
-- Tasks labeled `backend` → backend-engineer
-- Tasks labeled `frontend` → frontend-engineer
-- All tasks → qa-engineer (for test coverage)
-- All tasks → security-reviewer (for security review)
-
-See [Workflow Configuration](#workflow-configuration) for customizing agent assignments.
+| Agent | Location | Use For |
+|-------|----------|---------|
+| Backend | `.claude/agents/backend-engineer.md` | APIs, databases, Python |
+| Frontend | `.claude/agents/frontend-engineer.md` | React, TypeScript, UI |
+| QA | `.claude/agents/qa-engineer.md` | Tests, coverage |
+| Security | `.claude/agents/security-reviewer.md` | Security review (read-only) |
 
 ## Workflow Configuration
 
-Flowspec uses a configurable workflow system defined in `flowspec_workflow.yml` at the project root.
-
-### Configuration File Location
-
-**Default**: `{project-root}/flowspec_workflow.yml`
-
-The workflow configuration defines:
-- **States**: Task progression stages (e.g., Specified, Planned, Validated)
-- **Workflows**: `/flow:*` commands with agent assignments
-- **Transitions**: Valid state changes between states
-- **Agent Loops**: Inner/outer loop classification
-
-### How /flow:* Commands Use Workflow Config
-
-Each `/flow:*` command:
-1. Checks current task state from backlog.md
-2. Validates state is a valid input for the command (from `flowspec_workflow.yml`)
-3. Executes agents assigned to the workflow
-4. Transitions task to the command's output state
-5. Creates artifacts defined in transitions
-
-Example:
-```yaml
-workflows:
-  implement:
-    command: "/flow:implement"
-    agents:
-      - frontend-engineer
-      - backend-engineer
-    input_states: ["Planned"]
-    output_state: "In Implementation"
-```
-
-### Validate Workflow Configuration
+Defined in `flowspec_workflow.yml`. Validate with:
 
 ```bash
-# Validate default flowspec_workflow.yml
 flowspec workflow validate
-
-# Validate custom workflow file
-flowspec workflow validate --file custom_workflow.yml
-
-# Show detailed output with warnings
-flowspec workflow validate --verbose
-
-# JSON output for CI/automation
-flowspec workflow validate --json
-
-# Example output:
-# ✓ Schema validation passed
-# ✓ Validation passed: workflow configuration is valid
-
-# Exit codes:
-# 0 = validation passed
-# 1 = validation errors (schema or semantic)
-# 2 = file errors (not found, invalid YAML)
 ```
 
-### Quick Reference: Commands and Workflow Phases
-
-| Command | Input State(s) | Output State | Agents |
-|---------|---------------|--------------|--------|
-| `/flow:assess` | To Do | Assessed | workflow-assessor |
-| `/flow:specify` | Assessed | Specified | product-requirements-manager |
-| `/flow:research` | Specified | Researched | researcher, business-validator |
-| `/flow:plan` | Specified, Researched | Planned | software-architect, platform-engineer |
-| `/flow:implement` | Planned | In Implementation | frontend/backend engineers, reviewers |
-| `/flow:validate` | In Implementation | Validated | quality-guardian, secure-by-design-engineer |
-
-*Note: `/flow:research` is optional.*
-
-### Customizing Your Workflow
-
-You can customize the workflow by editing `flowspec_workflow.yml`:
-- Add/remove phases
-- Change agent assignments
-- Add custom states
-- Modify transitions
-
-See [Workflow Customization Guide](docs/guides/workflow-customization.md) for details.
-
-### /flow:* + Backlog.md Integration
-
-Every `/flow:*` command integrates with backlog.md:
-
-**Design commands create tasks**:
-```bash
-# /flow:specify creates implementation tasks with ACs
-backlog task create "Implement feature X" --ac "AC 1" --ac "AC 2" -l backend
-```
-
-**Implementation commands consume tasks**:
-```bash
-# /flow:implement discovers and works from existing tasks
-backlog task edit task-42 -s "In Progress" -a @backend-engineer
-backlog task edit task-42 --check-ac 1  # Check ACs progressively
-```
-
-**Key rule**: Never run `/flow:implement` without first running `/flow:specify` to create tasks.
-
-See [Flowspec + Backlog.md Integration Guide](docs/guides/flowspec-backlog-workflow.md) for complete details.
-
-### Workflow Documentation
-
-- [Flowspec + Backlog.md Integration](docs/guides/flowspec-backlog-workflow.md) - Complete integration guide
-- [Workflow State Mapping](docs/guides/workflow-state-mapping.md) - State and command mapping
-- [Workflow Customization Guide](docs/guides/workflow-customization.md) - How to modify workflows
-- [Workflow Architecture](docs/guides/workflow-architecture.md) - Overall design
-- [Workflow Troubleshooting](docs/guides/workflow-troubleshooting.md) - Common issues
-- [Configuration Examples](docs/examples/workflows/) - Working example configs
-
-@import memory/critical-rules.md
-
-@import .claude/partials/flow/_rigor-rules.md
+| Command | Input State | Output State |
+|---------|-------------|--------------|
+| `/flow:assess` | To Do | Assessed |
+| `/flow:specify` | Assessed | Specified |
+| `/flow:research` | Specified | Researched |
+| `/flow:plan` | Specified/Researched | Planned |
+| `/flow:implement` | Planned | In Implementation |
+| `/flow:validate` | In Implementation | Validated |
 
 ## Project Structure
 
@@ -308,84 +79,35 @@ flowspec/
 ├── src/flowspec_cli/       # CLI source code
 ├── tests/                  # Test suite (pytest)
 ├── templates/              # Project templates
-│   ├── docs/               # Workflow artifact directories (copied to project docs/)
-│   │   ├── assess/         # Assessment reports (/flow:assess)
-│   │   ├── prd/            # Product Requirements Documents (/flow:specify)
-│   │   ├── research/       # Research reports (/flow:research)
-│   │   ├── adr/            # Architecture Decision Records (/flow:plan)
-│   │   ├── platform/       # Platform design docs (/flow:plan)
-│   │   ├── qa/             # QA reports (/flow:validate)
-│   │   └── security/       # Security reports (/flow:validate)
-│   ├── skills/             # Skill templates (copied to .claude/skills/)
-│   ├── *-template.md       # Artifact templates
-│   └── commands/           # Slash command templates (flow/, vibe/)
+│   ├── docs/               # Workflow artifact directories
+│   └── commands/           # Slash command templates
 ├── docs/                   # Documentation
 │   ├── guides/             # User guides
 │   └── reference/          # Reference docs
 ├── memory/                 # Constitution & specs
-├── scripts/bash/           # Automation scripts
 ├── backlog/                # Task management
-├── .claude/commands/       # Slash command implementations (flow/, vibe/)
-└── .claude/skills/         # Model-invoked skills
+├── .claude/commands/       # Slash command implementations
+├── .claude/skills/         # Model-invoked skills
+└── .claude/rules/          # Automatic rules
 ```
 
-### Template Files in memory/
+## Task Management
 
-The `memory/constitution.md` file is a **template** for project-specific constitutions. It contains placeholder tokens like `[PROJECT_NAME]`, `[PRINCIPLE_1_NAME]`, etc. that are intentionally left unfilled.
+| Layer | Tool | Purpose |
+|-------|------|---------|
+| Feature/Task | Backlog.md | High-level work items, ACs |
+| Agent Work | Beads | Detailed implementation steps |
 
-**Purpose**: When users run `flowspec init` in a new project, they can customize this template with their project-specific values.
+Simple tasks: Backlog.md only. Complex tasks: Backlog.md + Beads.
 
-**Placeholders are intentional** and should NOT be replaced with "Flowspec" values. The flowspec repository itself does not need a filled constitution - it provides the template for other projects.
-
-See `memory/README.md` for details on all modular components in the memory directory.
-
-@import memory/code-standards.md
-
-@import memory/test-quality-standards.md
-
-## Task Management: Two-Tier Approach
-
-Flowspec uses a hierarchical task management system:
-
-| Layer | Tool | Purpose | Audience |
-|-------|------|---------|----------|
-| **Feature/Task** | Backlog.md | High-level work items, acceptance criteria, status | Humans, planning |
-| **Agent Work** | Beads | Detailed implementation steps, dependencies, blockers | Agents, execution |
-
-**Quick Decision**:
-- **Simple tasks** (single-session, no dependencies): Track entirely in Backlog.md
-- **Complex tasks** (multi-session, agent coordination): Use Backlog.md + Beads
-
-**Workflow Summary**:
-1. All work starts in **Backlog.md** (human-visible tasks)
-2. Move task to "In Progress" when starting work
-3. For complex implementations, create **Beads** issues for detailed agent tracking
-4. Beads work rolls up to the parent backlog task on completion
-5. Update backlog with notes and check acceptance criteria as work completes
-
-See [Two-Tier Task Management Guide](docs/guides/task-management-tiers.md) for complete details.
-
-## Documentation References
+## Documentation
 
 | Topic | Location |
 |-------|----------|
-| Two-Tier Task Management | `docs/guides/task-management-tiers.md` |
 | Backlog Quick Start | `docs/guides/backlog-quickstart.md` |
-| Backlog User Guide | `docs/guides/backlog-user-guide.md` |
-| Backlog Commands | `docs/reference/backlog-commands.md` |
-| Inner Loop | `docs/reference/inner-loop.md` |
-| Outer Loop | `docs/reference/outer-loop.md` |
-| Agent Classification | `docs/reference/agent-loop-classification.md` |
-| Flush Backlog | `docs/guides/backlog-flush.md` |
-
-## Subfolder Context
-
-Additional context loaded when working in specific directories:
-- `backlog/CLAUDE.md` - Task management workflow
-- `scripts/CLAUDE.md` - Script execution guidance
-- `src/CLAUDE.md` - Python code standards
-
-@import memory/mcp-configuration.md
+| Workflow Integration | `docs/guides/flowspec-backlog-workflow.md` |
+| Task Tiers | `docs/guides/task-management-tiers.md` |
+| Inner/Outer Loop | `docs/reference/inner-loop.md`, `docs/reference/outer-loop.md` |
 
 ## Environment Variables
 
@@ -394,33 +116,65 @@ Additional context loaded when working in specific directories:
 | `GITHUB_FLOWSPEC` | GitHub token for API requests |
 | `SPECIFY_FEATURE` | Override feature detection for non-Git repos |
 
-@import memory/claude-hooks.md
+## MCP Servers
 
-@import memory/claude-checkpoints.md
+| Server | Description |
+|--------|-------------|
+| `github` | GitHub API: repos, issues, PRs |
+| `backlog` | Backlog.md task management |
+| `serena` | LSP-grade code understanding |
+| `playwright-test` | Browser automation |
+| `trivy` | Container/IaC security scans |
+| `semgrep` | SAST code scanning |
 
-@import memory/claude-skills.md
+Health check: `./scripts/check-mcp-servers.sh`
 
-@import memory/claude-thinking.md
+## Claude Code Hooks
+
+| Hook | Type | Purpose |
+|------|------|---------|
+| `session-start.sh` | SessionStart | Environment verification |
+| `pre-tool-use-sensitive-files.py` | PreToolUse | Protect .env, secrets |
+| `pre-tool-use-git-safety.py` | PreToolUse | Warn on dangerous git |
+| `post-tool-use-format-python.sh` | PostToolUse | Auto-format Python |
+| `post-tool-use-lint-python.sh` | PostToolUse | Auto-lint Python |
+| `stop-quality-gate.py` | Stop | Backlog task quality gate |
+
+Test hooks: `.claude/hooks/test-hooks.sh`
+
+## Claude Code Skills
+
+17 skills auto-invoked by context. Key skills:
+- `pm-planner`: Task creation and breakdown
+- `architect`: Architecture decisions and ADRs
+- `qa-validator`: Test plans and quality gates
+- `security-reviewer`: Vulnerability assessment
+
+Full list: `docs/reference/claude-skills.md` or `.claude/skills/`
+
+## Checkpoints
+
+Press `Esc Esc` to undo last change. Use `/rewind` for interactive restore.
+
+## Extended Thinking
+
+| Trigger | Budget | Use Case |
+|---------|--------|----------|
+| `think` | 4K tokens | Quick decisions |
+| `think hard` | 10K tokens | Architecture, security |
+| `megathink` | 10K tokens | Complex research |
+| `ultrathink` | 32K tokens | Critical decisions |
 
 ## Quick Troubleshooting
 
 ```bash
-# Dependencies issues
-uv sync --force
-
-# CLI not found
-uv tool install . --force
-
-# Make scripts executable
-chmod +x scripts/bash/*.sh
-
-# Check Python version (requires 3.11+)
-python --version
-
-# Test hooks
-.claude/hooks/test-hooks.sh
+uv sync --force              # Dependencies issues
+uv tool install . --force    # CLI not found
+chmod +x scripts/bash/*.sh   # Make scripts executable
+python --version             # Check Python 3.11+
+.claude/hooks/test-hooks.sh  # Test hooks
 ```
 
 ---
 
-*Subfolder CLAUDE.md files provide additional context when working in those directories.*
+*See `.claude/rules/` for critical rules, coding standards, and rigor enforcement.*


### PR DESCRIPTION
## Summary

- Reduces CLAUDE.md from ~800 to 180 lines (under 200 target)
- Moves rules to `.claude/rules/` directory:
  - `critical.md` - Never delete tests, pre-PR validation, DCO
  - `coding-style.md` - Python standards, file I/O, API patterns
  - `rigor.md` - Workflow quality gates, branch naming, decision logging
- Removes embedded code examples > 10 lines
- Converts verbose sections to concise tables
- Removes @imports in favor of explicit `.claude/rules/` reference

## Changes

| File | Action |
|------|--------|
| `CLAUDE.md` | Reduced from ~800 to 180 lines |
| `.claude/rules/critical.md` | New - critical rules from memory/critical-rules.md |
| `.claude/rules/coding-style.md` | New - code standards from memory/code-standards.md |
| `.claude/rules/rigor.md` | New - rigor rules summary |

## Task

Implements task-581 (SPEC-011)

## Test plan

- [x] CLAUDE.md is under 200 lines (180 lines)
- [x] All rules accessible from new locations in `.claude/rules/`
- [x] No code examples > 10 lines remain in CLAUDE.md
- [x] Tests pass: `uv run pytest tests/ -x -q`
- [x] Lint passes: `uv run ruff check .`

Generated with Claude Code