### PR TITLE
fix: handle Windows Unicode encoding in banner display (#1186)

### DIFF
--- a/src/flowspec_cli/__init__.py
+++ b/src/flowspec_cli/__init__.py
@@ -1298,6 +1298,16 @@ BANNER = """
 ╚═╝     ╚══════╝ ╚═════╝  ╚══╝╚══╝ ╚══════╝╚═╝     ╚══════╝ ╚═════╝
 """
 
+# ASCII fallback banner for terminals that don't support Unicode (e.g., Windows cp1252)
+BANNER_ASCII = """
+ _____ _
+|  ___| | _____      _____ _ __   ___  ___
+| |_  | |/ _ \\ \\ /\\ / / __| '_ \\ / _ \\/ __|
+|  _| | | (_) \\ V  V /\\__ \\ |_) |  __/ (__
+|_|   |_|\\___/ \\_/\\_/ |___/ .__/ \\___|\\___|
+                          |_|
+"""
+
 # Version - keep in sync with pyproject.toml
 
 __version__ = "0.4.007"
@@ -3416,16 +3426,36 @@ def generate_flowspec_workflow_yml(
     workflow_file.write_text("\n".join(lines), encoding="utf-8")
 
 
+def _can_encode_unicode() -> bool:
+    """Check if stdout can encode Unicode box-drawing characters.
+
+    Returns False on Windows terminals using legacy encodings like cp1252.
+    """
+    try:
+        # Test with a box-drawing character from the banner
+        test_char = "█"
+        if hasattr(sys.stdout, "encoding") and sys.stdout.encoding:
+            test_char.encode(sys.stdout.encoding)
+        return True
+    except (UnicodeEncodeError, LookupError):
+        return False
+
+
 def show_banner():
-    """Display the ASCII art banner."""
-    banner_lines = BANNER.strip().split("\n")
+    """Display the ASCII art banner.
+
+    Uses Unicode box-drawing characters by default. Falls back to ASCII
+    on Windows terminals that don't support Unicode (e.g., cp1252 encoding).
+    """
+    # Check encoding support upfront to avoid Rich's internal encoding errors
+    banner_text = BANNER if _can_encode_unicode() else BANNER_ASCII
     colors = ["bright_blue", "blue", "cyan", "bright_cyan", "white", "bright_white"]
 
+    banner_lines = banner_text.strip().split("\n")
     styled_banner = Text()
     for i, line in enumerate(banner_lines):
         color = colors[i % len(colors)]
         styled_banner.append(line + "\n", style=color)
-
     console.print(Align.center(styled_banner))
     console.print(Align.center(Text(TAGLINE, style="italic bright_yellow")))
     console.print()


### PR DESCRIPTION
## Summary

Fixes #1186 - `flowspec init` was crashing on Windows with `UnicodeEncodeError` when trying to display the banner.

## Problem

The banner uses Unicode box-drawing characters (█, ╔, ═, ║, etc.) which cannot be encoded in Windows legacy encodings like cp1252. This caused a crash before any initialization could complete:

```
UnicodeEncodeError: 'charmap' codec can't encode characters in position 0-10: 
character maps to <undefined>
```

## Solution

1. **Added encoding detection**: New `_can_encode_unicode()` helper that tests if stdout can encode Unicode box-drawing characters before attempting to print

2. **Added ASCII fallback banner**: A figlet-style ASCII art banner that works on all terminals:
```
 _____ _
|  ___| | _____      _____ _ __   ___  ___
| |_  | |/ _ \ \ /\ / / __| '_ \ / _ \/ __|
|  _| | | (_) \ V  V /\__ \ |_) |  __/ (__
|_|   |_|\___/ \_/\_/ |___/ .__/ \___|\___|
                          |_|
```

3. **Proactive encoding check**: Rather than catching exceptions after Rich fails internally, we now check encoding capability upfront and select the appropriate banner

## Testing

- Verified on Windows Git Bash (cp1252 encoding) - ASCII banner displays correctly
- Verified existing tests pass (21/23, 2 pre-existing Windows-specific failures unrelated)

## Test Plan

- [x] Lint passes (`ruff format --check . && ruff check .`)
- [x] Banner displays correctly on Windows with limited encoding
- [x] Existing tests pass
- [ ] CI checks pass

Closes #1186