### PR TITLE
fix: Windows Unicode encoding crash in banner display

### DIFF
--- a/src/flowspec_cli/__init__.py
+++ b/src/flowspec_cli/__init__.py
@@ -3429,13 +3429,19 @@ def generate_flowspec_workflow_yml(
 def _can_encode_unicode() -> bool:
     """Check if stdout can encode Unicode box-drawing characters.
 
-    Returns False on Windows terminals using legacy encodings like cp1252.
+    Returns False on Windows terminals using legacy encodings like cp1252,
+    or when stdout/encoding cannot be determined.
     """
     try:
         # Test with a box-drawing character from the banner
         test_char = "█"
-        if hasattr(sys.stdout, "encoding") and sys.stdout.encoding:
-            test_char.encode(sys.stdout.encoding)
+        stdout = sys.stdout
+        if stdout is None:
+            return False
+        encoding = getattr(stdout, "encoding", None)
+        if not encoding:
+            return False
+        test_char.encode(encoding)
         return True
     except (UnicodeEncodeError, LookupError):
         return False


### PR DESCRIPTION
## Summary

- Add ASCII fallback banner for Windows terminals using legacy encodings (cp1252)
- Add `_can_encode_unicode()` helper to detect encoding capabilities upfront
- Handles edge cases: stdout is None, encoding attribute is None/empty
- Prevents `UnicodeEncodeError` crash on `flowspec init`

## Problem

On Windows terminals using cp1252 encoding, the Unicode box-drawing characters (█, ╔, ═, etc.) in the banner cause `UnicodeEncodeError` crashes during `flowspec init`.

## Solution

1. Added `BANNER_ASCII` constant with figlet-style ASCII fallback
2. Added `_can_encode_unicode()` to detect encoding support upfront
3. Use ASCII banner when Unicode encoding would fail

Fixes #1186

## Test plan

- [x] Verified on Windows with cp1252 encoding - correctly detects and uses ASCII fallback
- [x] Verified edge cases: None stdout, None encoding both return False
- [x] Lint and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)