### PR TITLE
docs: fix 404 errors on documentation site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,177 @@
+## Contributing to Flowspec
+
+Hi there! We're thrilled that you'd like to contribute to Flowspec. Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE).
+
+Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
+
+## Prerequisites for running and testing code
+
+These are one time installations required to be able to test your changes locally as part of the pull request (PR) submission process.
+
+1. Install [Python 3.11+](https://www.python.org/downloads/)
+1. Install [uv](https://docs.astral.sh/uv/) for package management
+1. Install [Git](https://git-scm.com/downloads)
+1. Have an [AI coding agent available](README.md#-supported-ai-agents)
+
+## Submitting a pull request
+
+>[!NOTE]
+>If your pull request introduces a large change that materially impacts the work of the CLI or the rest of the repository (e.g., you're introducing new templates, arguments, or otherwise major changes), make sure that it was **discussed and agreed upon** by the project maintainers. Pull requests with large changes that did not have a prior conversation and agreement will be closed.
+
+1. Fork and clone the repository
+1. Configure and install the dependencies: `uv sync`
+1. Make sure the CLI works on your machine: `uv run flowspec --help`
+1. Create a new branch: `git checkout -b my-branch-name`
+1. Make your change, add tests, and make sure everything still works
+1. Test the CLI functionality with a sample project if relevant
+1. Push to your fork and submit a pull request
+1. Wait for your pull request to be reviewed and merged.
+
+Here are a few things you can do that will increase the likelihood of your pull request being accepted:
+
+- Follow the project's coding conventions.
+- Write tests for new functionality.
+- Update documentation (`README.md`, `spec-driven.md`) if your changes affect user-facing features.
+- Keep your change as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
+- Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+- Test your changes with the Spec-Driven Development workflow to ensure compatibility.
+
+## Development workflow
+
+When working on Flowspec:
+
+1. Test changes with the `flowspec` CLI commands (`/flow.spec`, `/flow.plan`, `/flow.tasks`) in your coding agent of choice
+2. Verify templates are working correctly in `templates/` directory
+3. Test script functionality in the `scripts/` directory
+4. Ensure memory files (`memory/constitution.md`) are updated if major process changes are made
+
+## Development Setup for flowspec
+
+flowspec can use its own `/flow:*` commands during development. This ensures developers test the same commands that users receive.
+
+### Quick Setup
+
+Run the dev-setup command in the flowspec repository root:
+
+```bash
+flowspec dev-setup
+```
+
+This creates symlinks from `.claude/commands/` to `templates/commands/` so Claude Code can discover the commands while maintaining a single source of truth.
+
+### Manual Setup
+
+If you prefer to set up manually or the command fails, you can use the Makefile:
+
+```bash
+# Recreate all symlinks
+make dev-fix
+
+# Validate setup
+make dev-validate
+
+# Check status
+make dev-status
+```
+
+For detailed workflows, troubleshooting, and advanced scenarios, see [Dev-Setup Consistency Guide](docs/reference/dev-setup-consistency.md).
+
+### Platform Notes
+
+**Linux/macOS**: Symlinks work out of the box.
+
+**Windows**: Requires one of:
+- Enable Developer Mode in Windows Settings → Update & Security → For Developers
+- Run terminal as Administrator
+- Use WSL (Windows Subsystem for Linux)
+
+### How It Works
+
+The flowspec repository contains a `.flowspec-source` marker file that:
+- Prevents `flowspec init` from accidentally overwriting source files
+- Prevents `flowspec upgrade` from clobbering development work
+- Identifies the repository as the source (not a project created by `flowspec init`)
+
+The symlinks allow Claude Code to discover commands while keeping `templates/commands/` as the **single source of truth**. This ensures:
+- What developers test is exactly what users receive
+- No content divergence between development and distribution
+- Changes to templates are immediately reflected via symlinks
+
+For complete details, see [Dev-Setup Consistency Guide](docs/reference/dev-setup-consistency.md).
+
+### Available Commands After Dev-Setup
+
+Once set up, you can use these commands in Claude Code:
+
+**Flowspec Commands**:
+- `/flow:specify` - Product requirements management
+- `/flow:plan` - Architecture planning
+- `/flow:research` - Market research
+- `/flow:implement` - Multi-agent implementation
+- `/flow:validate` - QA and validation
+
+Note: `/flow:operate` has been removed - deployment is handled by external CI/CD tools (outer loop).
+
+## AI contributions in Flowspec
+
+> [!IMPORTANT]
+>
+> If you are using **any kind of AI assistance** to contribute to Flowspec,
+> it must be disclosed in the pull request or issue.
+
+We welcome and encourage the use of AI tools to help improve Flowspec! Many valuable contributions have been enhanced with AI assistance for code generation, issue detection, and feature definition.
+
+That being said, if you are using any kind of AI assistance (e.g., agents, ChatGPT) while contributing to Flowspec,
+**this must be disclosed in the pull request or issue**, along with the extent to which AI assistance was used (e.g., documentation comments vs. code generation).
+
+If your PR responses or comments are being generated by an AI, disclose that as well.
+
+As an exception, trivial spacing or typo fixes don't need to be disclosed, so long as the changes are limited to small parts of the code or short phrases.
+
+An example disclosure:
+
+> This PR was written primarily by GitHub Copilot.
+
+Or a more detailed disclosure:
+
+> I consulted ChatGPT to understand the codebase but the solution
+> was fully authored manually by myself.
+
+Failure to disclose this is first and foremost rude to the human operators on the other end of the pull request, but it also makes it difficult to
+determine how much scrutiny to apply to the contribution.
+
+In a perfect world, AI assistance would produce equal or higher quality work than any human. That isn't the world we live in today, and in most cases
+where human supervision or expertise is not in the loop, it's generating code that cannot be reasonably maintained or evolved.
+
+### What we're looking for
+
+When submitting AI-assisted contributions, please ensure they include:
+
+- **Clear disclosure of AI use** - You are transparent about AI use and degree to which you're using it for the contribution
+- **Human understanding and testing** - You've personally tested the changes and understand what they do
+- **Clear rationale** - You can explain why the change is needed and how it fits within Flowspec's goals
+- **Concrete evidence** - Include test cases, scenarios, or examples that demonstrate the improvement
+- **Your own analysis** - Share your thoughts on the end-to-end developer experience
+
+### What we'll close
+
+We reserve the right to close contributions that appear to be:
+
+- Untested changes submitted without verification
+- Generic suggestions that don't address specific Flowspec needs
+- Bulk submissions that show no human review or understanding
+
+### Guidelines for success
+
+The key is demonstrating that you understand and have validated your proposed changes. If a maintainer can easily tell that a contribution was generated entirely by AI without human input or testing, it likely needs more work before submission.
+
+Contributors who consistently submit low-effort AI-generated changes may be restricted from further contributions at the maintainers' discretion.
+
+Please be respectful to maintainers and disclose AI assistance.
+
+## Resources
+
+- [Spec-Driven Development Methodology](./spec-driven.md)
+- [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
+- [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)
+- [GitHub Help](https://help.github.com)


### PR DESCRIPTION
## Summary
- Add missing `CONTRIBUTING.md` to repository root (was only at `build-docs/CONTRIBUTING.md`)
- The docfx.json configuration expects this file at the root level

## 404 Errors Fixed
After merging and triggering a docs deployment:
- `/CONTRIBUTING.html` - was missing, now fixed
- `/SUPPORT.html` - exists at root, will be included in next deployment
- `/CODE_OF_CONDUCT.html` - exists at root, will be included in next deployment
- `/SECURITY.html` - exists at root, will be included in next deployment

## Test plan
- [ ] Merge PR
- [ ] Trigger docs deployment (manual or via release)
- [ ] Verify all 4 pages load without 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)