### PR TITLE
feat: flowspec doctor — setup health check and diagnostics

### DIFF
--- a/src/flowspec_cli/doctor.py
+++ b/src/flowspec_cli/doctor.py
@@ -1,0 +1,485 @@
+"""Health check and diagnostics for flowspec setup.
+
+This module provides the `flowspec doctor` command to verify that the environment
+is properly configured for flowspec development.
+
+Checks performed:
+- flowspec CLI version vs latest available
+- Python version compatibility (requires 3.11+)
+- Required tools installed (backlog.md, beads)
+- Workflow configuration present and valid
+- Agent files using correct naming convention (dot notation)
+- Constitution file present (if configured)
+
+Example:
+    >>> from flowspec_cli.doctor import run_doctor
+    >>> issues = run_doctor(fix=False)
+    >>> if not issues:
+    ...     print("All checks passed!")
+"""
+
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import yaml
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from flowspec_cli.workflow.validator import validate_workflow
+
+console = Console()
+
+
+class CheckStatus(Enum):
+    """Status of a health check."""
+
+    PASS = "pass"
+    WARN = "warn"
+    FAIL = "fail"
+
+
+@dataclass
+class CheckResult:
+    """Result of a single health check.
+
+    Attributes:
+        name: Display name of the check
+        status: Pass/warn/fail status
+        message: Human-readable message about the check result
+        fix_command: Optional command to fix the issue (for auto-fixable issues)
+        details: Additional context or details
+    """
+
+    name: str
+    status: CheckStatus
+    message: str
+    fix_command: str | None = None
+    details: dict[str, Any] | None = None
+
+
+def get_flowspec_version() -> str:
+    """Get the currently installed flowspec version.
+
+    Returns:
+        Version string (e.g., "0.4.004") or "unknown"
+    """
+    try:
+        # Import version from package metadata
+        from importlib.metadata import version
+
+        return version("flowspec-cli")
+    except Exception:
+        return "unknown"
+
+
+def check_flowspec_version() -> CheckResult:
+    """Check flowspec CLI version.
+
+    Returns:
+        CheckResult indicating version status
+    """
+    current = get_flowspec_version()
+    if current == "unknown":
+        return CheckResult(
+            name="flowspec CLI",
+            status=CheckStatus.FAIL,
+            message="Could not determine flowspec version",
+        )
+
+    # For now, just report the version - we don't check for updates yet
+    return CheckResult(
+        name="flowspec CLI",
+        status=CheckStatus.PASS,
+        message=f"v{current}",
+    )
+
+
+def check_python_version() -> CheckResult:
+    """Check Python version compatibility (requires 3.11+).
+
+    Returns:
+        CheckResult indicating Python version status
+    """
+    version_info = sys.version_info
+    major, minor = version_info[:2]
+    micro = version_info[2] if len(version_info) > 2 else 0
+    version_str = f"{major}.{minor}.{micro}"
+
+    if major < 3 or (major == 3 and minor < 11):
+        return CheckResult(
+            name="Python version",
+            status=CheckStatus.FAIL,
+            message=f"Python {version_str} (requires 3.11+)",
+        )
+
+    return CheckResult(
+        name="Python version",
+        status=CheckStatus.PASS,
+        message=f"Python {version_str}",
+    )
+
+
+def check_tool_installed(tool_name: str) -> CheckResult:
+    """Check if a CLI tool is installed and accessible.
+
+    Args:
+        tool_name: Name of the tool to check (e.g., "backlog", "beads")
+
+    Returns:
+        CheckResult indicating tool installation status
+    """
+    tool_path = shutil.which(tool_name)
+    if tool_path is None:
+        return CheckResult(
+            name=f"{tool_name} CLI",
+            status=CheckStatus.FAIL,
+            message=f"{tool_name} not found in PATH",
+            fix_command=f"Install {tool_name} following the installation guide",
+        )
+
+    # Try to get version if possible
+    try:
+        result = subprocess.run(
+            [tool_name, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        version_output = result.stdout.strip() or result.stderr.strip()
+        # Extract just the version number if present
+        version = version_output.split()[-1] if version_output else "installed"
+    except Exception:
+        version = "installed"
+
+    return CheckResult(
+        name=f"{tool_name} CLI",
+        status=CheckStatus.PASS,
+        message=version,
+    )
+
+
+def check_workflow_config() -> CheckResult:
+    """Check if workflow configuration exists and is valid.
+
+    Returns:
+        CheckResult indicating workflow configuration status
+    """
+    project_root = Path.cwd()
+
+    # Check for workflow config file
+    config_paths = [
+        project_root / "flowspec_workflow.yml",
+        project_root / ".flowspec" / "workflow.yml",
+    ]
+
+    config_path = None
+    for path in config_paths:
+        if path.exists():
+            config_path = path
+            break
+
+    if config_path is None:
+        return CheckResult(
+            name="Workflow config",
+            status=CheckStatus.WARN,
+            message="No workflow configuration found",
+            fix_command="Run: /flow:init",
+        )
+
+    # Try to load and validate the config
+    try:
+        with open(config_path) as f:
+            config_data = yaml.safe_load(f)
+
+        # Validate using the workflow validator
+        validation_result = validate_workflow(config_data)
+
+        if not validation_result.is_valid:
+            error_count = len(validation_result.errors)
+            warning_count = len(validation_result.warnings)
+            details = {
+                "errors": [str(e) for e in validation_result.errors],
+                "warnings": [str(w) for w in validation_result.warnings],
+            }
+            return CheckResult(
+                name="Workflow config",
+                status=CheckStatus.FAIL,
+                message=f"Invalid ({error_count} errors, {warning_count} warnings)",
+                fix_command="Run: flowspec workflow validate --verbose",
+                details=details,
+            )
+
+        # Valid config
+        warning_count = len(validation_result.warnings)
+        if warning_count > 0:
+            return CheckResult(
+                name="Workflow config",
+                status=CheckStatus.WARN,
+                message=f"Valid ({warning_count} warnings)",
+                details={"warnings": [str(w) for w in validation_result.warnings]},
+            )
+
+        return CheckResult(
+            name="Workflow config",
+            status=CheckStatus.PASS,
+            message="Valid",
+        )
+
+    except yaml.YAMLError as e:
+        return CheckResult(
+            name="Workflow config",
+            status=CheckStatus.FAIL,
+            message=f"Invalid YAML: {e}",
+        )
+    except Exception as e:
+        return CheckResult(
+            name="Workflow config",
+            status=CheckStatus.FAIL,
+            message=f"Error reading config: {e}",
+        )
+
+
+def check_agent_files() -> CheckResult:
+    """Check if agent files use correct naming convention (dot notation).
+
+    Looks for agent files in .github/agents/ and .claude/agents/ and checks
+    if they use the new dot notation (e.g., backend.engineer.md) instead of
+    old hyphen notation (e.g., backend-engineer.md).
+
+    Returns:
+        CheckResult indicating agent file naming status
+    """
+    project_root = Path.cwd()
+    agent_dirs = [
+        project_root / ".github" / "agents",
+        project_root / ".claude" / "agents",
+    ]
+
+    old_convention_files = []
+
+    for agent_dir in agent_dirs:
+        if not agent_dir.exists():
+            continue
+
+        for agent_file in agent_dir.glob("*.md"):
+            # Skip files that don't look like agent definitions
+            if agent_file.name.startswith("_") or agent_file.name.startswith("README"):
+                continue
+
+            # Check if file uses hyphens (old convention)
+            # New convention uses dots (e.g., backend.engineer.md)
+            if "-" in agent_file.stem and "." not in agent_file.stem:
+                old_convention_files.append(
+                    str(agent_file.relative_to(project_root))
+                )
+
+    if old_convention_files:
+        return CheckResult(
+            name="Agent file naming",
+            status=CheckStatus.WARN,
+            message=f"{len(old_convention_files)} files using old hyphen naming",
+            fix_command="Run: flowspec upgrade-repo",
+            details={"files": old_convention_files},
+        )
+
+    # Check if there are any agent files at all
+    has_agents = any(
+        agent_dir.exists()
+        and any(
+            f.suffix == ".md"
+            and not f.name.startswith("_")
+            and not f.name.startswith("README")
+            for f in agent_dir.glob("*.md")
+        )
+        for agent_dir in agent_dirs
+    )
+
+    if not has_agents:
+        return CheckResult(
+            name="Agent file naming",
+            status=CheckStatus.WARN,
+            message="No agent files found",
+        )
+
+    return CheckResult(
+        name="Agent file naming",
+        status=CheckStatus.PASS,
+        message="Using dot notation",
+    )
+
+
+def check_constitution() -> CheckResult:
+    """Check if constitution file exists.
+
+    Returns:
+        CheckResult indicating constitution file status
+    """
+    project_root = Path.cwd()
+    constitution_path = project_root / "memory" / "constitution.md"
+
+    if not constitution_path.exists():
+        return CheckResult(
+            name="Constitution",
+            status=CheckStatus.WARN,
+            message="Constitution not found",
+            fix_command="Run: /flow:init",
+        )
+
+    # Check if it's just the template (contains placeholders)
+    try:
+        content = constitution_path.read_text()
+        if "[PROJECT_NAME]" in content or "[PRINCIPLE_1_NAME]" in content:
+            return CheckResult(
+                name="Constitution",
+                status=CheckStatus.WARN,
+                message="Contains placeholders (not configured)",
+                fix_command="Run: /flow:init",
+            )
+    except Exception:
+        pass
+
+    return CheckResult(
+        name="Constitution",
+        status=CheckStatus.PASS,
+        message="Present",
+    )
+
+
+def run_all_checks() -> list[CheckResult]:
+    """Run all health checks.
+
+    Returns:
+        List of CheckResult objects for all checks performed
+    """
+    checks = [
+        check_flowspec_version(),
+        check_python_version(),
+        check_tool_installed("backlog"),
+        check_tool_installed("beads"),
+        check_workflow_config(),
+        check_agent_files(),
+        check_constitution(),
+    ]
+    return checks
+
+
+def display_results(results: list[CheckResult], verbose: bool = False) -> None:
+    """Display check results in a formatted table.
+
+    Args:
+        results: List of CheckResult objects to display
+        verbose: If True, show additional details
+    """
+    table = Table(show_header=False, box=None, padding=(0, 1))
+    table.add_column("Status", width=3)
+    table.add_column("Check", style="bold")
+    table.add_column("Details")
+
+    for result in results:
+        # Choose symbol and color based on status
+        if result.status == CheckStatus.PASS:
+            symbol = "[green]✅[/green]"
+        elif result.status == CheckStatus.WARN:
+            symbol = "[yellow]⚠️[/yellow]"
+        else:
+            symbol = "[red]❌[/red]"
+
+        table.add_row(symbol, result.name, result.message)
+
+        # Show fix commands for issues
+        if result.fix_command and result.status != CheckStatus.PASS:
+            table.add_row(
+                "",
+                "",
+                f"[dim cyan]→ Fix: {result.fix_command}[/dim cyan]",
+            )
+
+        # Show details in verbose mode
+        if verbose and result.details:
+            for key, value in result.details.items():
+                if isinstance(value, list):
+                    for item in value[:3]:  # Show first 3 items
+                        table.add_row(
+                            "",
+                            "",
+                            f"[dim]  {key}: {item}[/dim]",
+                        )
+                    if len(value) > 3:
+                        table.add_row(
+                            "",
+                            "",
+                            f"[dim]  ... and {len(value) - 3} more[/dim]",
+                        )
+                else:
+                    table.add_row(
+                        "",
+                        "",
+                        f"[dim]  {key}: {value}[/dim]",
+                    )
+
+    console.print()
+    console.print(table)
+    console.print()
+
+
+def run_doctor(fix: bool = False, verbose: bool = False) -> list[CheckResult]:
+    """Run health checks and optionally attempt fixes.
+
+    Args:
+        fix: If True, attempt to auto-fix fixable issues
+        verbose: If True, show additional details
+
+    Returns:
+        List of CheckResult objects with issues found
+    """
+    console.print()
+    console.print("[bold]flowspec doctor[/bold]")
+    console.print()
+
+    results = run_all_checks()
+
+    # Display results
+    display_results(results, verbose=verbose)
+
+    # Count issues
+    errors = sum(1 for r in results if r.status == CheckStatus.FAIL)
+    warnings = sum(1 for r in results if r.status == CheckStatus.WARN)
+
+    # Summary
+    if errors == 0 and warnings == 0:
+        console.print("[green]✓ All checks passed![/green]")
+    else:
+        summary_parts = []
+        if errors > 0:
+            summary_parts.append(f"[red]{errors} error(s)[/red]")
+        if warnings > 0:
+            summary_parts.append(f"[yellow]{warnings} warning(s)[/yellow]")
+        console.print(" ".join(summary_parts))
+
+        # Show suggestion to run with --fix if there are fixable issues
+        if not fix:
+            fixable = sum(1 for r in results if r.fix_command is not None)
+            if fixable > 0:
+                console.print()
+                console.print(
+                    f"[dim]Hint: Run 'flowspec doctor --fix' to attempt "
+                    f"automatic fixes ({fixable} fixable)[/dim]"
+                )
+
+    console.print()
+
+    # Auto-fix handling (not implemented yet - would require complex logic)
+    if fix:
+        console.print(
+            "[yellow]Note: Auto-fix is not yet implemented. "
+            "Please run the suggested fix commands manually.[/yellow]"
+        )
+        console.print()
+
+    return results

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,295 @@
+"""Tests for flowspec doctor health check command."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from flowspec_cli.doctor import (
+    CheckResult,
+    CheckStatus,
+    check_agent_files,
+    check_constitution,
+    check_flowspec_version,
+    check_python_version,
+    check_tool_installed,
+    check_workflow_config,
+    run_all_checks,
+)
+
+
+class TestCheckFlowspecVersion:
+    """Tests for flowspec version check."""
+
+    def test_returns_version(self):
+        """Should return current flowspec version."""
+        result = check_flowspec_version()
+        assert result.name == "flowspec CLI"
+        assert result.status == CheckStatus.PASS
+        assert "v" in result.message or result.message == "unknown"
+
+
+class TestCheckPythonVersion:
+    """Tests for Python version check."""
+
+    def test_compatible_version(self):
+        """Should pass for Python 3.11+."""
+        # Current test is running on 3.11+ since that's a requirement
+        result = check_python_version()
+        assert result.name == "Python version"
+        assert result.status == CheckStatus.PASS
+        assert "Python" in result.message
+
+    @patch("flowspec_cli.doctor.sys.version_info", (3, 10, 0))
+    def test_incompatible_version(self):
+        """Should fail for Python < 3.11."""
+        result = check_python_version()
+        assert result.status == CheckStatus.FAIL
+        assert "3.10" in result.message
+        assert "requires 3.11+" in result.message
+
+
+class TestCheckToolInstalled:
+    """Tests for tool installation checks."""
+
+    @patch("flowspec_cli.doctor.shutil.which")
+    def test_tool_not_found(self, mock_which):
+        """Should fail when tool not in PATH."""
+        mock_which.return_value = None
+        result = check_tool_installed("nonexistent-tool")
+        assert result.status == CheckStatus.FAIL
+        assert "not found in PATH" in result.message
+        assert result.fix_command is not None
+
+    @patch("flowspec_cli.doctor.shutil.which")
+    @patch("flowspec_cli.doctor.subprocess.run")
+    def test_tool_found_with_version(self, mock_run, mock_which):
+        """Should pass when tool is found and can get version."""
+        mock_which.return_value = "/usr/bin/backlog"
+        mock_run.return_value = MagicMock(stdout="backlog 1.28.1\n", stderr="")
+        result = check_tool_installed("backlog")
+        assert result.status == CheckStatus.PASS
+        assert "1.28.1" in result.message
+
+    @patch("flowspec_cli.doctor.shutil.which")
+    @patch("flowspec_cli.doctor.subprocess.run")
+    def test_tool_found_version_fails(self, mock_run, mock_which):
+        """Should still pass if tool found but version check fails."""
+        mock_which.return_value = "/usr/bin/tool"
+        mock_run.side_effect = Exception("Version check failed")
+        result = check_tool_installed("tool")
+        assert result.status == CheckStatus.PASS
+        assert "installed" in result.message
+
+
+class TestCheckWorkflowConfig:
+    """Tests for workflow configuration check."""
+
+    def test_no_config_file(self, tmp_path, monkeypatch):
+        """Should warn when no workflow config exists."""
+        monkeypatch.chdir(tmp_path)
+        result = check_workflow_config()
+        assert result.status == CheckStatus.WARN
+        assert "No workflow configuration found" in result.message
+        assert result.fix_command == "Run: /flow:init"
+
+    def test_valid_config(self, tmp_path, monkeypatch):
+        """Should pass for valid workflow config."""
+        monkeypatch.chdir(tmp_path)
+        config_path = tmp_path / "flowspec_workflow.yml"
+        valid_config = {
+            "states": ["To Do", "Done"],
+            "workflows": {
+                "complete": {
+                    "input_states": ["To Do"],
+                    "output_state": "Done",
+                }
+            },
+            "transitions": [
+                {"from": "To Do", "to": "Done", "via": "complete"}
+            ],
+        }
+        config_path.write_text(yaml.dump(valid_config))
+
+        result = check_workflow_config()
+        assert result.status == CheckStatus.PASS
+        assert "Valid" in result.message
+
+    def test_invalid_yaml(self, tmp_path, monkeypatch):
+        """Should fail for invalid YAML."""
+        monkeypatch.chdir(tmp_path)
+        config_path = tmp_path / "flowspec_workflow.yml"
+        config_path.write_text("invalid: yaml: content: [")
+
+        result = check_workflow_config()
+        assert result.status == CheckStatus.FAIL
+        assert "Invalid YAML" in result.message
+
+    def test_config_with_errors(self, tmp_path, monkeypatch):
+        """Should fail for config with validation errors."""
+        monkeypatch.chdir(tmp_path)
+        config_path = tmp_path / "flowspec_workflow.yml"
+        # Config missing initial state "To Do"
+        invalid_config = {
+            "states": ["In Progress", "Done"],
+            "workflows": {},
+            "transitions": [],
+        }
+        config_path.write_text(yaml.dump(invalid_config))
+
+        result = check_workflow_config()
+        assert result.status == CheckStatus.FAIL
+        assert "Invalid" in result.message
+        assert result.details is not None
+        assert "errors" in result.details
+
+    def test_config_with_warnings(self, tmp_path, monkeypatch):
+        """Should warn for config with validation warnings only."""
+        monkeypatch.chdir(tmp_path)
+        config_path = tmp_path / "flowspec_workflow.yml"
+        # Config with warnings but no errors
+        config_with_warnings = {
+            "states": ["To Do", "In Progress"],  # No terminal states (warning)
+            "workflows": {
+                "start": {
+                    "input_states": ["To Do"],
+                    "output_state": "In Progress",
+                }
+            },
+            "transitions": [
+                {"from": "To Do", "to": "In Progress", "via": "start"}
+            ],
+        }
+        config_path.write_text(yaml.dump(config_with_warnings))
+
+        result = check_workflow_config()
+        # Should pass with warnings (warnings don't make config invalid)
+        assert result.status in (CheckStatus.PASS, CheckStatus.WARN)
+
+
+class TestCheckAgentFiles:
+    """Tests for agent file naming check."""
+
+    def test_no_agent_files(self, tmp_path, monkeypatch):
+        """Should warn when no agent files found."""
+        monkeypatch.chdir(tmp_path)
+        result = check_agent_files()
+        assert result.status == CheckStatus.WARN
+        assert "No agent files found" in result.message
+
+    def test_old_hyphen_convention(self, tmp_path, monkeypatch):
+        """Should warn for files using old hyphen naming."""
+        monkeypatch.chdir(tmp_path)
+        agents_dir = tmp_path / ".github" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "backend-engineer.md").write_text("# Backend Engineer")
+        (agents_dir / "frontend-engineer.md").write_text("# Frontend Engineer")
+
+        result = check_agent_files()
+        assert result.status == CheckStatus.WARN
+        assert "old hyphen naming" in result.message
+        assert result.fix_command == "Run: flowspec upgrade-repo"
+        assert result.details is not None
+        assert len(result.details["files"]) == 2
+
+    def test_new_dot_convention(self, tmp_path, monkeypatch):
+        """Should pass for files using new dot naming."""
+        monkeypatch.chdir(tmp_path)
+        agents_dir = tmp_path / ".claude" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "backend.engineer.md").write_text("# Backend Engineer")
+        (agents_dir / "frontend.engineer.md").write_text("# Frontend Engineer")
+
+        result = check_agent_files()
+        assert result.status == CheckStatus.PASS
+        assert "Using dot notation" in result.message
+
+    def test_mixed_convention(self, tmp_path, monkeypatch):
+        """Should warn for mixed old and new naming."""
+        monkeypatch.chdir(tmp_path)
+        agents_dir = tmp_path / ".github" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "backend-engineer.md").write_text("# Old")
+        (agents_dir / "frontend.engineer.md").write_text("# New")
+
+        result = check_agent_files()
+        assert result.status == CheckStatus.WARN
+        assert "old hyphen naming" in result.message
+        # Should only report the old convention file
+        assert len(result.details["files"]) == 1
+
+    def test_skips_special_files(self, tmp_path, monkeypatch):
+        """Should skip README and underscore-prefixed files."""
+        monkeypatch.chdir(tmp_path)
+        agents_dir = tmp_path / ".github" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "README.md").write_text("# README")
+        (agents_dir / "_template.md").write_text("# Template")
+        (agents_dir / "backend.engineer.md").write_text("# Backend Engineer")
+
+        result = check_agent_files()
+        assert result.status == CheckStatus.PASS
+
+
+class TestCheckConstitution:
+    """Tests for constitution file check."""
+
+    def test_no_constitution(self, tmp_path, monkeypatch):
+        """Should warn when constitution not found."""
+        monkeypatch.chdir(tmp_path)
+        result = check_constitution()
+        assert result.status == CheckStatus.WARN
+        assert "Constitution not found" in result.message
+        assert result.fix_command == "Run: /flow:init"
+
+    def test_constitution_with_placeholders(self, tmp_path, monkeypatch):
+        """Should warn for constitution with placeholders."""
+        monkeypatch.chdir(tmp_path)
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+        constitution = memory_dir / "constitution.md"
+        constitution.write_text("# [PROJECT_NAME]\n\nPrinciple: [PRINCIPLE_1_NAME]")
+
+        result = check_constitution()
+        assert result.status == CheckStatus.WARN
+        assert "placeholders" in result.message
+        assert result.fix_command == "Run: /flow:init"
+
+    def test_valid_constitution(self, tmp_path, monkeypatch):
+        """Should pass for properly configured constitution."""
+        monkeypatch.chdir(tmp_path)
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+        constitution = memory_dir / "constitution.md"
+        constitution.write_text("# My Project\n\nPrinciple: Security First")
+
+        result = check_constitution()
+        assert result.status == CheckStatus.PASS
+        assert "Present" in result.message
+
+
+class TestRunAllChecks:
+    """Tests for run_all_checks function."""
+
+    def test_returns_all_check_results(self):
+        """Should return results for all checks."""
+        results = run_all_checks()
+        assert len(results) == 7  # 7 checks defined
+        assert all(isinstance(r, CheckResult) for r in results)
+
+    def test_check_names(self):
+        """Should include all expected check names."""
+        results = run_all_checks()
+        names = {r.name for r in results}
+        expected = {
+            "flowspec CLI",
+            "Python version",
+            "backlog CLI",
+            "beads CLI",
+            "Workflow config",
+            "Agent file naming",
+            "Constitution",
+        }
+        assert names == expected


### PR DESCRIPTION
Closes #1221

Adds `flowspec doctor` command that checks environment setup and surfaces problems with clear fix instructions.

## Changes

- New `flowspec doctor` command with health checks for:
  - flowspec CLI version
  - Python version compatibility (requires 3.11+)
  - Required tools installed (backlog.md, beads)
  - Workflow configuration present and valid
  - Agent files using correct naming convention (dot notation)
  - Constitution file present

## Features

- Color-coded output (✅ pass, ⚠️ warn, ❌ fail)
- Suggested fix commands for each issue
- `--verbose` flag for detailed diagnostics
- `--fix` flag stub for future auto-fix functionality

## Testing

- 21 unit tests covering all check functions
- Tests include edge cases and error handling
- All tests passing

## Usage

```bash
flowspec doctor              # Run all checks
flowspec doctor --verbose    # Show detailed output
flowspec doctor --fix        # Attempt auto-fix (not yet implemented)
```